### PR TITLE
Dockerfile java install fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ ENV JETTY_RUN $JETTY_BASE/logs
 ENV JETTY_PID $JETTY_RUN/jetty.pid
 ENV JETTY_STATE $JETTY_RUN/jetty.state
 
-ENV JAVA_HOME /var/www/render/deploy/jdk1.8.0_73
 ENV PATH $JAVA_HOME/bin:$PATH
 ENV JAVA $JAVA_HOME/bin/java
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,26 @@ WORKDIR /var/www/render/
 # install JDK and Jetty
 RUN ./render-ws/src/main/scripts/install.sh
 
+RUN \
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \ 
+  apt-get install -y software-properties-common && \ 
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+
 # set java home
-RUN { echo 'JAVA_HOME="$(readlink -m ./deploy/jdk*)"'; } >> ~/.mavenrc
+#RUN { echo 'JAVA_HOME="$(readlink -m ./deploy/jdk*)"'; } >> ~/.mavenrc
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+RUN { echo 'JAVA_HOME="/usr/lib/jvm/java-8-oracle"';}>> ~/.mavenrc
 
 RUN mvn -Dproject.build.sourceEncoding=UTF-8 package -DskipTests
 COPY . /var/www/render/
 
 # set java home
-RUN { echo 'JAVA_HOME="$(readlink -m ./deploy/jdk*)"'; } >> ~/.mavenrc
+RUN { echo 'JAVA_HOME="/usr/lib/jvm/java-8-oracle"';}>> ~/.mavenrc
+#RUN { echo 'JAVA_HOME="$(readlink -m ./deploy/jdk*)"'; } >> ~/.mavenrc
 
 # build render modules
 #RUN mvn package


### PR DESCRIPTION
This is a fix for the docker install of render which install java8 from oracle via ubuntu package management, rather than the link which is presently broken... hope this will be more robust. 