### PR TITLE
added 16 bit tiff web endpoint

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/RenderParameters.java
+++ b/render-app/src/main/java/org/janelia/alignment/RenderParameters.java
@@ -696,14 +696,16 @@ public class RenderParameters implements Serializable {
         }
         return hasMasks;
     }
-
+    public BufferedImage openTargetImage() {
+        return openTargetImage(BufferedImage.TYPE_INT_ARGB);
+    }
     /**
      * Opens the target/input image specified by these parameters or
      * creates a new (in-memory) image if no input image was specified.
      *
      * @return {@link BufferedImage} representation of the image.
      */
-    public BufferedImage openTargetImage() {
+    public BufferedImage openTargetImage(final int imageType) {
 
         BufferedImage targetImage = null;
 
@@ -715,11 +717,12 @@ public class RenderParameters implements Serializable {
             final double derivedScale = getScale();
             final int targetWidth = (int) (derivedScale * width);
             final int targetHeight = (int) (derivedScale * height);
-            targetImage = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB);
+            targetImage = new BufferedImage(targetWidth, targetHeight, imageType);
         }
 
         return targetImage;
     }
+
 
     /**
      * @return string representation of these parameters (only non-default values are included).

--- a/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
@@ -362,6 +362,42 @@ public class RenderImageService {
         }
     }
 
+    @Path("v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/tiff16-image")
+    @GET
+    @Produces(RenderServiceUtil.IMAGE_TIFF_MIME_TYPE)
+    @ApiOperation(
+            tags = "Bounding Box Image APIs",
+            value = "Render TIFF image for the specified bounding box")
+    public Response renderTiff16ImageForBox(@PathParam("owner") final String owner,
+                                          @PathParam("project") final String project,
+                                          @PathParam("stack") final String stack,
+                                          @PathParam("x") final Double x,
+                                          @PathParam("y") final Double y,
+                                          @PathParam("z") final Double z,
+                                          @PathParam("width") final Integer width,
+                                          @PathParam("height") final Integer height,
+                                          @PathParam("scale") final Double scale,
+                                          @QueryParam("filter") final Boolean filter,
+                                          @QueryParam("binaryMask") final Boolean binaryMask,
+                                          @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
+                                          @QueryParam("minIntensity") final Double minIntensity,
+                                          @QueryParam("maxIntensity") final Double maxIntensity,
+                                          @QueryParam("channels") final String channels,
+                                          @Context final Request request) {
+
+        LOG.info("renderTiffImageForBox: entry");
+
+        final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
+        if (responseHelper.isModified()) {
+            final RenderParameters renderParameters =
+                    getRenderParametersForGroupBox(owner, project, stack, null,
+                                                   x, y, z, width, height, scale, filter, binaryMask,
+                                                   minIntensity, maxIntensity, channels);
+            return RenderServiceUtil.renderTiffImage(renderParameters, maxTileSpecsToRender, responseHelper, true);
+        } else {
+            return responseHelper.getNotModifiedResponse();
+        }
+    }
     @Path("v1/owner/{owner}/project/{project}/stack/{stack}/dvid/imagetile/raw/xy/{width}_{height}/{x}_{y}_{z}/tif")
     @GET
     @Produces(RenderServiceUtil.IMAGE_TIFF_MIME_TYPE)


### PR DESCRIPTION
This is a prototype for adding 16 bit tiff web api endpoints.  This is useful for 16 bit hierarchal alignment, where you don't want to degrade your bit depth as you make virtual boxes.