### PR TITLE
added a point match call to get all point matches that involve a part…

### DIFF
--- a/render-ws/src/main/java/org/janelia/render/service/MatchService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/MatchService.java
@@ -324,7 +324,40 @@ public class MatchService {
 
         return streamResponse(responseOutput);
     }
+    
+    @Path("owner/{owner}/matchCollection/{matchCollection}/group/{groupId}/id/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Find matches from or to a specific object",
+            notes = "Find all matches that either come from or to a specific tile.",
+            response = CanvasMatches.class,
+            responseContainer="List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Match collection not found")
+    })
+    public Response getMatchesInvolvingObject(@PathParam("owner") final String owner,
+                                             @PathParam("matchCollection") final String matchCollection,
+                                             @PathParam("groupId") final String groupId,
+                                             @PathParam("id") final String id,
+                                             @QueryParam("mergeCollection") final List<String> mergeCollectionList) {
 
+        LOG.info("getMatchesInvolvingObject: entry, owner={}, matchCollection={}, groupId={}, id={}, mergeCollectionList={}",
+                 owner, matchCollection, groupId, id, mergeCollectionList);
+
+        final MatchCollectionId collectionId = getCollectionId(owner, matchCollection);
+        final List<MatchCollectionId> mergeCollectionIdList = getCollectionIdList(owner, mergeCollectionList);
+        final StreamingOutput responseOutput = new StreamingOutput() {
+            @Override
+            public void write(final OutputStream output)
+                    throws IOException, WebApplicationException {
+                matchDao.writeMatchesInvolvingObject(collectionId, mergeCollectionIdList, groupId, id, output);
+            }
+        };
+
+        return streamResponse(responseOutput);
+    }
+    
     @Path("owner/{owner}/matchCollection/{matchCollection}/group/{pGroupId}/id/{pId}/matchesWith/{qGroupId}/id/{qId}")
     @DELETE
     @ApiOperation(

--- a/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
@@ -196,7 +196,25 @@ public class MatchDao {
 
         writeMatches(collectionList, query, outputStream);
     }
-
+    public void writeMatchesInvolvingObject(final MatchCollectionId collectionId,
+								           final List<MatchCollectionId> mergeCollectionIdList,
+								           final String groupId,
+								           final String id,
+								           final OutputStream outputStream)
+			throws IllegalArgumentException, IOException, ObjectNotFoundException {
+			
+			LOG.debug("writeMatchesInvolvingObject: entry, collectionId={}, mergeCollectionIdList={}, groupId={}, id={}",
+			collectionId, mergeCollectionIdList, groupId, id);
+			
+			final List<MongoCollection<Document>> collectionList = getDistinctCollectionList(collectionId,
+			                                                          mergeCollectionIdList);
+			MongoUtil.validateRequiredParameter("groupId", groupId);
+			MongoUtil.validateRequiredParameter("id", id);
+					
+			final Document query = getInvolvingObjectQuery(groupId,id);	
+			
+			writeMatches(collectionList, query, outputStream);
+	}
     public void removeMatchesBetweenTiles(final MatchCollectionId collectionId,
                                           final String pGroupId,
                                           final String pId,
@@ -551,6 +569,15 @@ public class MatchDao {
         queryList.add(new Document("qGroupId", groupId).append(
                 "pGroupId", new Document(QueryOperators.NE, groupId)));
         return new Document(QueryOperators.OR, queryList);
+    }
+    
+    private Document getInvolvingObjectQuery(final String groupId,final String Id){
+    	 final List<Document> queryList = new ArrayList<>();
+         queryList.add(new Document("pGroupId", groupId).append(
+                 "pId", Id));
+         queryList.add(new Document("qGroupId", groupId).append(
+                 "qId", Id));
+         return new Document(QueryOperators.OR, queryList);
     }
 
     private void ensureMatchIndexes(final MongoCollection<Document> collection) {


### PR DESCRIPTION
…icular tile.

I think this is a logical extension of the interface that I wrote because I am writing code to delete all point matches that originate or end up outside a defined polygon.
So my logic was to ... 

a) determine if the tile is outside, inside, or partially overlapping the polygon.

i.If it's outside, I want to delete all point matches from or to that tile (and drop the tile from the output stack). 
(hence I need this call to make this easy and efficent).

ii. If it's partially overlapping, i want to get all the point matches that originate OR end on that tile, and figure out which ones lay inside, vs outside the polygon.  I was imagining i would get a json list from the web interface and then just iterate through it, with each element being a tile pair, then analyze all the points to figure out which ones to drop, and then reupload an edited set of points for that tile pair. (i also need this call here to make this simple and straightforward).

iii. if it's inside.. just leave it

