### PR TITLE
don't convert hidden tiles

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/trakem2/Converter.java
+++ b/render-app/src/main/java/org/janelia/alignment/trakem2/Converter.java
@@ -178,21 +178,23 @@ public class Converter {
                                     final boolean isFirstPatch) {
 
                 final StringBuilder json = new StringBuilder(16 * 1024);
-                if (! isFirstPatch) {
-                    json.append(",\n");
-                }
+                if (patch.isVisible){
+                    if (! isFirstPatch) {
+                        json.append(",\n");
+                    }
 
                 final TileSpec tileSpec = patch.getTileSpec(projectPath, baseMaskPath, layer.z,useTitleForTileId);
                 if (validateConvertedTileSpecs) {
                     tileSpec.validate();
                 }
 
-                json.append(tileSpec.toJson());
+                    json.append(tileSpec.toJson());
 
-                try {
-                    jsonStream.write(json.toString().getBytes());
-                } catch (final IOException e) {
-                    throw new RuntimeException("failed to write to JSON stream", e);
+                    try {
+                        jsonStream.write(json.toString().getBytes());
+                    } catch (final IOException e) {
+                        throw new RuntimeException("failed to write to JSON stream", e);
+                    }
                 }
             }
         };
@@ -364,6 +366,7 @@ public class Converter {
         @XmlAttribute(name = "mres")             public Integer meshResolution;
         @XmlAttribute(name = "alpha_mask_id")    public String alphaMaskId;
         @XmlAttribute(name = "title")			 public String title;
+        @XmlAttribute(name = "visible")          public Boolean isVisible=true;
         @XmlElement(name = "ict_transform_list") public IctTransformList transforms;
 
         private AffineTransform fullCoordinateTransform;


### PR DESCRIPTION
This feature lets people choose in trakem2 GUI what tiles will get converted by hiding them. We use this to make sure that we calculate cross modal registration transforms using the tiles that were actually used rather than those that were hidden.