### PR TITLE
Channel metadata

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/spec/stack/StackStats.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/stack/StackStats.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 import org.janelia.alignment.json.JsonUtils;
 import org.janelia.alignment.spec.Bounds;
+import java.util.ArrayList;
 
 /**
  * Derived stats for a stack.
@@ -22,6 +23,7 @@ public class StackStats
     private final Integer maxTileWidth;
     private final Integer minTileHeight;
     private final Integer maxTileHeight;
+    private final ArrayList channels;
 
     // no-arg constructor needed for JSON deserialization
     @SuppressWarnings("unused")
@@ -35,17 +37,17 @@ public class StackStats
         this.maxTileWidth = null;
         this.minTileHeight = null;
         this.maxTileHeight = null;
+        this.channels = null;
     }
-
     public StackStats(final Bounds stackBounds,
-                      final Long sectionCount,
-                      final Long nonIntegralSectionCount,
-                      final Long tileCount,
-                      final Long transformCount,
-                      final Integer minTileWidth,
-                      final Integer maxTileWidth,
-                      final Integer minTileHeight,
-                      final Integer maxTileHeight) {
+            final Long sectionCount,
+            final Long nonIntegralSectionCount,
+            final Long tileCount,
+            final Long transformCount,
+            final Integer minTileWidth,
+            final Integer maxTileWidth,
+            final Integer minTileHeight,
+            final Integer maxTileHeight) {
         this.stackBounds = stackBounds;
         this.sectionCount = sectionCount;
         this.nonIntegralSectionCount = nonIntegralSectionCount;
@@ -55,6 +57,28 @@ public class StackStats
         this.maxTileWidth = maxTileWidth;
         this.minTileHeight = minTileHeight;
         this.maxTileHeight = maxTileHeight;
+        this.channels = null;
+    }
+    public StackStats(final Bounds stackBounds,
+                      final Long sectionCount,
+                      final Long nonIntegralSectionCount,
+                      final Long tileCount,
+                      final Long transformCount,
+                      final Integer minTileWidth,
+                      final Integer maxTileWidth,
+                      final Integer minTileHeight,
+                      final Integer maxTileHeight,
+                      final ArrayList channels) {
+        this.stackBounds = stackBounds;
+        this.sectionCount = sectionCount;
+        this.nonIntegralSectionCount = nonIntegralSectionCount;
+        this.tileCount = tileCount;
+        this.transformCount = transformCount;
+        this.minTileWidth = minTileWidth;
+        this.maxTileWidth = maxTileWidth;
+        this.minTileHeight = minTileHeight;
+        this.maxTileHeight = maxTileHeight;
+        this.channels = channels;
     }
 
     public Bounds getStackBounds() {
@@ -92,7 +116,9 @@ public class StackStats
     public Integer getMaxTileHeight() {
         return maxTileHeight;
     }
-
+    public ArrayList getChannels() {
+        return channels;
+    }
     @Override
     public String toString() {
         return toJson();

--- a/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
@@ -1070,7 +1070,7 @@ public class RenderDao {
         final Document tileHeight = new Document("$subtract", buildBasicDBList(new String[] {"$maxY","$minY" }));
         final Document tileValues = new Document("z", "$z").append(
                 "minX", "$minX").append("minY", "$minY").append("maxX", "$maxX").append("maxY", "$maxY").append(
-                "width", tileWidth).append("height", tileHeight);
+                "width", tileWidth).append("height", tileHeight).append("channels","$channels.name");
 
         final Document projectStage = new Document("$project", tileValues);
 

--- a/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
@@ -1070,7 +1070,7 @@ public class RenderDao {
         final Document tileHeight = new Document("$subtract", buildBasicDBList(new String[] {"$maxY","$minY" }));
         final Document tileValues = new Document("z", "$z").append(
                 "minX", "$minX").append("minY", "$minY").append("maxX", "$maxX").append("maxY", "$maxY").append(
-                "width", tileWidth).append("height", tileHeight).append("channels","$channels.name");
+                "width", tileWidth).append("height", tileHeight);
 
         final Document projectStage = new Document("$project", tileValues);
 
@@ -1096,7 +1096,6 @@ public class RenderDao {
         minAndMaxValues.append(maxWidthKey, new Document(QueryOperators.MAX, "$width"));
         minAndMaxValues.append(minHeightKey, new Document(QueryOperators.MIN, "$height"));
         minAndMaxValues.append(maxHeightKey, new Document(QueryOperators.MAX, "$height"));
-
         final Document groupStage = new Document("$group", minAndMaxValues);
 
         final List<Document> pipeline = new ArrayList<>();
@@ -1107,7 +1106,6 @@ public class RenderDao {
         // mongodb java 3.0 driver notes:
         // -- need to set cursor batchSize to prevent NPE from cursor creation
         final Document aggregateResult = tileCollection.aggregate(pipeline).batchSize(1).first();
-
         if (aggregateResult == null) {
             String cause = "";
             if (tileCollection.count() == 0) {
@@ -1117,6 +1115,9 @@ public class RenderDao {
                                             "The aggregation query was " + MongoUtil.fullName(tileCollection) +
                                             ".aggregate(" + pipeline + ") .");
         }
+        ArrayList<String> channels = tileCollection.distinct("channels.name",String.class).into(new ArrayList<String>());
+
+
 
         final Bounds stackBounds = new Bounds(aggregateResult.get(minXKey, Double.class),
                                               aggregateResult.get(minYKey, Double.class),
@@ -1138,7 +1139,8 @@ public class RenderDao {
                                                 minTileWidth,
                                                 maxTileWidth,
                                                 minTileHeight,
-                                                maxTileHeight);
+                                                maxTileHeight,
+                                                channels);
         stackMetaData.setStats(stats);
 
         LOG.debug("ensureIndexesAndDeriveStats: completed stat derivation for {}, stats={}", stackId, stats);


### PR DESCRIPTION
added channels to stack metadata and calculate distinct entries when completing stacks (I think) please check my work.  I've tested it manually on the  multichannel data and test data sets i have with render-python, but I wasn't sure how to insert this feature into the testing framework as you have it.