### PR TITLE
Make cache slightly aware of bit-depth to prevent memory exhaustion.

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/util/ImageProcessorCache.java
+++ b/render-app/src/main/java/org/janelia/alignment/util/ImageProcessorCache.java
@@ -86,7 +86,7 @@ public class ImageProcessorCache {
                         if (value == null) {
                             weight = 0;
                         } else {
-                            weight = value.getPixelCount();
+                            weight = value.getPixelCount() * value.getBitDepth() / 8;
                         }
                         return weight;
                     }


### PR DESCRIPTION
The current image cache assumes 1 pixel = 1 byte.  16-bit and RGB images would cause the cache to be larger than intended.  (e.g., "bytes" are a better unit than "pixels" in a memory constrained environment).