### PR TITLE
Optimize distributed solve match fetch

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecCollection.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecCollection.java
@@ -435,9 +435,9 @@ public class ResolvedTileSpecCollection implements Serializable {
     /**
      * Removes any tile specs not identified in the provided set from this collection.
      *
-     * @param  tileIdsToKeep  identifies which tile specs should be kept.
+     * @param  tileIdsToKeep  identifies which tile specs should be retained.
      */
-    public void removeDifferentTileSpecs(final Set<String> tileIdsToKeep) {
+    public void retainTileSpecs(final Set<String> tileIdsToKeep) {
         removeTileSpecs(tileIdsToKeep, false);
     }
 

--- a/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
@@ -57,9 +57,18 @@ public class ResolvedTileSpecsWithMatchPairs
      * Resolves all tile specs for client-side usage and normalizes match pairs
      * by removing pairs that are too far from each other in z and by sorting them.
      *
-     * @param  maxZDistance  maximum integral z distance for all retained pairs.
+     * @param  maxZDistance  maximum non-negative integral z distance for all retained pairs
+     *                       (or null to accept all pairs).
+     *
+     * @throws IllegalArgumentException
+     *   if maxZDistance < 0
      */
-    public void resolveTileSpecsAndNormalizeMatchPairs(final int maxZDistance) {
+    public void resolveTileSpecsAndNormalizeMatchPairs(final Integer maxZDistance)
+            throws IllegalArgumentException {
+
+        if ((maxZDistance != null) && (maxZDistance <= 0)) {
+            throw new IllegalArgumentException("maxZDistance must be >= 0 or null");
+        }
 
         resolvedTileSpecs.resolveTileSpecs();
 
@@ -69,9 +78,13 @@ public class ResolvedTileSpecsWithMatchPairs
             final TileSpec pTileSpec = resolvedTileSpecs.getTileSpec(pair.getpId());
             final TileSpec qTileSpec = resolvedTileSpecs.getTileSpec(pair.getqId());
             if ((pTileSpec != null) && (qTileSpec != null)) {
-                final int zDistance = (int) Math.abs(pTileSpec.getZ() - qTileSpec.getZ());
-                if (zDistance <= maxZDistance) {
+                if (maxZDistance == null) {
                     normalizedMatchPairs.add(pair);
+                } else {
+                    final int zDistance = (int) Math.abs(pTileSpec.getZ() - qTileSpec.getZ());
+                    if (zDistance <= maxZDistance) {
+                        normalizedMatchPairs.add(pair);
+                    }
                 }
             }
         }

--- a/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
@@ -80,7 +80,7 @@ public class ResolvedTileSpecsWithMatchPairs
             throw new IllegalArgumentException("maxZDistance must be >= 0 or null");
         }
 
-        // remove unwanted tiles (which will later cause associated math pairs to be removed)
+        // remove unwanted tiles (which will later cause associated match pairs to be removed)
         if (tileIdsToKeep != null) {
 
             // track and log removal info if debugging

--- a/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
@@ -87,7 +87,7 @@ public class ResolvedTileSpecsWithMatchPairs
             final boolean isDebugEnabled = LOG.isDebugEnabled();
             final Set<String> beforeTileIds = isDebugEnabled ? new HashSet<>(resolvedTileSpecs.getTileIds()) : null;
 
-            resolvedTileSpecs.removeDifferentTileSpecs(tileIdsToKeep);
+            resolvedTileSpecs.retainTileSpecs(tileIdsToKeep);
 
             if (isDebugEnabled) {
                 final Set<String> afterTileIds = resolvedTileSpecs.getTileIds();

--- a/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/ResolvedTileSpecsWithMatchPairs.java
@@ -114,8 +114,7 @@ public class ResolvedTileSpecsWithMatchPairs
                 if (maxZDistance == null) {
                     normalizedMatchPairs.add(pair);
                 } else {
-                    final int zDistance = (int) Math.abs(pTileSpec.getZ() - qTileSpec.getZ());
-                    if (zDistance <= maxZDistance) {
+                    if (pTileSpec.zDistanceFrom(qTileSpec) <= maxZDistance) {
                         normalizedMatchPairs.add(pair);
                     }
                 }

--- a/render-app/src/main/java/org/janelia/alignment/spec/TileSpec.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/TileSpec.java
@@ -118,8 +118,18 @@ public class TileSpec implements Serializable {
         return z;
     }
 
-    public Integer getIntegralZ() {
+    @JsonIgnore
+    public Integer getIntegerZ() {
         return z == null ? null : z.intValue();
+    }
+
+
+    /**
+     * @return absolute difference between this tile's integer z and the specified tile's integer z.
+     */
+    @JsonIgnore
+    public int zDistanceFrom(final TileSpec that) {
+        return Math.abs(this.getIntegerZ() - that.getIntegerZ());
     }
 
     public void setZ(final Double z) {

--- a/render-app/src/main/java/org/janelia/alignment/spec/TileSpec.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/TileSpec.java
@@ -118,6 +118,10 @@ public class TileSpec implements Serializable {
         return z;
     }
 
+    public Integer getIntegralZ() {
+        return z == null ? null : z.intValue();
+    }
+
     public void setZ(final Double z) {
         this.z = z;
     }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/CopyStackClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/CopyStackClient.java
@@ -334,7 +334,7 @@ public class CopyStackClient {
 
         if (parameters.layerBounds.minX != null) {
             final Set<String> tileIdsToKeep = getIdsForTilesInBox(z);
-            sourceCollection.removeDifferentTileSpecs(tileIdsToKeep);
+            sourceCollection.retainTileSpecs(tileIdsToKeep);
         }
 
         if (parameters.replaceLastTransformWithStage) {
@@ -394,7 +394,7 @@ public class CopyStackClient {
 
         if (tileIdsToKeep.size() > 0) {
             final int numberOfTilesBeforeFilter = sourceCollection.getTileCount();
-            sourceCollection.removeDifferentTileSpecs(tileIdsToKeep);
+            sourceCollection.retainTileSpecs(tileIdsToKeep);
             final int numberOfTilesRemoved = numberOfTilesBeforeFilter - sourceCollection.getTileCount();
             LOG.info("copyLayer: removed {} tiles not found in {}", numberOfTilesRemoved, filterStack);
         }
@@ -426,7 +426,7 @@ public class CopyStackClient {
 
         if (parameters.includedTileIdsJson != null) {
             final int numberOfTilesBeforeFilter = sourceCollection.getTileCount();
-            sourceCollection.removeDifferentTileSpecs(parameters.getIncludedTileIdsSet());
+            sourceCollection.retainTileSpecs(parameters.getIncludedTileIdsSet());
             final int numberOfTilesRemoved = numberOfTilesBeforeFilter - sourceCollection.getTileCount();
             if (numberOfTilesRemoved > 0) {
                 LOG.info("copyLayer: removed {} tiles that were not explicitly included", numberOfTilesRemoved);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/ExponentialRecoveryOffsetTransformDerivationClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/ExponentialRecoveryOffsetTransformDerivationClient.java
@@ -340,7 +340,7 @@ public class ExponentialRecoveryOffsetTransformDerivationClient
             resolvedTilesForLayer.addTransformSpecToTile(tileId,
                                                          transformSpec,
                                                          parameters.transformApplicationMethod);
-            resolvedTilesForLayer.removeDifferentTileSpecs(Collections.singleton(tileId));
+            resolvedTilesForLayer.retainTileSpecs(Collections.singleton(tileId));
             updatedCollection.merge(resolvedTilesForLayer);
         }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/ImportMETClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/ImportMETClient.java
@@ -436,7 +436,7 @@ public class ImportMETClient {
 
             LOG.info("updateTiles: filtering tile spec collection {}", updatedTiles);
 
-            updatedTiles.removeDifferentTileSpecs(tileIdToAlignTransformMap.keySet());
+            updatedTiles.retainTileSpecs(tileIdToAlignTransformMap.keySet());
 
             if (!updatedTiles.hasTileSpecs()) {
                 throw new IllegalArgumentException("after filtering out non-aligned tiles, " +

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/ImportTransformChangesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/ImportTransformChangesClient.java
@@ -260,7 +260,7 @@ public class ImportTransformChangesClient {
 
             LOG.info("updateTiles: filtering tile spec collection {}", tileSpecs);
 
-            tileSpecs.removeDifferentTileSpecs(tileIdToLoadedTransformMap.keySet());
+            tileSpecs.retainTileSpecs(tileIdToLoadedTransformMap.keySet());
 
             if (! tileSpecs.hasTileSpecs()) {
                 throw new IllegalArgumentException("after filtering out unreferenced source tiles, " +

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -317,7 +317,7 @@ public class RenderTilesClient {
             if (clientParameters.hackStack != null) {
                 final Set<String> tileIdsToKeep = new HashSet<>(tileIds);
                 for (final ResolvedTileSpecCollection resolvedTiles : zToResolvedTiles.values()) {
-                    resolvedTiles.removeDifferentTileSpecs(tileIdsToKeep);
+                    resolvedTiles.retainTileSpecs(tileIdsToKeep);
                 }
             }
         }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RigidTransformClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RigidTransformClient.java
@@ -154,8 +154,8 @@ public class RigidTransformClient {
                 alignDataClient.getResolvedTiles(parameters.warp.alignStack, z);
 
         if (parameters.warp.excludeTilesNotInBothStacks) {
-            montageTiles.removeDifferentTileSpecs(alignTiles.getTileIds());
-            alignTiles.removeDifferentTileSpecs(montageTiles.getTileIds());
+            montageTiles.retainTileSpecs(alignTiles.getTileIds());
+            alignTiles.retainTileSpecs(montageTiles.getTileIds());
         }
 
         if (parameters.tileCluster.isDefined()) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/SectionUpdateClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/SectionUpdateClient.java
@@ -292,7 +292,7 @@ public class SectionUpdateClient {
                             "), max (" + parameters.maxX + ", " + parameters.maxY + ")");
                 }
 
-                resolvedTiles.removeDifferentTileSpecs(updateTileIds);
+                resolvedTiles.retainTileSpecs(updateTileIds);
 
             } else if (sectionIdSet != null) {
 
@@ -307,7 +307,7 @@ public class SectionUpdateClient {
                             "no tile specs exist in stack " + stack + " with sectionId(s) " + sectionIdSet);
                 }
 
-                resolvedTiles.removeDifferentTileSpecs(updateTileIds);
+                resolvedTiles.retainTileSpecs(updateTileIds);
 
             }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/SubstrateMaskGeneratorClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/SubstrateMaskGeneratorClient.java
@@ -240,7 +240,7 @@ public class SubstrateMaskGeneratorClient {
         final ResolvedTileSpecCollection resolvedTiles = sourceDataClient.getResolvedTiles(parameters.stack, z);
 
         if (explicitTileCount > 0) {
-            resolvedTiles.removeDifferentTileSpecs(explicitTileIds);
+            resolvedTiles.retainTileSpecs(explicitTileIds);
         }
 
         final Path maskDirectoryPath = Paths.get(parameters.getBaseMaskDirectoryPath(),

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TransformSectionClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TransformSectionClient.java
@@ -325,7 +325,7 @@ public class TransformSectionClient {
                         TileBounds::getTileId).collect(Collectors.toList()));
 
         if (tileBoundsList.size() > tileIdsToKeep.size()) {
-            tiles.removeDifferentTileSpecs(tileIdsToKeep);
+            tiles.retainTileSpecs(tileIdsToKeep);
             LOG.info("removeTilesOutsideBox: removed {} tiles outside of bounding box",
                      (tileBoundsList.size() - tileIdsToKeep.size()));
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TranslateClustersClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TranslateClustersClient.java
@@ -194,7 +194,7 @@ public class TranslateClustersClient {
 
             if (tileIdsToKeep.size() > 0) {
                 final int numberOfTilesBeforeFilter = resolvedTiles.getTileCount();
-                resolvedTiles.removeDifferentTileSpecs(tileIdsToKeep);
+                resolvedTiles.retainTileSpecs(tileIdsToKeep);
                 final int numberOfTilesRemoved = numberOfTilesBeforeFilter - resolvedTiles.getTileCount();
                 LOG.info("translateLayerClusters: removed {} tiles not found in {}", numberOfTilesRemoved, filterStack);
             }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/UnconnectedTileRemovalClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/UnconnectedTileRemovalClient.java
@@ -350,7 +350,7 @@ public class UnconnectedTileRemovalClient {
         final ResolvedTileSpecCollection filteredTiles =
                 new ResolvedTileSpecCollection(allTiles.getTransformSpecs(),
                                                allTiles.getTileSpecs());
-        filteredTiles.removeDifferentTileSpecs(keepTileIds);
+        filteredTiles.retainTileSpecs(keepTileIds);
         return filteredTiles;
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/WarpTransformClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/WarpTransformClient.java
@@ -137,8 +137,8 @@ public class WarpTransformClient {
                 alignDataClient.getResolvedTiles(parameters.warp.alignStack, z);
 
         if (parameters.warp.excludeTilesNotInBothStacks) {
-            montageTiles.removeDifferentTileSpecs(alignTiles.getTileIds());
-            alignTiles.removeDifferentTileSpecs(montageTiles.getTileIds());
+            montageTiles.retainTileSpecs(alignTiles.getTileIds());
+            alignTiles.retainTileSpecs(montageTiles.getTileIds());
         }
 
         if (parameters.tileCluster.isDefined()) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVMontageSolverClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVMontageSolverClient.java
@@ -163,7 +163,7 @@ public class MFOVMontageSolverClient {
                     .map(TileSpec::getTileId)
                     .filter(id -> mFOVSet.contains(Utilities.getMFOVForTileId(id)))
                     .collect(Collectors.toSet());
-            resolvedTiles.removeDifferentTileSpecs(tileIdsToKeep);
+            resolvedTiles.retainTileSpecs(tileIdsToKeep);
             resolvedTiles.resolveTileSpecs();
 
             final Map<String, Set<String>> mFOVToTileIdMap = new HashMap<>();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
@@ -35,6 +35,8 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 
 	private int id;
 
+	private final Bounds bounds;
+
 	// the BlockFactory that created this BlockData
 	final private BlockFactory blockFactory;
 
@@ -64,9 +66,11 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 			final BlockFactory blockFactory, // knows how it was created for assembly later?
 			final P solveTypeParameters,
 			final int id,
+			final Bounds bounds,
 			final ResolvedTileSpecCollection rtsc )
 	{
 		this.id = id;
+		this.bounds = bounds;
 		this.blockFactory = blockFactory;
 		this.solveTypeParameters = solveTypeParameters;
 		this.rtsc = rtsc;
@@ -86,6 +90,11 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	public Map<String, ArrayList<Double>> sectionIdToZMap() { return sectionIdToZMap; }
 
 	public int getId() { return id; }
+
+	public Bounds getBounds() {
+		return bounds;
+	}
+
 	public WeightFunction createWeightFunction() {
 		return blockFactory.createWeightFunction(this);
 	}
@@ -171,5 +180,14 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 			return false;
 		final BlockData<?,?> other = (BlockData<?,?>) obj;
 		return id == other.id && maxZ == other.maxZ && minZ == other.minZ && Objects.equals(rtsc, other.rtsc);
+	}
+
+	@Override
+	public String toString() {
+		return "{\"id:\" " + id + ", \"bounds\": " + bounds + '}';
+	}
+
+	public int getTileCount() {
+		return rtsc == null ? 0 : rtsc().getTileCount();
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
@@ -63,7 +63,11 @@ public abstract class BlockFactory implements Serializable {
 			} else {
 				pruneRtsc(rtsc, bound);
 				LOG.info("   Loaded " + rtsc.getTileIds().size() + " tiles.");
-				final BlockData<R, P> block = new BlockData<>(this, parameterProvider.create(rtsc), id, rtsc);
+				final BlockData<R, P> block = new BlockData<>(this,
+															  parameterProvider.create(rtsc),
+															  id,
+															  bound,
+															  rtsc);
 				blockDataList.add(block);
 				id++;
 			}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -227,8 +227,8 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 					)
 			);//CanvasMatchResult.convertMatchesToPointMatchList(match.getMatches()) ) );
 
-			final int pZ = pTileSpec.getIntegralZ();
-			final int qZ = qTileSpec.getIntegralZ();
+			final int pZ = pTileSpec.getIntegerZ();
+			final int qZ = qTileSpec.getIntegerZ();
 
 			blockData.zToTileId().computeIfAbsent(pZ, k -> new HashSet<>()).add(pId);
 			blockData.zToTileId().computeIfAbsent(qZ, k -> new HashSet<>()).add(qId);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -283,8 +283,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			final int samplesPerDimension,
 			final int stabilizationRadius )
 	{
-		final String blockContext = "block " + solveItem.blockData.getId();
-		LOG.info("assignRegularizationModel: entry, {}", blockContext);
+		LOG.info("assignRegularizationModel: entry, block {}", solveItem.blockData);
 
 		final HashMap< Integer, List<Tile<M>> > zToGroupedTileList = new HashMap<>();
 
@@ -303,7 +302,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			}
 			catch (final Exception e) {
 				final String currentTileId = solveItem.tileToIdMap().get(currentTile);
-				throw new RuntimeException("failed to to populate zToGroupedTileList for " + blockContext +
+				throw new RuntimeException("failed to to populate zToGroupedTileList for block " + solveItem.blockData +
 										   ", currentTileId is " + currentTileId, e);
 			}
 		}
@@ -316,12 +315,12 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 		if (model instanceof ConstantAffineModel2D) {
 			// it is based on ConstantAffineModels, meaning we extract metadata and use that as regularizer
 			assignConstantAffineModel(solveItem, samplesPerDimension, allZ, zToGroupedTileList);
-			LOG.info("assignRegularizationModel: exit, {}", blockContext);
+			LOG.info("assignRegularizationModel: exit, block {}", solveItem.blockData);
 
 		} else if (model instanceof StabilizingAffineModel2D) {
 			// it is based on StabilizingAffineModel2Ds, meaning each image wants to sit where its corresponding one in the above layer sits
 			assignStabilizingAffineModel(solveItem, samplesPerDimension, stabilizationRadius, allZ, zToGroupedTileList);
-			LOG.info("assignRegularizationModel: exit, {}", blockContext);
+			LOG.info("assignRegularizationModel: exit, block {}", solveItem.blockData);
 
 		} else {
 			LOG.info( "Not using ConstantAffineModel2D for regularization. Nothing to do in assignRegularizationModel()." );

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -203,8 +203,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 		// block tileIds are filtered by center point during BlockFactory.defineBlockCollection process
 		// (more specifically by BlockFactory.pruneRtsc), so apply the same filtering to retrieved tile and match data
 		final Set<String> tileIdsToKeep = new HashSet<>(blockData.rtsc().getTileIds());
-		tileSpecsWithMatchPairs.resolveTileSpecsAndNormalizeMatchPairs(tileIdsToKeep,
-																	   maxZDistance);
+		tileSpecsWithMatchPairs.normalize(tileIdsToKeep, maxZDistance);
 
 		final List<CanvasMatches> matchPairs = new ArrayList<>(tileSpecsWithMatchPairs.getMatchPairCount());
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -182,12 +182,16 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			throws IOException {
 
 		final BlockData<AffineModel2D, FIBSEMAlignmentParameters<M, S>> blockData = inputSolveItem.blockData();
-		final int maxZRangeMatches =
-				blockData.solveTypeParameters().maxZRangeMatches(); // TODO: move this parameter to API query
+
+		Integer maxZDistance = blockData.solveTypeParameters().maxZRangeMatches(); // TODO: move this parameter to API query
+		if (maxZDistance < 0) {
+			maxZDistance = null;
+		}
+
 		final String matchCollectionName = matchDataClient.getProject(); // TODO: remove matchDataClient
 
-		LOG.info("assembleMatchData: entry, loading transforms and matches for block {} with {} tiles and maxZRangeMatches={}",
-				 blockData, blockData.getTileCount(), maxZRangeMatches);
+		LOG.info("assembleMatchData: entry, loading transforms and matches for block {} with {} tiles and maxZDistance={}",
+				 blockData, blockData.getTileCount(), maxZDistance);
 
 		final ResolvedTileSpecsWithMatchPairs tileSpecsWithMatchPairs =
 				renderDataClient.getResolvedTilesWithMatchPairs(renderStack,
@@ -196,7 +200,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 																null,
 																null);
 
-		tileSpecsWithMatchPairs.resolveTileSpecsAndNormalizeMatchPairs(maxZRangeMatches);
+		tileSpecsWithMatchPairs.resolveTileSpecsAndNormalizeMatchPairs(maxZDistance);
 
 		final List<CanvasMatches> matchPairs = new ArrayList<>(tileSpecsWithMatchPairs.getMatchPairCount());
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -200,7 +200,11 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 																null,
 																null);
 
-		tileSpecsWithMatchPairs.resolveTileSpecsAndNormalizeMatchPairs(maxZDistance);
+		// block tileIds are filtered by center point during BlockFactory.defineBlockCollection process
+		// (more specifically by BlockFactory.pruneRtsc), so apply the same filtering to retrieved tile and match data
+		final Set<String> tileIdsToKeep = new HashSet<>(blockData.rtsc().getTileIds());
+		tileSpecsWithMatchPairs.resolveTileSpecsAndNormalizeMatchPairs(tileIdsToKeep,
+																	   maxZDistance);
 
 		final List<CanvasMatches> matchPairs = new ArrayList<>(tileSpecsWithMatchPairs.getMatchPairCount());
 
@@ -1101,5 +1105,5 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 		return graphs;
 	}
 
-	private static final Logger LOG = LoggerFactory.getLogger(Worker.class);
+	private static final Logger LOG = LoggerFactory.getLogger(AffineAlignBlockWorker.class);
 }

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/RenderDataClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/RenderDataClientTest.java
@@ -2,7 +2,9 @@ package org.janelia.render.client;
 
 import java.util.List;
 
+import org.janelia.alignment.spec.Bounds;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.ResolvedTileSpecsWithMatchPairs;
 import org.janelia.alignment.spec.TileBounds;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackMetaData;
@@ -13,7 +15,6 @@ import org.junit.Test;
 
 /**
  * Tests the {@link RenderDataClient} class.
- *
  * All tests are "ignored" because of the dependency on a real web server.
  * They can be configured to run as needed in specific environments.
  *
@@ -28,9 +29,11 @@ public class RenderDataClientTest {
 
     @Before
     public void setup() {
-        renderDataClient = new RenderDataClient("http://renderer-dev:8080/render-ws/v1", "flyTEM", "FAFB00");
-        stack = "v14_align_tps_20170818";
-        z = 3451.0;
+        renderDataClient = new RenderDataClient("http://renderer-dev:8080/render-ws/v1",
+                                                "hess_wafer_53",
+                                                "cut_000_to_009");
+        stack = "c000_s095_v01";
+        z = 1.0;
     }
 
     @Test
@@ -82,6 +85,24 @@ public class RenderDataClientTest {
         Assert.assertNotNull("null resolvedTiles", resolvedTiles);
 
         Assert.assertTrue("not enough tiles", resolvedTiles.getTileCount() > 100);
+    }
+
+    @Test
+    public void testGetResolvedTileSpecsWithMatchPairs()
+            throws Exception {
+
+        final Bounds bounds = new Bounds(66001.0,   30668.0, 1.0,
+                                         78000.0,   43001.0, 36.0);
+        final String matchCollectionName = "c000_s095_v01_match_agg2";
+
+        final ResolvedTileSpecsWithMatchPairs tileSpecsWithMatchPairs =
+                renderDataClient.getResolvedTilesWithMatchPairs(stack,
+                                                                bounds,
+                                                                matchCollectionName,
+                                                                null,
+                                                                null);
+
+        Assert.assertNotNull("null result", tileSpecsWithMatchPairs);
     }
 
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/CopyStackClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/CopyStackClient.java
@@ -345,7 +345,7 @@ public class CopyStackClient implements Serializable {
 
                 if (tileIdsToKeep.size() > 0) {
                     final int numberOfTilesBeforeFilter = sourceCollection.getTileCount();
-                    sourceCollection.removeDifferentTileSpecs(tileIdsToKeep);
+                    sourceCollection.retainTileSpecs(tileIdsToKeep);
                     final int numberOfTilesRemoved = numberOfTilesBeforeFilter - sourceCollection.getTileCount();
                     LOG.info("copyFunction: removed {} tiles not found in {}", numberOfTilesRemoved, filterStack);
                 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/WarpTransformClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/WarpTransformClient.java
@@ -156,8 +156,8 @@ public class WarpTransformClient
                             alignDataClient.getResolvedTiles(parameters.warp.alignStack, z);
 
                     if (parameters.warp.excludeTilesNotInBothStacks) {
-                        montageTiles.removeDifferentTileSpecs(alignTiles.getTileIds());
-                        alignTiles.removeDifferentTileSpecs(montageTiles.getTileIds());
+                        montageTiles.retainTileSpecs(alignTiles.getTileIds());
+                        alignTiles.retainTileSpecs(montageTiles.getTileIds());
                     }
 
                     if (parameters.tileCluster.isDefined()) {

--- a/render-ws/src/main/java/org/janelia/render/service/CombinedRenderAndMatchService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/CombinedRenderAndMatchService.java
@@ -40,6 +40,7 @@ import org.janelia.render.service.util.RenderServiceUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -52,6 +53,7 @@ import static org.janelia.render.service.dao.RenderDao.MAX_TILE_SPEC_COUNT_FOR_Q
  * @author Eric Trautman
  */
 @Path("/")
+@Api(tags = {"Point Match APIs"})
 public class CombinedRenderAndMatchService {
 
     private final RenderDao renderDao;

--- a/render-ws/src/main/java/org/janelia/render/service/CombinedRenderAndMatchService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/CombinedRenderAndMatchService.java
@@ -18,6 +18,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
 
 import mpicbg.models.PointMatch;
@@ -27,6 +29,7 @@ import org.janelia.alignment.match.CanvasMatches;
 import org.janelia.alignment.match.MatchCollectionId;
 import org.janelia.alignment.match.SortedConnectedCanvasIdClusters;
 import org.janelia.alignment.match.TileIdsWithMatches;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileBounds;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.spec.stack.StackId;
@@ -41,6 +44,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.janelia.render.service.dao.RenderDao.MAX_TILE_SPEC_COUNT_FOR_QUERIES;
+
 /**
  * APIs that pull data from both the render and match databases.
  *
@@ -50,18 +55,66 @@ import io.swagger.annotations.ApiResponses;
 public class CombinedRenderAndMatchService {
 
     private final RenderDao renderDao;
+    private final RenderDataService renderDataService;
     private final MatchDao matchDao;
 
     @SuppressWarnings("UnusedDeclaration")
     public CombinedRenderAndMatchService()
             throws UnknownHostException {
-        this(RenderDao.build(), MatchDao.build());
+        this(RenderDao.build(), new RenderDataService(), MatchDao.build());
     }
 
     private CombinedRenderAndMatchService(final RenderDao renderDao,
+                                          final RenderDataService renderDataService,
                                           final MatchDao matchDao) {
         this.renderDao = renderDao;
+        this.renderDataService = renderDataService;
         this.matchDao = matchDao;
+    }
+
+    @Path("v1/owner/{owner}/project/{project}/stack/{stack}/resolvedTilesWithMatchesFrom/{matchCollection}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            tags = {"Stack Data APIs", "Point Match APIs"},
+            value = "Get raw tile and transform specs for specified group or bounding box " +
+                    "along with the point matches for those tiles")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "too many (> " + MAX_TILE_SPEC_COUNT_FOR_QUERIES + ") matching tiles found"),
+            @ApiResponse(code = 404, message = "no tile specs found"),
+    })
+    public Response getResolvedTilesWithMatches(@PathParam("owner") final String owner,
+                                                @PathParam("project") final String project,
+                                                @PathParam("stack") final String stack,
+                                                @PathParam("matchCollection") final String matchCollection,
+                                                @QueryParam("minZ") final Double minZ,
+                                                @QueryParam("maxZ") final Double maxZ,
+                                                @QueryParam("groupId") final String groupId,
+                                                @QueryParam("minX") final Double minX,
+                                                @QueryParam("maxX") final Double maxX,
+                                                @QueryParam("minY") final Double minY,
+                                                @QueryParam("maxY") final Double maxY,
+                                                @QueryParam("matchPattern") final String matchPattern) {
+
+        LOG.info("getResolvedTilesWithMatches: entry, owner={}, project={}, stack={}, matchCollection={}, minZ={}, maxZ={}, groupId={}, minX={}, maxX={}, minY={}, maxY={}, matchPattern={}",
+                 owner, project, stack, matchCollection, minZ, maxZ, groupId, minX, maxX, minY, maxY, matchPattern);
+
+        final MatchCollectionId collectionId = MatchService.getCollectionId(owner, matchCollection);
+        final ResolvedTileSpecCollection resolvedTiles = renderDataService.getResolvedTiles(owner,
+                                                                                            project,
+                                                                                            stack,
+                                                                                            minZ,
+                                                                                            maxZ,
+                                                                                            groupId,
+                                                                                            minX,
+                                                                                            maxX,
+                                                                                            minY,
+                                                                                            maxY,
+                                                                                            matchPattern);
+        final StreamingOutput responseOutput =
+                output -> matchDao.writeMatchesAndTileSpecs(collectionId, resolvedTiles, output);
+
+        return MatchService.streamResponse(responseOutput);
     }
 
     @Path("v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/clusteredTileBoundsForCollection/{matchCollection}")

--- a/render-ws/src/main/java/org/janelia/render/service/MatchService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/MatchService.java
@@ -784,7 +784,7 @@ public class MatchService {
         return collectionIdList;
     }
 
-    private Response streamResponse(final StreamingOutput responseOutput) {
+    public static Response streamResponse(final StreamingOutput responseOutput) {
 
         Response response = null;
         try {

--- a/render-ws/src/main/java/org/janelia/render/service/RenderDataService.java
+++ b/render-ws/src/main/java/org/janelia/render/service/RenderDataService.java
@@ -52,6 +52,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
 import static org.janelia.alignment.spec.stack.StackMetaData.StackState.LOADING;
+import static org.janelia.render.service.dao.RenderDao.MAX_TILE_SPEC_COUNT_FOR_QUERIES;
 
 /**
  * APIs for accessing tile and transform data stored in the Render service database.
@@ -170,7 +171,7 @@ public class RenderDataService {
         try {
             final StackId stackId = new StackId(owner, project, stack);
             list = renderDao.getZValues(stackId, minZ, maxZ);
-            if (list.size() == 0) {
+            if (list.isEmpty()) {
                 // if no z values were found, make sure stack exists ...
                 getStackMetaData(stackId);
             }
@@ -499,7 +500,7 @@ public class RenderDataService {
             tags = "Section Data APIs",
             value = "Get raw tile and transform specs for section with specified z")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "too many (> 50,000) tiles in section"),
+            @ApiResponse(code = 400, message = "too many (> " + MAX_TILE_SPEC_COUNT_FOR_QUERIES + ") tiles in section"),
             @ApiResponse(code = 404, message = "no tile specs found"),
     })
     public ResolvedTileSpecCollection getResolvedTiles(@PathParam("owner") final String owner,
@@ -528,7 +529,7 @@ public class RenderDataService {
             tags = "Stack Data APIs",
             value = "Get raw tile and transform specs for specified group or bounding box")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "too many (> 50,000) matching tiles found"),
+            @ApiResponse(code = 400, message = "too many (> " + MAX_TILE_SPEC_COUNT_FOR_QUERIES + ") matching tiles found"),
             @ApiResponse(code = 404, message = "no tile specs found"),
     })
     public ResolvedTileSpecCollection getResolvedTiles(@PathParam("owner") final String owner,

--- a/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
@@ -650,12 +650,10 @@ public class MatchDao {
         int pairCount = 0;
         for (final Document query : queryList) {
             try (final MongoCursor<Document> cursor = collection.find(query).projection(EXCLUDE_MONGO_ID_KEY).iterator()) {
-                if (cursor.hasNext()) {
-                    outputStream.write(cursor.next().toJson().getBytes());
-                    pairCount++;
-                }
                 while (cursor.hasNext()) {
-                    outputStream.write(COMMA_WITH_NEW_LINE);
+                    if (pairCount > 0) {
+                        outputStream.write(COMMA_WITH_NEW_LINE);
+                    }
                     outputStream.write(cursor.next().toJson().getBytes());
                     pairCount++;
                 }

--- a/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/MatchDao.java
@@ -201,23 +201,6 @@ public class MatchDao {
         return getMatches(collection, query, excludeMatchDetails);
     }
 
-    public List<CanvasMatches> getMatchesOutsideGroup(final MatchCollectionId collectionId,
-                                                      final String groupId,
-                                                      final boolean excludeMatchDetails)
-            throws IllegalArgumentException, ObjectNotFoundException {
-
-        LOG.debug("getMatchesOutsideGroup: entry, collectionId={}, groupId={}",
-                  collectionId, groupId);
-
-        final MongoCollection<Document> collection = getExistingCollection(collectionId);
-
-        MongoUtil.validateRequiredParameter("groupId", groupId);
-
-        final Document query = getOutsideGroupQuery(groupId);
-
-        return getMatches(collection, query, excludeMatchDetails);
-    }
-
     public List<CanvasMatches> getMatchesBetweenGroups(final MatchCollectionId collectionId,
                                                        final String pGroupId,
                                                        final String qGroupId,
@@ -691,6 +674,8 @@ public class MatchDao {
 
     public static List<Document> buildMatchQueryListForTiles(final ResolvedTileSpecCollection resolvedTileSpecCollection,
                                                              final int maxTilesPerQuery) {
+
+        // TODO: need to include qGroupId and qId to include connected p tiles outside of bounding box
 
         // organize by sectionId since that is needed to ensure queries use index
         final Map<String, Set<String>> sectionIdToTileIds = resolvedTileSpecCollection.buildSectionIdToTileIdsMap();

--- a/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
+++ b/render-ws/src/main/java/org/janelia/render/service/dao/RenderDao.java
@@ -57,6 +57,7 @@ public class RenderDao {
 
     public static final String RENDER_DB_NAME = "render";
     public static final String STACK_META_DATA_COLLECTION_NAME = "admin__stack_meta_data";
+    public static final int MAX_TILE_SPEC_COUNT_FOR_QUERIES = 100000;
 
     public static RenderDao build()
             throws UnknownHostException {
@@ -144,7 +145,7 @@ public class RenderDao {
 
         if (tileIdPattern != null) {
             final List<TileSpec> tileSpecList = renderParameters.getTileSpecs();
-            if (tileSpecList.size() > 0) {
+            if (! tileSpecList.isEmpty()) {
                 Bounds filteredBounds = tileSpecList.get(0).toTileBounds();
                 for (int i = 1; i < tileSpecList.size(); i++) {
                     filteredBounds = filteredBounds.union(tileSpecList.get(i).toTileBounds());
@@ -584,11 +585,11 @@ public class RenderDao {
         final Collection<TransformSpec> transformSpecs = resolvedTileSpecs.getTransformSpecs();
         final Collection<TileSpec> tileSpecs = resolvedTileSpecs.getTileSpecs();
 
-        if (transformSpecs.size() > 0) {
+        if (! transformSpecs.isEmpty()) {
             saveResolvedTransforms(stackId, transformSpecs);
         }
 
-        if (tileSpecs.size() > 0) {
+        if (! tileSpecs.isEmpty()) {
 
             final MongoCollection<Document> tileCollection = getTileCollection(stackId);
 
@@ -1511,7 +1512,7 @@ public class RenderDao {
         }
 
         final Document filterQuery = new Document();
-        if ((zValues != null) && (zValues.size() > 0)) {
+        if ((zValues != null) && (! zValues.isEmpty())) {
             final BasicDBList list = new BasicDBList();
             list.addAll(zValues);
             final Document zFilter = new Document(MongoUtil.OP_IN, list);
@@ -1798,7 +1799,7 @@ public class RenderDao {
             }
         }
 
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             throwExceptionIfStackIsMissing(stackId);
         }
 
@@ -1865,7 +1866,7 @@ public class RenderDao {
                 }
             }
 
-            if (newlyUnresolvedSpecIds.size() > 0) {
+            if (! newlyUnresolvedSpecIds.isEmpty()) {
                 getDataForTransformSpecReferences(transformCollection,
                                                   newlyUnresolvedSpecIds,
                                                   resolvedIdToSpecMap,
@@ -1891,7 +1892,7 @@ public class RenderDao {
             TileSpec tileSpec;
             int count = 0;
             while (cursor.hasNext()) {
-                if (count > 100000) {
+                if (count > MAX_TILE_SPEC_COUNT_FOR_QUERIES) {
                     throw new IllegalArgumentException("query too broad, over " + count + " tiles match " + tileQuery);
                 }
                 document = cursor.next();
@@ -2002,7 +2003,7 @@ public class RenderDao {
 
         final Set<String> unresolvedTransformSpecIds = transformSpec.getUnresolvedIds();
 
-        if (unresolvedTransformSpecIds.size() > 0) {
+        if (! unresolvedTransformSpecIds.isEmpty()) {
             final MongoCollection<Document> transformCollection = getTransformCollection(stackId);
             final List<TransformSpec> transformSpecList = getTransformSpecs(transformCollection,
                                                                             unresolvedTransformSpecIds);
@@ -2141,7 +2142,7 @@ public class RenderDao {
             toCount = toCollection.countDocuments();
 
             // if nothing was filtered, verify that all documents got copied
-            if (filterQuery.keySet().size() == 0) {
+            if (filterQuery.keySet().isEmpty()) {
                 if (toCount != fromCount) {
                     throw new IllegalStateException("only inserted " + toCount + " out of " + fromCount + " documents");
                 }

--- a/render-ws/src/test/java/org/janelia/render/service/dao/MatchDaoWithoutEmbeddedMongoTest.java
+++ b/render-ws/src/test/java/org/janelia/render/service/dao/MatchDaoWithoutEmbeddedMongoTest.java
@@ -35,7 +35,7 @@ public class MatchDaoWithoutEmbeddedMongoTest {
 
         final List<Document> queryList = MatchDao.buildMatchQueryListForTiles(tileSpecs,
                                                                               4);
-        Assert.assertEquals("invalid number of queries", 4, queryList.size());
+        Assert.assertEquals("invalid number of queries", 8, queryList.size());
 
         LOG.info("testBuildMatchQueryListForTiles: queryList is {}", queryList);
     }

--- a/trakem2-scripts/src/main/java/org/janelia/render/trakem2/ExportToRenderUsingBasisStack_Plugin.java
+++ b/trakem2-scripts/src/main/java/org/janelia/render/trakem2/ExportToRenderUsingBasisStack_Plugin.java
@@ -192,7 +192,7 @@ public class ExportToRenderUsingBasisStack_Plugin
 
             final ResolvedTileSpecCollection resolvedTiles = zToTilesMap.get(basisZ);
             final Set<String> tileIdSet = zToTileIdSetMap.get(basisZ);
-            resolvedTiles.removeDifferentTileSpecs(tileIdSet);
+            resolvedTiles.retainTileSpecs(tileIdSet);
 
             Utils.log("exportPatches: updating bounding boxes for z " + basisZ);
             resolvedTiles.recalculateBoundingBoxes();


### PR DESCRIPTION
by adding resolvedTilesWithMatchesFrom API endpoint and integrating it into AffineAlignBlockWorker.  

This is just a first draft that produces equivalent results to the original distributed solve implementation.  Further refinement is expected.  The key optimization achieved was reduction in the number of web service requests for each solve and reduction in the amount of data returned for each request.  For a distributed solve of hess_wafer_53::c000_s095_v01, the total number of service GET requests were reduced from 5959 to 208.  