### PR TITLE
Load highstock.js via https

### DIFF
--- a/render-ws/src/main/webapp/view/stack-details.html
+++ b/render-ws/src/main/webapp/view/stack-details.html
@@ -9,7 +9,7 @@
 
     <script type="text/javascript" src="../script/jquery-2.1.1.min.js"></script>
 
-    <script src="http://code.highcharts.com/stock/4.2.6/highstock.js"></script>
+    <script src="https://code.highcharts.com/stock/4.2.6/highstock.js"></script>
     <script src="https://code.highcharts.com/4.2.6/modules/exporting.js"></script>
 
     <script type="text/javascript" src="../script/janelia-render.js?v=20170808_001"></script>


### PR DESCRIPTION
Required to make charts work when render is accessed through https.