### PR TITLE
16-bit PNG and raw image support

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/Utils.java
+++ b/render-app/src/main/java/org/janelia/alignment/Utils.java
@@ -62,6 +62,7 @@ public class Utils {
     public static final String PNG_FORMAT = "png";
     public static final String TIFF_FORMAT = "tiff";
     public static final String TIF_FORMAT = "tif";
+    public static final String RAW_FORMAT = "raw";
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 

--- a/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
@@ -417,7 +417,7 @@ public class RenderImageService {
                                            @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
                                            @Context final Request request) {
 
-        LOG.info("renderRawImageForBox: entry");
+        LOG.info("renderRaw16ImageForBox: entry");
 
         final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
         if (responseHelper.isModified()) {
@@ -426,6 +426,39 @@ public class RenderImageService {
                                                    x, y, z, width, height, scale,
                                                    renderQueryParameters);
             return RenderServiceUtil.renderRawImage(renderParameters, maxTileSpecsToRender, responseHelper, true);
+        } else {
+            return responseHelper.getNotModifiedResponse();
+        }
+    }
+
+    @Path("v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/raw-image")
+    @GET
+    @Produces(RenderServiceUtil.IMAGE_RAW_MIME_TYPE)
+    @ApiOperation(
+            tags = "Bounding Box Image APIs",
+            value = "Render raw image for the specified bounding box")
+    public Response renderRawImageForBox(@PathParam("owner") final String owner,
+                                           @PathParam("project") final String project,
+                                           @PathParam("stack") final String stack,
+                                           @PathParam("x") final Double x,
+                                           @PathParam("y") final Double y,
+                                           @PathParam("z") final Double z,
+                                           @PathParam("width") final Integer width,
+                                           @PathParam("height") final Integer height,
+                                           @PathParam("scale") final Double scale,
+                                           @BeanParam final RenderQueryParameters renderQueryParameters,
+                                           @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
+                                           @Context final Request request) {
+
+        LOG.info("renderRawImageForBox: entry");
+
+        final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
+        if (responseHelper.isModified()) {
+            final RenderParameters renderParameters =
+                    getRenderParametersForGroupBox(owner, project, stack, null,
+                                                   x, y, z, width, height, scale,
+                                                   renderQueryParameters);
+            return RenderServiceUtil.renderRawImage(renderParameters, maxTileSpecsToRender, responseHelper, false);
         } else {
             return responseHelper.getNotModifiedResponse();
         }

--- a/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
@@ -364,6 +364,40 @@ public class RenderImageService {
             return responseHelper.getNotModifiedResponse();
         }
     }
+
+    @Path("v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/png16-image")
+    @GET
+    @Produces(RenderServiceUtil.IMAGE_PNG_MIME_TYPE)
+    @ApiOperation(
+            tags = "Bounding Box Image APIs",
+            value = "Render 16-bit PNG image for the specified bounding box")
+    public Response renderPng16ImageForBox(@PathParam("owner") final String owner,
+                                           @PathParam("project") final String project,
+                                           @PathParam("stack") final String stack,
+                                           @PathParam("x") final Double x,
+                                           @PathParam("y") final Double y,
+                                           @PathParam("z") final Double z,
+                                           @PathParam("width") final Integer width,
+                                           @PathParam("height") final Integer height,
+                                           @PathParam("scale") final Double scale,
+                                           @BeanParam final RenderQueryParameters renderQueryParameters,
+                                           @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
+                                           @Context final Request request) {
+
+        LOG.info("renderPngImageForBox: entry");
+
+        final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
+        if (responseHelper.isModified()) {
+            final RenderParameters renderParameters =
+                    getRenderParametersForGroupBox(owner, project, stack, null,
+                                                   x, y, z, width, height, scale,
+                                                   renderQueryParameters);
+            return RenderServiceUtil.renderPngImage(renderParameters, maxTileSpecsToRender, responseHelper, true);
+        } else {
+            return responseHelper.getNotModifiedResponse();
+        }
+    }
+
     @Path("v1/owner/{owner}/project/{project}/stack/{stack}/dvid/imagetile/raw/xy/{width}_{height}/{x}_{y}_{z}/tif")
     @GET
     @Produces(RenderServiceUtil.IMAGE_TIFF_MIME_TYPE)
@@ -701,7 +735,6 @@ public class RenderImageService {
                 if (maxTileSpecsToRender == null) {
                     maxTileSpecsToRender = DEFAULT_MAX_TILE_SPECS_FOR_LARGE_DATA;
                 }
-
                 return RenderServiceUtil.renderImageStream(renderParameters,
                                                            format,
                                                            mimeType,

--- a/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/RenderImageService.java
@@ -384,7 +384,7 @@ public class RenderImageService {
                                            @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
                                            @Context final Request request) {
 
-        LOG.info("renderPngImageForBox: entry");
+        LOG.info("renderPng16ImageForBox: entry");
 
         final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
         if (responseHelper.isModified()) {
@@ -393,6 +393,39 @@ public class RenderImageService {
                                                    x, y, z, width, height, scale,
                                                    renderQueryParameters);
             return RenderServiceUtil.renderPngImage(renderParameters, maxTileSpecsToRender, responseHelper, true);
+        } else {
+            return responseHelper.getNotModifiedResponse();
+        }
+    }
+
+    @Path("v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/raw16-image")
+    @GET
+    @Produces(RenderServiceUtil.IMAGE_RAW_MIME_TYPE)
+    @ApiOperation(
+            tags = "Bounding Box Image APIs",
+            value = "Render 16-bit raw image for the specified bounding box")
+    public Response renderRaw16ImageForBox(@PathParam("owner") final String owner,
+                                           @PathParam("project") final String project,
+                                           @PathParam("stack") final String stack,
+                                           @PathParam("x") final Double x,
+                                           @PathParam("y") final Double y,
+                                           @PathParam("z") final Double z,
+                                           @PathParam("width") final Integer width,
+                                           @PathParam("height") final Integer height,
+                                           @PathParam("scale") final Double scale,
+                                           @BeanParam final RenderQueryParameters renderQueryParameters,
+                                           @QueryParam("maxTileSpecsToRender") final Integer maxTileSpecsToRender,
+                                           @Context final Request request) {
+
+        LOG.info("renderRawImageForBox: entry");
+
+        final ResponseHelper responseHelper = new ResponseHelper(request, getStackMetaData(owner, project, stack));
+        if (responseHelper.isModified()) {
+            final RenderParameters renderParameters =
+                    getRenderParametersForGroupBox(owner, project, stack, null,
+                                                   x, y, z, width, height, scale,
+                                                   renderQueryParameters);
+            return RenderServiceUtil.renderRawImage(renderParameters, maxTileSpecsToRender, responseHelper, true);
         } else {
             return responseHelper.getNotModifiedResponse();
         }

--- a/render-ws/src/main/java/org/janelia/render/service/util/BufferedImageStreamingOutput.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/BufferedImageStreamingOutput.java
@@ -2,6 +2,7 @@ package org.janelia.render.service.util;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
+import java.awt.image.DataBufferUShort;
 import java.awt.image.SinglePixelPackedSampleModel;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -86,34 +87,60 @@ public class BufferedImageStreamingOutput implements StreamingOutput {
                                      final OutputStream outputStream)
             throws IOException {
 
-        if (bufferedImage.getType() != BufferedImage.TYPE_INT_ARGB) {
-            throw new IOException("invalid image type (" + bufferedImage.getType() +
-                                  "), must be BufferedImage.TYPE_INT_ARGB");
-        }
 
-        final ImageInfo imageInfo = new ImageInfo(bufferedImage.getWidth(), bufferedImage.getHeight(), 8, true);
 
-        final PngWriter pngWriter = new PngWriter(outputStream, imageInfo);
-        pngWriter.setCompLevel(compressionLevel);
-        pngWriter.setFilterType(filterType);
+        if (bufferedImage.getType() == BufferedImage.TYPE_INT_ARGB) {
+            // Existing code for TYPE_INT_ARGB
+            final ImageInfo imageInfo = new ImageInfo(bufferedImage.getWidth(), bufferedImage.getHeight(), 8, true);
 
-        final DataBufferInt dataBuffer =((DataBufferInt) bufferedImage.getRaster().getDataBuffer());
-        if (dataBuffer.getNumBanks() != 1) {
-            throw new IOException("invalid number of banks (" + dataBuffer.getNumBanks() + "), must be 1");
-        }
+            final PngWriter pngWriter = new PngWriter(outputStream, imageInfo);
+            pngWriter.setCompLevel(compressionLevel);
+            pngWriter.setFilterType(filterType);
 
-        final SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) bufferedImage.getSampleModel();
-        final ImageLineInt line = new ImageLineInt(imageInfo);
-        final int[] data = dataBuffer.getData();
-        for (int row = 0; row < imageInfo.rows; row++) {
-            int elem = sampleModel.getOffset(0, row);
-            for (int col = 0; col < imageInfo.cols; col++) {
-                final int sample = data[elem++];
-                ImageLineHelper.setPixelRGBA8(line, col, sample);
+            final DataBufferInt dataBuffer =((DataBufferInt) bufferedImage.getRaster().getDataBuffer());
+            if (dataBuffer.getNumBanks() != 1) {
+                throw new IOException("invalid number of banks (" + dataBuffer.getNumBanks() + "), must be 1");
             }
-            pngWriter.writeRow(line, row);
+
+            final SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) bufferedImage.getSampleModel();
+            final ImageLineInt line = new ImageLineInt(imageInfo);
+            final int[] data = dataBuffer.getData();
+            for (int row = 0; row < imageInfo.rows; row++) {
+                int elem = sampleModel.getOffset(0, row);
+                for (int col = 0; col < imageInfo.cols; col++) {
+                    final int sample = data[elem++];
+                    ImageLineHelper.setPixelRGBA8(line, col, sample);
+                }
+                pngWriter.writeRow(line, row);
+            }
+            pngWriter.end();
+
+        } else if (bufferedImage.getType() == BufferedImage.TYPE_USHORT_GRAY) {
+            // Modified code to avoid "java.awt.image.DataBufferUShort cannot be cast to java.awt.image.DataBufferInt"
+            final ImageInfo imageInfo = new ImageInfo(bufferedImage.getWidth(), bufferedImage.getHeight(), 16, false, true, false);
+            final PngWriter pngWriter = new PngWriter(outputStream, imageInfo);
+            pngWriter.setCompLevel(compressionLevel);
+            pngWriter.setFilterType(filterType);
+
+            final DataBufferUShort dataBuffer = (DataBufferUShort) bufferedImage.getRaster().getDataBuffer();
+            if (dataBuffer.getNumBanks() != 1) {
+                throw new IOException("invalid number of banks (" + dataBuffer.getNumBanks() + "), must be 1");
+            }
+
+            final int [] scanline = new int[imageInfo.cols];
+            ImageLineInt line = new ImageLineInt(imageInfo, scanline);
+
+            for (int row = 0; row < imageInfo.rows; row++) {
+                for (int col = 0; col < imageInfo.cols; col++) {
+                    scanline[col] = dataBuffer.getData()[row * imageInfo.cols + col];
+                }
+                pngWriter.writeRow(line, row);
+            }
+            pngWriter.end();
+        } else {
+            throw new IOException("invalid image type (" + bufferedImage.getType() +
+                    "), must be BufferedImage.TYPE_INT_ARGB or BufferedImage.TYPE_USHORT_GRAY");
         }
-        pngWriter.end();
 
 //        // This looked like a nicer option, but only works for DataBufferByte (not DataBufferInt)
 //        final ImageLineSetARGBbi lines = new ImageLineSetARGBbi(bufferedImage, imageInfo);

--- a/render-ws/src/main/java/org/janelia/render/service/util/BufferedImageStreamingOutput.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/BufferedImageStreamingOutput.java
@@ -1,6 +1,7 @@
 package org.janelia.render.service.util;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferUShort;
 import java.awt.image.SinglePixelPackedSampleModel;
@@ -173,6 +174,9 @@ public class BufferedImageStreamingOutput implements StreamingOutput {
             for (int i:dataBuffer.getData()){
                 dataStream.writeInt(i);
             }
+        } else if (bufferedImage.getType() == BufferedImage.TYPE_BYTE_GRAY) {
+            final DataBufferByte dataBuffer = (DataBufferByte) bufferedImage.getRaster().getDataBuffer();
+            dataStream.write(dataBuffer.getData());
         } else if (bufferedImage.getType() == BufferedImage.TYPE_USHORT_GRAY) {
             final DataBufferUShort dataBuffer = (DataBufferUShort) bufferedImage.getRaster().getDataBuffer();
             for (int i:dataBuffer.getData()){
@@ -180,7 +184,7 @@ public class BufferedImageStreamingOutput implements StreamingOutput {
             }
         } else {
             throw new IOException("invalid image type (" + bufferedImage.getType() +
-                    "), must be BufferedImage.TYPE_INT_ARGB or BufferedImage.TYPE_USHORT_GRAY");
+                    "), must be BufferedImage.TYPE_INT_ARGB, BufferedImage.TYPE_BYTE_GRAY or BufferedImage.TYPE_USHORT_GRAY");
         }
     }
 }

--- a/render-ws/src/main/java/org/janelia/render/service/util/RenderServiceUtil.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/RenderServiceUtil.java
@@ -79,19 +79,28 @@ public class RenderServiceUtil {
 
     public static Response renderPngImage(final RenderParameters renderParameters,
                                           final Integer maxTileSpecsToRender,
-                                          final ResponseHelper responseHelper) {
+                                          final ResponseHelper responseHelper)
+    {
+        return renderPngImage(renderParameters, maxTileSpecsToRender, responseHelper, false);
+
+    }
+    public static Response renderPngImage(final RenderParameters renderParameters,
+                                          final Integer maxTileSpecsToRender,
+                                          final ResponseHelper responseHelper,
+                                          final boolean render16bit) {
         return renderImageStream(renderParameters,
                                  Utils.PNG_FORMAT,
                                  IMAGE_PNG_MIME_TYPE,
                                  maxTileSpecsToRender,
-                                 responseHelper);
+                                 responseHelper,
+                                 render16bit);
     }
 
     public static Response renderTiffImage(final RenderParameters renderParameters,
-    final Integer maxTileSpecsToRender,
-    final ResponseHelper responseHelper) {
-return renderTiffImage(renderParameters, maxTileSpecsToRender, responseHelper, false);
-}
+                                           final Integer maxTileSpecsToRender,
+                                           final ResponseHelper responseHelper) {
+        return renderTiffImage(renderParameters, maxTileSpecsToRender, responseHelper, false);
+    }
 
     public static Response renderTiffImage(final RenderParameters renderParameters,
                                            final Integer maxTileSpecsToRender,
@@ -104,6 +113,7 @@ return renderTiffImage(renderParameters, maxTileSpecsToRender, responseHelper, f
                                  responseHelper,
                                  render16bit);
     }
+
     public static Response renderImageStream(final RenderParameters renderParameters,
     final String format,
     final String mimeType,

--- a/render-ws/src/main/java/org/janelia/render/service/util/RenderServiceUtil.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/RenderServiceUtil.java
@@ -26,6 +26,7 @@ public class RenderServiceUtil {
     public static final String IMAGE_JPEG_MIME_TYPE = "image/jpeg";
     public static final String IMAGE_PNG_MIME_TYPE = "image/png";
     public static final String IMAGE_TIFF_MIME_TYPE = "image/tiff";
+    public static final String IMAGE_RAW_MIME_TYPE = "iapplication/octet-stream";
 
     public static void throwServiceException(final Throwable t)
             throws ServiceException {
@@ -91,6 +92,25 @@ public class RenderServiceUtil {
         return renderImageStream(renderParameters,
                                  Utils.PNG_FORMAT,
                                  IMAGE_PNG_MIME_TYPE,
+                                 maxTileSpecsToRender,
+                                 responseHelper,
+                                 render16bit);
+    }
+
+    public static Response renderRawImage(final RenderParameters renderParameters,
+                                          final Integer maxTileSpecsToRender,
+                                          final ResponseHelper responseHelper)
+    {
+        return renderRawImage(renderParameters, maxTileSpecsToRender, responseHelper, false);
+
+    }
+    public static Response renderRawImage(final RenderParameters renderParameters,
+                                          final Integer maxTileSpecsToRender,
+                                          final ResponseHelper responseHelper,
+                                          final boolean render16bit) {
+        return renderImageStream(renderParameters,
+                                 Utils.RAW_FORMAT,
+                                 IMAGE_RAW_MIME_TYPE,
                                  maxTileSpecsToRender,
                                  responseHelper,
                                  render16bit);


### PR DESCRIPTION
I am reviving a long overdue thread for better png support (#76).

As of now, this branch adds a "png16-image" target, as well as "raw-image" (RGBA) and "raw16-image) (short gray), which I'm using for small experiment at the moment.

@trautmane: Instead of creating end-points for 16-bit, do you think the data type should be specified as an argument, e.g. &dtype=RGBA or &grayscale=true&depth=16 or something like that?

