### PR TITLE
modified docker file to allow dynamic mongo configuration of render

### DIFF
--- a/render-ws/Dockerfile
+++ b/render-ws/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Forrest Collman (forrestc@alleninstitute.org)
 # see https://github.com/saalfeldlab/render/blob/master/docs/src/site/markdown/render-ws.md
 
 #RUN apt-get update
+ENV MONGO_HOST="localhost"
+ENV MONGO_PORT="27107"
 ENV LOGBACK_VERSION="1.1.5"
 ENV SLF4J_VERSION="1.7.16"
 ENV SWAGGER_UI_VERSION="2.1.4"
@@ -63,4 +65,5 @@ COPY docker_jetty/lib/logging/*.jar $JETTY_LIB_LOGGING
 COPY target/render-ws-*.war webapps/render-ws.war
 RUN mkdir -p logs && chgrp jetty logs && chmod 777 logs
 #RUN echo y | java -jar "$JETTY_HOME/start.jar" --add-to-startd=logging-log4j 
-
+COPY render-config-entrypoint.sh /render-config-entrypoint.sh
+ENTRYPOINT ["/render-config-entrypoint.sh"]

--- a/render-ws/render-config-entrypoint.sh
+++ b/render-ws/render-config-entrypoint.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+set -e
+sed -i "s/servers=.*/servers=${MONGO_HOST}/g" $JETTY_BASE/logs/render-db.properties
+sed -i "s/port=.*/servers=${MONGO_PORT}/g" $JETTY_BASE/logs/render-db.properties
+if [ -z "$MONGO_USERNAME" ]; then
+     sed -i "s/#authenticationDatabase=admin.*/authenticationDatabase=admin/g" $JETTY_BASE/logs/render-db.properties
+     sed -i "s/#userName=.*/userName=${MONGO_USERNAME}/g" $JETTY_BASE/logs/render-db.properties
+     sed -i "s/#password=.*/password=${MONGO_PASSWORD}/g" $JETTY_BASE/logs/render-db.properties
+fi
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+			exec "$@"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
+	else
+		# Do a jetty dry run to set the final command
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
+			# command was more than a dry-run
+			cat $JETTY_START \
+			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
+			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
+			exit
+		fi
+		set -- $(sed 's/\\$//' $JETTY_START)
+	fi
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	java="$1"
+	shift
+	set -- "$java" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"
+


### PR DESCRIPTION
I'm modified the render-ws docker to allow for dynamic configuration of the mongo database parameters via environment variables.  The entrypoint now uses sed to reconfigure the render-db.properties file with the MONGO_HOST and MONGO_PORT, which have defaults, and will do the same for authentication if appropriate environment variables are set. (MONGO_USERNAME,MONGO_PASSWORD).