### PR TITLE
fixed arity=0 when you have default=true, makes it impossible to set …

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/PointMatchClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/PointMatchClient.java
@@ -70,7 +70,7 @@ public class PointMatchClient {
 
         // NOTE: --baseDataUrl, --owner, and --collection parameters defined in MatchDataClientParameters
 
-        @Parameter(names = "--fillWithNoise", description = "Fill each canvas image with noise before rendering to improve point match derivation", required = false, arity = 0)
+        @Parameter(names = "--fillWithNoise", description = "Fill each canvas image with noise before rendering to improve point match derivation", required = false, arity = 1)
         private boolean fillWithNoise = true;
 
         @Parameter(names = "--SIFTfdSize", description = "SIFT feature descriptor size: how many samples per row and column", required = false)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderSectionClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderSectionClient.java
@@ -43,10 +43,10 @@ public class RenderSectionClient {
         @Parameter(names = "--format", description = "Format for rendered boxes", required = false)
         private String format = Utils.PNG_FORMAT;
 
-        @Parameter(names = "--doFilter", description = "Use ad hoc filter to support alignment", required = false, arity = 0)
+        @Parameter(names = "--doFilter", description = "Use ad hoc filter to support alignment", required = false, arity = 1)
         private boolean doFilter = true;
 
-        @Parameter(names = "--fillWithNoise", description = "Fill image with noise before rendering to improve point match derivation", required = false, arity = 0)
+        @Parameter(names = "--fillWithNoise", description = "Fill image with noise before rendering to improve point match derivation", required = false, arity = 1)
         private boolean fillWithNoise = true;
 
         @Parameter(description = "Z values for sections to render", required = true)


### PR DESCRIPTION
…it =false.

The clients were forcing the filter and fillwithnoise=on by having arity=0 and the default be true.. you can only use arity=0 with defaults of false.  I have set arity =1 in order to allow it to be left off and default to true, or included with --doFilter false, and have it set to false.  I hope that you were not using --doFilter and the like in most of your calls to these clients so it will remain backward compatible.