### PR TITLE
Docker modifications

### DIFF
--- a/render-ws/Dockerfile
+++ b/render-ws/Dockerfile
@@ -59,12 +59,17 @@ ENV JAVA_OPTIONS="-Xms3g -Xmx3g -server -Djava.awt.headless=true"
 #CMD ["/usr/bin/supervisord"]
 
 # clone render repo
-WORKDIR /var/lib/jetty
+WORKDIR $JETTY_BASE
+RUN echo --module=rewrite>>$JETTY_BASE/start.d/start.ini
+RUN mkdir -p $JETTY_BASE/logs && chown -R jetty:jetty $JETTY_BASE/logs
+
 COPY docker_jetty/ .
 COPY docker_jetty/lib/logging/*.jar $JETTY_LIB_LOGGING
 COPY docker_jetty/resources/root-context.xml $JETTY_BASE/webapps/root-context.xml
+
 COPY target/render-ws-*.war webapps/render-ws.war
-RUN mkdir -p logs && chgrp jetty logs && chmod 777 logs
 #RUN echo y | java -jar "$JETTY_HOME/start.jar" --add-to-startd=logging-log4j 
 COPY render-config-entrypoint.sh /render-config-entrypoint.sh
+RUN chown -R jetty:jetty $JETTY_BASE 
+USER jetty
 ENTRYPOINT ["/render-config-entrypoint.sh"]

--- a/render-ws/Dockerfile
+++ b/render-ws/Dockerfile
@@ -62,6 +62,7 @@ ENV JAVA_OPTIONS="-Xms3g -Xmx3g -server -Djava.awt.headless=true"
 WORKDIR /var/lib/jetty
 COPY docker_jetty/ .
 COPY docker_jetty/lib/logging/*.jar $JETTY_LIB_LOGGING
+COPY docker_jetty/resources/root-context.xml $JETTY_BASE/webapps/root-context.xml
 COPY target/render-ws-*.war webapps/render-ws.war
 RUN mkdir -p logs && chgrp jetty logs && chmod 777 logs
 #RUN echo y | java -jar "$JETTY_HOME/start.jar" --add-to-startd=logging-log4j 

--- a/render-ws/Dockerfile
+++ b/render-ws/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Forrest Collman (forrestc@alleninstitute.org)
 # see https://github.com/saalfeldlab/render/blob/master/docs/src/site/markdown/render-ws.md
 
 #RUN apt-get update
+ENV MONGO_HOST="localhost"
+ENV MONGO_PORT="27107"
 ENV LOGBACK_VERSION="1.1.5"
 ENV SLF4J_VERSION="1.7.16"
 ENV SWAGGER_UI_VERSION="2.1.4"
@@ -63,4 +65,5 @@ COPY docker_jetty/lib/logging/*.jar $JETTY_LIB_LOGGING
 COPY target/render-ws-*.war webapps/render-ws.war
 RUN mkdir -p logs && chgrp jetty logs && chmod 777 logs
 #RUN echo y | java -jar "$JETTY_HOME/start.jar" --add-to-startd=logging-log4j 
-
+COPY render-config-entrypoint.sh /render-config-entrypoint.sh
+ENTRYPOINT ["/render-config-entrypoint.sh"]

--- a/render-ws/docker_jetty/etc/jetty-rewrite.xml
+++ b/render-ws/docker_jetty/etc/jetty-rewrite.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<!-- =============================================================== -->
+<!-- Mixin the RewriteHandler                                        -->
+<!-- =============================================================== -->
+
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- =========================================================== -->
+  <!-- configure rewrite handler                                   -->
+  <!-- =========================================================== -->
+  <Get id="oldhandler" name="handler"/>
+
+  <Set name="handler">
+    <New id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
+      <Set name="handler"><Ref refid="oldhandler"/></Set>
+      <Set name="rewriteRequestURI"><Property name="jetty.rewrite.rewriteRequestURI" deprecated="rewrite.rewriteRequestURI" default="true"/></Set>
+      <Set name="rewritePathInfo"><Property name="jetty.rewrite.rewritePathInfo" deprecated="rewrite.rewritePathInfo" default="false"/></Set>
+      <Set name="originalPathAttribute"><Property name="jetty.rewrite.originalPathAttribute" deprecated="rewrite.originalPathAttribute" default="requestedPath"/></Set>
+   
+      <!-- Set DispatcherTypes  -->
+      <Set name="dispatcherTypes">
+        <Array type="javax.servlet.DispatcherType">
+          <Item><Call class="javax.servlet.DispatcherType" name="valueOf"><Arg>REQUEST</Arg></Call></Item>
+          <Item><Call class="javax.servlet.DispatcherType" name="valueOf"><Arg>ASYNC</Arg></Call></Item>
+        </Array>
+      </Set>
+
+	<Call name="addRule">      
+	<Arg>
+               <New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
+                    <Set name="regex">^(.*?)/render-ws/view/$</Set>
+                    <Set name="replacement">$1/render-ws/view/index.html?ndvizHost=NDVIZHOST</Set>
+                    <Set name="terminating">true</Set>
+                </New>
+             </Arg>
+	</Call> 
+      
+      <Call name="addRule">
+	<Arg>
+	  <New class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+	    <Set name="pattern">/favicon.ico</Set>
+	    <Set name="name">Cache-Control</Set>
+	    <Set name="value">Max-Age=3600,public</Set>
+	    <Set name="terminating">true</Set>
+	  </New>
+	</Arg>
+      </Call>
+      
+
+    </New>
+  </Set>
+</Configure>

--- a/render-ws/docker_jetty/resources/root-context.xml
+++ b/render-ws/docker_jetty/resources/root-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.server.handler.MovedContextHandler">
+  <Set name="contextPath">/</Set>
+  <Set name="newContextURL">/render-ws/view/</Set>
+  <Set name="permanent">false</Set>
+  <Set name="discardPathInfo">false</Set>
+  <Set name="discardQuery">false</Set>
+</Configure>

--- a/render-ws/render-config-entrypoint.sh
+++ b/render-ws/render-config-entrypoint.sh
@@ -2,7 +2,13 @@
 set -e
 sed -i "s/servers=.*/servers=${MONGO_HOST}/g" $JETTY_BASE/logs/render-db.properties
 sed -i "s/port=.*/servers=${MONGO_PORT}/g" $JETTY_BASE/logs/render-db.properties
-if [ -z "$MONGO_USERNAME" ]; then
+if [ ! -z "${NDVIZHOST}" ]; then
+	sed -i "s/NDVIZHOST/$NDVIZHOST:$NDVIZPORT/g" $JETTY_BASE/etc/jetty-rewrite.xml
+else
+	sed -i "s/ndvizHost=NDVIZHOST//g" $JETTY_BASE/etc/jetty-rewrite.xml
+fi
+
+if [ ! -z "${MONGO_USERNAME}" ]; then
      sed -i "s/#authenticationDatabase=admin.*/authenticationDatabase=admin/g" $JETTY_BASE/logs/render-db.properties
      sed -i "s/#userName=.*/userName=${MONGO_USERNAME}/g" $JETTY_BASE/logs/render-db.properties
      sed -i "s/#password=.*/password=${MONGO_PASSWORD}/g" $JETTY_BASE/logs/render-db.properties

--- a/render-ws/render-config-entrypoint.sh
+++ b/render-ws/render-config-entrypoint.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+set -e
+sed -i "s/servers=.*/servers=${MONGO_HOST}/g" $JETTY_BASE/logs/render-db.properties
+sed -i "s/port=.*/servers=${MONGO_PORT}/g" $JETTY_BASE/logs/render-db.properties
+if [ -z "$MONGO_USERNAME" ]; then
+     sed -i "s/#authenticationDatabase=admin.*/authenticationDatabase=admin/g" $JETTY_BASE/logs/render-db.properties
+     sed -i "s/#userName=.*/userName=${MONGO_USERNAME}/g" $JETTY_BASE/logs/render-db.properties
+     sed -i "s/#password=.*/password=${MONGO_PASSWORD}/g" $JETTY_BASE/logs/render-db.properties
+fi
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-to-start* |\
+			--create-files |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			-v )\
+			# It is a terminating command, so exec directly
+			exec "$@"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated. Either delete 
+			         the $JETTY_START file or re-run 
+			             /generate-jetty.start.sh 
+			         from a Dockerfile
+			********************************************************************
+			EOWARN
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+		set -- $(cat $JETTY_START)
+	else
+		# Do a jetty dry run to set the final command
+		"$@" --dry-run > $JETTY_START
+		if [ $(egrep -v '\\$' $JETTY_START | wc -l ) -gt 1 ] ; then
+			# command was more than a dry-run
+			cat $JETTY_START \
+			| awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1' \
+			| egrep -v '[^ ]*java .* org\.eclipse\.jetty\.xml\.XmlConfiguration '
+			exit
+		fi
+		set -- $(sed 's/\\$//' $JETTY_START)
+	fi
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	java="$1"
+	shift
+	set -- "$java" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"
+


### PR DESCRIPTION
This changes the dockerfile to be more flexibly configured at runtime.

These environment variables include

MONGO_HOST=hostname of mongo server (default=localhost)
MONGO_PORT=hostname of mongo port (default=27017)
MONGO_USERNAME=username for authentication of mongo host (default none, and no auth is configured)
MONGO_PASSWORD=password for authentication of mongo host (default none, need to configure if MONGO_USERNAME)
NDVIZHOST=host where ndviz can be found, used for dynamically generating links, will autoappend this query parameter to all initial management console URLs (default none, behavior off by default)
NDVIZPORT = port where ndviz can be found

this is all done through an entrypoint script which is a modification of the default jetty entrypoint script.

It also adds a default root_context to redirect web users to the management console.. when deploying this as a docker it is safe to assume that this is the only service running on this port, or else the dockerfile has been modified and people are free to reconfigure it as such. 

i have also reconfigured permissions to run this container as jetty user by default and disable root permissions making it safer to run.