### PR TITLE
Make intensities uniform again

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang.math.IntRange;
 import org.janelia.alignment.spec.Bounds;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
-import org.janelia.render.client.newsolver.assembly.AssemblyMaps;
+import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.assembly.WeightFunction;
 import org.janelia.render.client.newsolver.blockfactories.BlockFactory;
 import org.janelia.render.client.newsolver.blocksolveparameters.BlockDataSolveParameters;
@@ -55,7 +55,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	//
 	// below are the results that the worker has to fill up
 	//
-	final private AssemblyMaps<R> localData = new AssemblyMaps<>();
+	final private ResultContainer<R> localData = new ResultContainer<>();
 
 	// TODO: specifically collected should go into the Parameter objects? We need to make sure each has it's own instance then
 	// coefficient-tile intensity average for global intensity-correction

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -17,7 +16,6 @@ import org.janelia.render.client.newsolver.assembly.WeightFunction;
 import org.janelia.render.client.newsolver.blockfactories.BlockFactory;
 import org.janelia.render.client.newsolver.blocksolveparameters.BlockDataSolveParameters;
 import org.janelia.render.client.newsolver.solvers.Worker;
-import org.janelia.render.client.solver.SerializableValuePair;
 
 /**
  * Should contain only geometric data, nothing specific to the type of solve
@@ -54,7 +52,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	//
 	// below are the results that the worker has to fill up
 	//
-	final private ResultContainer<R> localData = new ResultContainer<>();
+	final private ResultContainer<R> localResults = new ResultContainer<>();
 
 	// TODO: specifically collected should go into the Parameter objects? We need to make sure each has it's own instance then
 	// coefficient-tile intensity average for global intensity-correction
@@ -75,8 +73,8 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 		this.rtsc = rtsc;
 
 		this.sectionIdToZMap = new HashMap<>();
-		localData.addTileSpecs(rtsc.getTileSpecs());
-		localData.sharedTransformSpecs.addAll(rtsc.getTransformSpecs());
+		localResults.addTileSpecs(rtsc.getTileSpecs());
+		localResults.addSharedTransforms(rtsc.getTransformSpecs());
 
 		// TODO: trautmane
 		final IntRange zRange = fetchRenderDetails( rtsc.getTileSpecs(), sectionIdToZMap );
@@ -112,11 +110,9 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	public BlockFactory blockFactory() { return blockFactory; }
 
 	public ResolvedTileSpecCollection rtsc() { return rtsc; }
-	public HashMap<String, R> idToNewModel() { return localData.idToModel; }
-	public HashMap<String, List<SerializableValuePair<String, Double>>> idToBlockErrorMap() { return localData.idToErrorMap; }
 	public HashMap<String, ArrayList<Double>> idToAverages() { return idToAverages; }
 
-	public ResultContainer<R> getResults() { return localData; }
+	public ResultContainer<R> getResults() { return localResults; }
 
 	public void assignUpdatedId( final int id ) { this.id = id; }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
@@ -40,9 +40,6 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	// contains solve-specific parameters and models
 	final private P solveTypeParameters;
 
-	// used for saving and display
-	final private ResolvedTileSpecCollection rtsc;
-
 	// all z-layers as String map to List that only contains the z-layer as double
 	final protected Map<String, ArrayList<Double>> sectionIdToZMap; 
 
@@ -52,7 +49,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	//
 	// below are the results that the worker has to fill up
 	//
-	final private ResultContainer<R> localResults = new ResultContainer<>();
+	final private ResultContainer<R> localResults;
 
 	// TODO: specifically collected should go into the Parameter objects? We need to make sure each has it's own instance then
 	// coefficient-tile intensity average for global intensity-correction
@@ -64,17 +61,15 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 			final P solveTypeParameters,
 			final int id,
 			final Bounds bounds,
-			final ResolvedTileSpecCollection rtsc )
+			final ResolvedTileSpecCollection rtsc)
 	{
 		this.id = id;
 		this.bounds = bounds;
 		this.blockFactory = blockFactory;
 		this.solveTypeParameters = solveTypeParameters;
-		this.rtsc = rtsc;
 
 		this.sectionIdToZMap = new HashMap<>();
-		localResults.addTileSpecs(rtsc.getTileSpecs());
-		localResults.addSharedTransforms(rtsc.getTransformSpecs());
+		localResults = new ResultContainer<>(rtsc);
 
 		// TODO: trautmane
 		final IntRange zRange = fetchRenderDetails( rtsc.getTileSpecs(), sectionIdToZMap );
@@ -109,7 +104,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	public P solveTypeParameters() { return solveTypeParameters; }
 	public BlockFactory blockFactory() { return blockFactory; }
 
-	public ResolvedTileSpecCollection rtsc() { return rtsc; }
+	public ResolvedTileSpecCollection rtsc() { return localResults.getResolvedTileSpecs(); }
 	public HashMap<String, ArrayList<Double>> idToAverages() { return idToAverages; }
 
 	public ResultContainer<R> getResults() { return localResults; }
@@ -162,7 +157,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, maxZ, minZ, rtsc);
+		return Objects.hash(id, maxZ, minZ, localResults);
 	}
 
 	@Override
@@ -174,7 +169,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 		if (getClass() != obj.getClass())
 			return false;
 		final BlockData<?,?> other = (BlockData<?,?>) obj;
-		return id == other.id && maxZ == other.maxZ && minZ == other.minZ && Objects.equals(rtsc, other.rtsc);
+		return id == other.id && maxZ == other.maxZ && minZ == other.minZ && Objects.equals(localResults, other.localResults);
 	}
 
 	@Override
@@ -183,6 +178,6 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	}
 
 	public int getTileCount() {
-		return rtsc == null ? 0 : rtsc().getTileCount();
+		return localResults == null ? 0 : localResults.getResolvedTileSpecs().getTileCount();
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/BlockData.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +75,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 		this.rtsc = rtsc;
 
 		this.sectionIdToZMap = new HashMap<>();
-		localData.idToTileSpec.putAll(rtsc.getTileIdToSpecMap());
+		localData.addTileSpecs(rtsc.getTileSpecs());
 		localData.sharedTransformSpecs.addAll(rtsc.getTransformSpecs());
 
 		// TODO: trautmane
@@ -117,7 +116,7 @@ public class BlockData<R, P extends BlockDataSolveParameters<?, R, P>> implement
 	public HashMap<String, List<SerializableValuePair<String, Double>>> idToBlockErrorMap() { return localData.idToErrorMap; }
 	public HashMap<String, ArrayList<Double>> idToAverages() { return idToAverages; }
 
-	public HashMap<Integer, HashSet<String>> zToTileId() { return localData.zToTileId; }
+	public ResultContainer<R> getResults() { return localData; }
 
 	public void assignUpdatedId( final int id ) { this.id = id; }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -155,7 +155,7 @@ public class DistributedAffineBlockSolver
 
 		// save the re-aligned part
 		LOG.info( "Saving targetstack=" + cmdLineSetup.targetStack );
-		final List<Double> zToSave = finalTiles.getIdToTileSpec().values().stream()
+		final List<Double> zToSave = finalTiles.getResolvedTileSpecs().getTileSpecs().stream()
 				.map(TileSpec::getZ)
 				.distinct()
 				.sorted()

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -155,7 +155,7 @@ public class DistributedAffineBlockSolver
 
 		// save the re-aligned part
 		LOG.info( "Saving targetstack=" + cmdLineSetup.targetStack );
-		final List<Double> zToSave = finalTiles.idToTileSpec.values().stream()
+		final List<Double> zToSave = finalTiles.getIdToTileSpec().values().stream()
 				.map(TileSpec::getZ)
 				.distinct()
 				.sorted()

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -216,17 +216,13 @@ public class DistributedAffineBlockSolver
 				);
 
 		final Assembler<AffineModel2D, RigidModel2D, AffineModel2D> assembler =
-				new Assembler<>(
-						allItems,
-						blockSolver,
-						fusion,
-						(r) -> {
+				new Assembler<>(blockSolver, fusion, (r) -> {
 							final AffineModel2D a = new AffineModel2D();
 							a.set(r);
 							return a;
 						});
 
-		return assembler.createAssembly();
+		return assembler.createAssembly(allItems);
 	}
 
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -173,7 +173,7 @@ public class DistributedAffineBlockSolver
 		runParams.maxZ = zToSave.get(zToSave.size() - 1);
 		LOG.info("Saving from " + runParams.minZ + " to " + runParams.maxZ);
 
-		SolveTools.saveTargetStackTiles(cmdLineSetup.stack, cmdLineSetup.targetStack.stack, runParams, finalTiles.getIdToModel(), null, zToSave, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
+		SolveTools.saveTargetStackTiles(cmdLineSetup.stack, cmdLineSetup.targetStack.stack, runParams, finalTiles.getModelMap(), null, zToSave, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
 		if (cmdLineSetup.targetStack.completeStack) {
 			LOG.info("Completing targetstack=" + cmdLineSetup.targetStack.stack);
 			SolveTools.completeStack(cmdLineSetup.targetStack.stack, runParams);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -173,7 +173,7 @@ public class DistributedAffineBlockSolver
 		runParams.maxZ = zToSave.get(zToSave.size() - 1);
 		LOG.info("Saving from " + runParams.minZ + " to " + runParams.maxZ);
 
-		SolveTools.saveTargetStackTiles(cmdLineSetup.stack, cmdLineSetup.targetStack.stack, runParams, finalTiles.idToModel, null, zToSave, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
+		SolveTools.saveTargetStackTiles(cmdLineSetup.stack, cmdLineSetup.targetStack.stack, runParams, finalTiles.getIdToModel(), null, zToSave, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
 		if (cmdLineSetup.targetStack.completeStack) {
 			LOG.info("Completing targetstack=" + cmdLineSetup.targetStack.stack);
 			SolveTools.completeStack(cmdLineSetup.targetStack.stack, runParams);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -19,7 +19,7 @@ import org.janelia.alignment.spec.TileSpec;
 import org.janelia.render.client.newsolver.assembly.Assembler;
 import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.assembly.BlockCombiner;
-import org.janelia.render.client.newsolver.assembly.BlockSolver;
+import org.janelia.render.client.newsolver.assembly.GlobalSolver;
 import org.janelia.render.client.newsolver.assembly.matches.SameTileMatchCreatorAffine2D;
 import org.janelia.render.client.newsolver.blockfactories.BlockFactory;
 import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters;
@@ -203,24 +203,20 @@ public class DistributedAffineBlockSolver
 			final AffineBlockSolverSetup cmdLineSetup,
 			final ArrayList<BlockData<AffineModel2D, ?>> allItems) {
 
-		final BlockSolver<AffineModel2D, RigidModel2D, AffineModel2D> blockSolver =
-				new BlockSolver<>(new RigidModel2D(),
-						new SameTileMatchCreatorAffine2D<AffineModel2D>(),
-						cmdLineSetup.distributedSolve);
-
 		final BlockCombiner<AffineModel2D, AffineModel2D, RigidModel2D, AffineModel2D> fusion =
-				new BlockCombiner<>(
-						blockSolver,
-						DistributedAffineBlockSolver::integrateGlobalModel,
-						DistributedAffineBlockSolver::interpolateModels
-				);
+				new BlockCombiner<>(DistributedAffineBlockSolver::integrateGlobalModel,
+									DistributedAffineBlockSolver::interpolateModels);
+
+		final GlobalSolver<RigidModel2D, AffineModel2D> globalSolver =
+				new GlobalSolver<>(new RigidModel2D(),
+								   new SameTileMatchCreatorAffine2D<AffineModel2D>(),
+								   cmdLineSetup.distributedSolve);
 
 		final Assembler<AffineModel2D, RigidModel2D, AffineModel2D> assembler =
-				new Assembler<>(blockSolver, fusion, (r) -> {
+				new Assembler<>(globalSolver, fusion, (r) -> {
 							final AffineModel2D a = new AffineModel2D();
 							a.set(r);
-							return a;
-						});
+							return a;});
 
 		return assembler.createAssembly(allItems);
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -17,7 +17,7 @@ import mpicbg.models.RigidModel2D;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.render.client.newsolver.assembly.Assembler;
-import org.janelia.render.client.newsolver.assembly.AssemblyMaps;
+import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.assembly.BlockCombiner;
 import org.janelia.render.client.newsolver.assembly.BlockSolver;
 import org.janelia.render.client.newsolver.assembly.matches.SameTileMatchCreatorAffine2D;
@@ -151,7 +151,7 @@ public class DistributedAffineBlockSolver
 			throw new IllegalStateException("no blocks were computed, something is wrong");
 		}
 
-		final AssemblyMaps<AffineModel2D> finalTiles = solveAndCombineBlocks(cmdLineSetup, allItems);
+		final ResultContainer<AffineModel2D> finalTiles = solveAndCombineBlocks(cmdLineSetup, allItems);
 
 		// save the re-aligned part
 		LOG.info( "Saving targetstack=" + cmdLineSetup.targetStack );
@@ -199,7 +199,7 @@ public class DistributedAffineBlockSolver
 			return new ArrayList<>(blockDataList);
 	}
 
-	private static AssemblyMaps<AffineModel2D> solveAndCombineBlocks(
+	private static ResultContainer<AffineModel2D> solveAndCombineBlocks(
 			final AffineBlockSolverSetup cmdLineSetup,
 			final ArrayList<BlockData<AffineModel2D, ?>> allItems) {
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -164,7 +164,7 @@ public class DistributedIntensityCorrectionSolver {
 		final RenderDataClient renderDataClient = solverSetup.renderWeb.getDataClient();
 		if (saveResults) {
 			final List<TileSpec> tileSpecs = new ArrayList<>(finalizedItems.getIdToTileSpec().values());
-			final HashMap<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.idToModel;
+			final Map<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.getIdToModel();
 			final Map<String, FilterSpec> idToFilterSpec = convertCoefficientsToFilter(tileSpecs, coefficientTiles, solverSetup.intensityAdjust.numCoefficients);
 			addFilters(finalizedItems.getIdToTileSpec(), idToFilterSpec);
 			final ResolvedTileSpecCollection rtsc = finalizedItems.buildResolvedTileSpecs();
@@ -228,7 +228,7 @@ public class DistributedIntensityCorrectionSolver {
 
 	private static Map<String, FilterSpec> convertCoefficientsToFilter(
 			final List<TileSpec> tiles,
-			final HashMap<String, ArrayList<AffineModel1D>> coefficientTiles,
+			final Map<String, ArrayList<AffineModel1D>> coefficientTiles,
 			final int numCoefficients) {
 
 		final ArrayList<OnTheFlyIntensity> corrected = convertModelsToOtfIntensities(tiles, numCoefficients, coefficientTiles);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -61,7 +61,7 @@ public class DistributedIntensityCorrectionSolver {
 		// TODO: remove testing hack ...
 		if (args.length == 0) {
 			final String[] testArgs = {
-					"--baseDataUrl", "http://em-services-1.int.janelia.org:8080/render-ws/v1",
+					"--baseDataUrl", "http://render-dev.int.janelia.org:8080/render-ws/v1",
 					"--owner", "cellmap",
 					"--project", "jrc_mus_thymus_1",
 					"--stack", "v2_acquire_align",
@@ -146,7 +146,7 @@ public class DistributedIntensityCorrectionSolver {
 									DistributedIntensityCorrectionSolver::interpolateModels);
 
 		final Assembler<ArrayList<AffineModel1D>, TranslationModel1D, ArrayList<AffineModel1D>> assembler =
-				new Assembler<>(allItems, blockSolver, fusion, r -> {
+				new Assembler<>(blockSolver, fusion, r -> {
 					final ArrayList<AffineModel1D> rCopy = new ArrayList<>(r.size());
 					r.forEach(model -> rCopy.add(model.copy()));
 					return rCopy;
@@ -154,7 +154,7 @@ public class DistributedIntensityCorrectionSolver {
 
 		LOG.info("assembleBlocks: exit");
 
-		return assembler.createAssembly();
+		return assembler.createAssembly(allItems);
 	}
 
 	public void saveResultsAsNeeded(final ResultContainer<ArrayList<AffineModel1D>> finalizedItems)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -162,7 +162,7 @@ public class DistributedIntensityCorrectionSolver {
 		if (saveResults) {
 			final ResolvedTileSpecCollection rtsc = finalizedItems.getResolvedTileSpecs();
 			final List<TileSpec> tileSpecs = new ArrayList<>(rtsc.getTileSpecs());
-			final Map<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.getIdToModel();
+			final Map<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.getModelMap();
 			final Map<String, FilterSpec> idToFilterSpec = convertCoefficientsToFilter(tileSpecs, coefficientTiles, solverSetup.intensityAdjust.numCoefficients);
 			addFilters(rtsc, idToFilterSpec);
 			renderDataClient.saveResolvedTiles(rtsc, solverSetup.targetStack.stack, null);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -26,7 +26,7 @@ import org.janelia.render.client.intensityadjust.MinimalTileSpecWrapper;
 import org.janelia.render.client.intensityadjust.virtual.LinearOnTheFlyIntensity;
 import org.janelia.render.client.intensityadjust.virtual.OnTheFlyIntensity;
 import org.janelia.render.client.newsolver.assembly.Assembler;
-import org.janelia.render.client.newsolver.assembly.AssemblyMaps;
+import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.assembly.BlockSolver;
 import org.janelia.render.client.newsolver.assembly.BlockCombiner;
 import org.janelia.render.client.newsolver.assembly.matches.SameTileMatchCreatorAffineIntensity;
@@ -90,7 +90,7 @@ public class DistributedIntensityCorrectionSolver {
 		final ArrayList<BlockData<ArrayList<AffineModel1D>, ?>> allItems =
 				intensitySolver.solveBlocksUsingThreadPool(blockCollection);
 
-		final AssemblyMaps<ArrayList<AffineModel1D>> finalizedItems = intensitySolver.assembleBlocks(allItems);
+		final ResultContainer<ArrayList<AffineModel1D>> finalizedItems = intensitySolver.assembleBlocks(allItems);
 
 		intensitySolver.saveResultsAsNeeded(finalizedItems);
 	}
@@ -130,7 +130,7 @@ public class DistributedIntensityCorrectionSolver {
 		return new ArrayList<>(worker.getBlockDataList());
 	}
 
-	public AssemblyMaps<ArrayList<AffineModel1D>> assembleBlocks(final List<BlockData<ArrayList<AffineModel1D>, ?>> allItems) {
+	public ResultContainer<ArrayList<AffineModel1D>> assembleBlocks(final List<BlockData<ArrayList<AffineModel1D>, ?>> allItems) {
 
 		LOG.info("assembleBlocks: entry, processing {} blocks", allItems.size());
 
@@ -157,7 +157,7 @@ public class DistributedIntensityCorrectionSolver {
 		return assembler.createAssembly();
 	}
 
-	public void saveResultsAsNeeded(final AssemblyMaps<ArrayList<AffineModel1D>> finalizedItems)
+	public void saveResultsAsNeeded(final ResultContainer<ArrayList<AffineModel1D>> finalizedItems)
 			throws IOException {
 		// this adds the filters to the tile specs and pushes the data to the DB
 		final boolean saveResults = (solverSetup.targetStack.stack != null);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -160,11 +160,11 @@ public class DistributedIntensityCorrectionSolver {
 		final boolean saveResults = (solverSetup.targetStack.stack != null);
 		final RenderDataClient renderDataClient = solverSetup.renderWeb.getDataClient();
 		if (saveResults) {
-			final List<TileSpec> tileSpecs = new ArrayList<>(finalizedItems.getIdToTileSpec().values());
+			final ResolvedTileSpecCollection rtsc = finalizedItems.getResolvedTileSpecs();
+			final List<TileSpec> tileSpecs = new ArrayList<>(rtsc.getTileSpecs());
 			final Map<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.getIdToModel();
 			final Map<String, FilterSpec> idToFilterSpec = convertCoefficientsToFilter(tileSpecs, coefficientTiles, solverSetup.intensityAdjust.numCoefficients);
-			addFilters(finalizedItems.getIdToTileSpec(), idToFilterSpec);
-			final ResolvedTileSpecCollection rtsc = finalizedItems.getResolvedTileSpecs();
+			addFilters(rtsc, idToFilterSpec);
 			renderDataClient.saveResolvedTiles(rtsc, solverSetup.targetStack.stack, null);
 			if (solverSetup.targetStack.completeStack)
 				renderDataClient.setStackState(solverSetup.targetStack.stack, StackMetaData.StackState.COMPLETE);
@@ -263,10 +263,10 @@ public class DistributedIntensityCorrectionSolver {
 		return correctedOnTheFly;
 	}
 
-	private static void addFilters(final Map<String, TileSpec> idToTileSpec,
+	private static void addFilters(final ResolvedTileSpecCollection rtsc,
 								   final Map<String, FilterSpec> idToFilterSpec) {
 		idToFilterSpec.forEach((tileId, filterSpec) -> {
-			final TileSpec tileSpec = idToTileSpec.get(tileId);
+			final TileSpec tileSpec = rtsc.getTileSpec(tileId);
 			tileSpec.setFilterSpec(filterSpec);
 			tileSpec.convertSingleChannelSpecToLegacyForm();
 		});

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -72,7 +72,7 @@ public class DistributedIntensityCorrectionSolver {
 					"--completeTargetStack",
 					// for entire stack minZ is 1 and maxZ is 14,503
 					"--zDistance", "0", "--minZ", "1245", "--maxZ", "1246",
-					"--preEquilibrateIntensity"
+					"--equilibrateIntensities"
 			};
 			cmdLineSetup.parse(testArgs);
 		} else {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -163,10 +163,10 @@ public class DistributedIntensityCorrectionSolver {
 		final boolean saveResults = (solverSetup.targetStack.stack != null);
 		final RenderDataClient renderDataClient = solverSetup.renderWeb.getDataClient();
 		if (saveResults) {
-			final List<TileSpec> tileSpecs = new ArrayList<>(finalizedItems.idToTileSpec.values());
+			final List<TileSpec> tileSpecs = new ArrayList<>(finalizedItems.getIdToTileSpec().values());
 			final HashMap<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.idToModel;
 			final Map<String, FilterSpec> idToFilterSpec = convertCoefficientsToFilter(tileSpecs, coefficientTiles, solverSetup.intensityAdjust.numCoefficients);
-			addFilters(finalizedItems.idToTileSpec, idToFilterSpec);
+			addFilters(finalizedItems.getIdToTileSpec(), idToFilterSpec);
 			final ResolvedTileSpecCollection rtsc = finalizedItems.buildResolvedTileSpecs();
 			renderDataClient.saveResolvedTiles(rtsc, solverSetup.targetStack.stack, null);
 			if (solverSetup.targetStack.completeStack)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -61,7 +61,7 @@ public class DistributedIntensityCorrectionSolver {
 		// TODO: remove testing hack ...
 		if (args.length == 0) {
 			final String[] testArgs = {
-					"--baseDataUrl", "http://render-dev.int.janelia.org:8080/render-ws/v1",
+					"--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
 					"--owner", "cellmap",
 					"--project", "jrc_mus_thymus_1",
 					"--stack", "v2_acquire_align",
@@ -167,7 +167,7 @@ public class DistributedIntensityCorrectionSolver {
 			final Map<String, ArrayList<AffineModel1D>> coefficientTiles = finalizedItems.getIdToModel();
 			final Map<String, FilterSpec> idToFilterSpec = convertCoefficientsToFilter(tileSpecs, coefficientTiles, solverSetup.intensityAdjust.numCoefficients);
 			addFilters(finalizedItems.getIdToTileSpec(), idToFilterSpec);
-			final ResolvedTileSpecCollection rtsc = finalizedItems.buildResolvedTileSpecs();
+			final ResolvedTileSpecCollection rtsc = finalizedItems.getResolvedTileSpecs();
 			renderDataClient.saveResolvedTiles(rtsc, solverSetup.targetStack.stack, null);
 			if (solverSetup.targetStack.completeStack)
 				renderDataClient.setStackState(solverSetup.targetStack.stack, StackMetaData.StackState.COMPLETE);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -71,7 +71,8 @@ public class DistributedIntensityCorrectionSolver {
 					"--blockSizeZ", "6",
 					"--completeTargetStack",
 					// for entire stack minZ is 1 and maxZ is 14,503
-					"--zDistance", "0", "--minZ", "1000", "--maxZ", "1001"
+					"--zDistance", "0", "--minZ", "1245", "--maxZ", "1246",
+					"--preEquilibrateIntensity"
 			};
 			cmdLineSetup.parse(testArgs);
 		} else {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -72,7 +72,7 @@ public class DistributedIntensityCorrectionSolver {
 					"--completeTargetStack",
 					// for entire stack minZ is 1 and maxZ is 14,503
 					"--zDistance", "0", "--minZ", "1245", "--maxZ", "1246",
-					"--equilibrateIntensities"
+					"--equilibrationWeight", "0.5"
 			};
 			cmdLineSetup.parse(testArgs);
 		} else {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
@@ -1,17 +1,12 @@
 package org.janelia.render.client.newsolver.assembly;
 
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
-import org.janelia.alignment.spec.TileSpec;
 import org.janelia.render.client.newsolver.BlockData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,21 +24,21 @@ import mpicbg.models.Tile;
  */
 public class Assembler<Z, G extends Model<G>, R>
 {
-	final BlockSolver<Z, G, R> blockSolver;
+	final GlobalSolver<G, R> globalSolver;
 	final BlockCombiner<Z, ?, G, R> blockCombiner;
 	final Function<R, Z> converter;
 
 	/**
-	 * @param blockSolver - solver to use for the final assembly
+	 * @param globalSolver - solver to use for the final assembly
 	 * @param blockCombiner - fusion to use for the final assembly
 	 * @param converter - a converter from R to Z - for the trivial case of a single block
 	 */
 	public Assembler(
-			final BlockSolver<Z, G, R> blockSolver,
+			final GlobalSolver<G, R> globalSolver,
 			final BlockCombiner<Z, ?, G, R> blockCombiner,
 			final Function<R, Z> converter )
 	{
-		this.blockSolver = blockSolver;
+		this.globalSolver = globalSolver;
 		this.blockCombiner = blockCombiner;
 		this.converter = converter;
 	}
@@ -61,7 +56,7 @@ public class Assembler<Z, G extends Model<G>, R>
 		try {
 			// now compute the final alignment for each block
 			final HashMap<BlockData<R, ?>, Tile<G>> blockToTile =
-					blockSolver.globalSolve(blocks);
+					globalSolver.globalSolve(blocks);
 
 			// now fuse blocks into a full assembly
 			blockCombiner.fuseGlobally(results, blockToTile);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
@@ -91,7 +91,7 @@ public class Assembler<Z, G extends Model<G>, R>
 
 		final ResultContainer<Z> globalData = new ResultContainer<>(block.rtsc());
 		for (final String tileId : block.rtsc().getTileIds()) {
-			globalData.recordModel(tileId, converter.apply(block.getResults().getIdToModel().get(tileId)));
+			globalData.recordModel(tileId, converter.apply(block.getResults().getModelFor(tileId)));
 		}
 		return globalData;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/Assembler.java
@@ -45,14 +45,14 @@ public class Assembler<Z, G extends Model<G>, R>
 		this.converter = converter;
 	}
 
-	public AssemblyMaps< Z > createAssembly()
+	public ResultContainer< Z > createAssembly()
 	{
 		// the trivial case of a single block, would crash with the code below
 		if (isTrivialCase()) {
 			return buildTrivialAssembly();
 		}
 
-		final AssemblyMaps<Z> am = new AssemblyMaps<>();
+		final ResultContainer<Z> am = new ResultContainer<>();
 
 		// add shared transforms to assembly so that they can be used later when building resolved tile spec collections
 		blocks.forEach(block -> am.sharedTransformSpecs.addAll(block.rtsc().getTransformSpecs()));
@@ -81,11 +81,11 @@ public class Assembler<Z, G extends Model<G>, R>
 	/**
 	 * @return - the result of the trivial case
 	 */
-	private AssemblyMaps< Z > buildTrivialAssembly()
+	private ResultContainer< Z > buildTrivialAssembly()
 	{
 		LOG.info("buildTrivialAssembly: entry, only a single block, no solve across blocks necessary.");
 
-		final AssemblyMaps< Z > globalData = new AssemblyMaps<>();
+		final ResultContainer< Z > globalData = new ResultContainer<>();
 
 		final BlockData<R, ?> solveItem = blocks.get( 0 );
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
@@ -33,7 +33,7 @@ public class BlockCombiner<Z, I, G extends Model<G>, R> {
 	}
 
 	public void fuseGlobally(
-			final AssemblyMaps<Z> globalData,
+			final ResultContainer<Z> globalData,
 			final HashMap<BlockData<R, ?>, Tile<G>> blockToTile
 	) {
 		final HashMap<BlockData<R, ?>, G> blockToG = new HashMap<>();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
@@ -18,16 +18,13 @@ import java.util.stream.Collectors;
 
 public class BlockCombiner<Z, I, G extends Model<G>, R> {
 
-	final BlockSolver<Z, G, R> solver;
 	final BiFunction<R, G, I> combineResultGlobal;
 	final BiFunction<List<I>, List<Double>, Z> fusion;
 
 	public BlockCombiner(
-			final BlockSolver<Z, G, R> solver,
 			final BiFunction<R, G, I> combineResultGlobal,
 			final BiFunction<List<I>, List<Double>, Z> fusion
 	) {
-		this.solver = solver;
 		this.combineResultGlobal = combineResultGlobal;
 		this.fusion = fusion;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockCombiner.java
@@ -4,7 +4,6 @@ import mpicbg.models.Model;
 import mpicbg.models.Tile;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.render.client.newsolver.BlockData;
-import org.janelia.render.client.solver.SerializableValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,7 @@ public class BlockCombiner<Z, I, G extends Model<G>, R> {
 
 		final Map<String, List<BlockData<R, ?>>> tileIdToBlocks = new HashMap<>();
 		for (final BlockData<R, ?> block : blockToTile.keySet()) {
-			for (final String tileId : block.getResults().getIdToModel().keySet()) {
+			for (final String tileId : block.getResults().getTileIds()) {
 				tileIdToBlocks.computeIfAbsent(tileId, k -> new ArrayList<>()).add(block);
 			}
 		}
@@ -61,11 +60,11 @@ public class BlockCombiner<Z, I, G extends Model<G>, R> {
 
 			final List<I> models = new ArrayList<>();
 			final List<Double> weights = new ArrayList<>();
-			List<SerializableValuePair<String, Double>> error = null;
+			Map<String, Double> error = null;
 			double maxWeight = -1.0;
 			for (final BlockData<R, ?> block : blocksForTile) {
 				final G globalModel = blockToG.get(block);
-				final R newModel = block.getResults().getIdToModel().get(tileId);
+				final R newModel = block.getResults().getModelFor(tileId);
 				// TODO: confirm this is proper way to handle, consider moving retrieval to block method and put check there
 				if (newModel == null) {
 					throw new IllegalArgumentException("failed to find new model for tile " + tileId);
@@ -80,7 +79,7 @@ public class BlockCombiner<Z, I, G extends Model<G>, R> {
 				// TODO: proper error computation using the matches that are now stored in the SolveItemData object
 				if (w > maxWeight) {
 					maxWeight = w;
-					error = block.getResults().getIdToErrorMap().get(tileId);
+					error = block.getResults().getErrorMapFor(tileId);
 				}
 			}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
@@ -51,14 +51,12 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 	}
 
 	public HashMap<BlockData<R, ?>, Tile<G>> globalSolve(
-			final List<? extends BlockData<R, ?>> blocks,
-			final ResultContainer<Z> globalResults
+			final List<? extends BlockData<R, ?>> blocks
 	) throws NotEnoughDataPointsException, IllDefinedDataPointsException, InterruptedException, ExecutionException {
 
 		final HashMap<BlockData<R, ?>, Tile<G>> blockToTile = new HashMap<>();
 		for (final BlockData<R, ?> block : blocks) {
 			blockToTile.put(block, new Tile<>(globalModel.copy()));
-			globalResults.addTileSpecs(block.rtsc().getTileSpecs());
 		}
 
 		LOG.info("globalSolve: solving {} items", blocks.size());

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
@@ -81,8 +81,8 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 				for (final String tileId : commonTileIds) {
 					final TileSpec tileSpecAB = tileSpecs.getTileSpec(tileId);
 
-					final R modelA = solveItemA.idToNewModel().get(tileId);
-					final R modelB = solveItemB.idToNewModel().get(tileId);
+					final R modelA = solveItemA.getResults().getIdToModel().get(tileId);
+					final R modelB = solveItemB.getResults().getIdToModel().get(tileId);
 					if (modelA == null)  {
 						throw new IllegalArgumentException("model A is missing for tile " + tileId);
 					} else if (modelB == null)  {
@@ -125,8 +125,8 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 			final BlockData<?, ?> blockA,
 			final BlockData<?, ?> blockB
 	) {
-		final Set<String> tileIdsA = new HashSet<>(blockA.idToNewModel().keySet());
-		final Set<String> tileIdsB = blockB.idToNewModel().keySet();
+		final Set<String> tileIdsA = new HashSet<>(blockA.getResults().getIdToModel().keySet());
+		final Set<String> tileIdsB = blockB.getResults().getIdToModel().keySet();
 		tileIdsA.retainAll(tileIdsB);
 		return tileIdsA;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
@@ -52,20 +52,13 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 
 	public HashMap<BlockData<R, ?>, Tile<G>> globalSolve(
 			final List<? extends BlockData<R, ?>> blocks,
-			final ResultContainer<Z> am
+			final ResultContainer<Z> globalResults
 	) throws NotEnoughDataPointsException, IllDefinedDataPointsException, InterruptedException, ExecutionException {
 
 		final HashMap<BlockData<R, ?>, Tile<G>> blockToTile = new HashMap<>();
 		for (final BlockData<R, ?> block : blocks) {
 			blockToTile.put(block, new Tile<>(globalModel.copy()));
-
-			final ResolvedTileSpecCollection tileSpecs = block.rtsc();
-			for (final String tileId : tileSpecs.getTileIds()) {
-				final TileSpec tileSpec = tileSpecs.getTileSpec(tileId);
-				final Integer z = tileSpec.getZ().intValue();
-				am.idToTileSpec.put(tileId, tileSpec);
-				am.zToTileId.computeIfAbsent(z, k -> new HashSet<>()).add(tileId);
-			}
+			globalResults.addTileSpecs(block.rtsc().getTileSpecs());
 		}
 
 		LOG.info("globalSolve: solving {} items", blocks.size());
@@ -87,7 +80,6 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 
 				for (final String tileId : commonTileIds) {
 					final TileSpec tileSpecAB = tileSpecs.getTileSpec(tileId);
-					am.idToTileSpec.put(tileId, tileSpecAB);
 
 					final R modelA = solveItemA.idToNewModel().get(tileId);
 					final R modelB = solveItemB.idToNewModel().get(tileId);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/BlockSolver.java
@@ -52,7 +52,7 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 
 	public HashMap<BlockData<R, ?>, Tile<G>> globalSolve(
 			final List<? extends BlockData<R, ?>> blocks,
-			final AssemblyMaps<Z> am
+			final ResultContainer<Z> am
 	) throws NotEnoughDataPointsException, IllDefinedDataPointsException, InterruptedException, ExecutionException {
 
 		final HashMap<BlockData<R, ?>, Tile<G>> blockToTile = new HashMap<>();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-public class BlockSolver<Z, G extends Model<G>, R> {
+public class GlobalSolver<G extends Model<G>, R> {
 
 	final private G globalModel;
 	final private SameTileMatchCreator<R> sameTileMatchCreator;
@@ -33,7 +33,7 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 	final private int maxIterations;
 	final private int numThreads;
 
-	public BlockSolver(
+	public GlobalSolver(
 			final G globalModel,
 			final SameTileMatchCreator<R> sameTileMatchCreator,
 			final DistributedSolveParameters parameters
@@ -129,5 +129,5 @@ public class BlockSolver<Z, G extends Model<G>, R> {
 		return tileIdsA;
 	}
 
-	private static final Logger LOG = LoggerFactory.getLogger(BlockSolver.class);
+	private static final Logger LOG = LoggerFactory.getLogger(GlobalSolver.class);
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
@@ -79,8 +79,8 @@ public class GlobalSolver<G extends Model<G>, R> {
 				for (final String tileId : commonTileIds) {
 					final TileSpec tileSpecAB = tileSpecs.getTileSpec(tileId);
 
-					final R modelA = solveItemA.getResults().getIdToModel().get(tileId);
-					final R modelB = solveItemB.getResults().getIdToModel().get(tileId);
+					final R modelA = solveItemA.getResults().getModelFor(tileId);
+					final R modelB = solveItemB.getResults().getModelFor(tileId);
 					if (modelA == null)  {
 						throw new IllegalArgumentException("model A is missing for tile " + tileId);
 					} else if (modelB == null)  {
@@ -123,8 +123,8 @@ public class GlobalSolver<G extends Model<G>, R> {
 			final BlockData<?, ?> blockA,
 			final BlockData<?, ?> blockB
 	) {
-		final Set<String> tileIdsA = new HashSet<>(blockA.getResults().getIdToModel().keySet());
-		final Set<String> tileIdsB = blockB.getResults().getIdToModel().keySet();
+		final Set<String> tileIdsA = new HashSet<>(blockA.getResults().getTileIds());
+		final Set<String> tileIdsB = blockB.getResults().getTileIds();
 		tileIdsA.retainAll(tileIdsB);
 		return tileIdsA;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -1,21 +1,20 @@
 package org.janelia.render.client.newsolver.assembly;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
-import org.janelia.render.client.solver.SerializableValuePair;
 
 public class ResultContainer<M> implements Serializable {
 
-	final private HashMap<String, M> idToModel = new HashMap<>();
-	final private HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
-	final private HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
+	final private Map<String, M> idToModel = new HashMap<>();
+	final private Map<Integer, Set<String>> zToTileId = new HashMap<>();
+	final private Map<String, Map<String, Double>> idToErrorMap = new HashMap<>();
 	final private ResolvedTileSpecCollection rtsc;
 
 
@@ -28,37 +27,50 @@ public class ResultContainer<M> implements Serializable {
 		}
 	}
 
-	public void recordAllErrors(final String tileId, final List<SerializableValuePair<String, Double>> errorMap) {
+	public void recordAllErrors(final String tileId, final Map<String, Double> errorMap) {
 		idToErrorMap.put(tileId, errorMap);
 	}
 
 	public void recordPairwiseTileError(final String pTileId, final String qTileId, final double error) {
-		idToErrorMap.computeIfAbsent(pTileId, k -> new ArrayList<>())
-				.add(new SerializableValuePair<>(qTileId, error));
-		idToErrorMap.computeIfAbsent(qTileId, k -> new ArrayList<>())
-				.add(new SerializableValuePair<>(pTileId, error));
+		idToErrorMap.computeIfAbsent(pTileId, k -> new HashMap<>())
+				.put(qTileId, error);
+		idToErrorMap.computeIfAbsent(qTileId, k -> new HashMap<>())
+				.put(pTileId, error);
 	}
 
 	public void recordModel(final String tileId, final M model) {
 		idToModel.put(tileId, model);
 	}
 
-	public Map<Integer, HashSet<String>> getZLayerTileIds() {
-		return zToTileId;
+	public Set<String> getTileIds() {
+		return rtsc.getTileIds();
 	}
 
-	public Map<String, M> getIdToModel() {
+	public Set<String> getTileIdsForZLayer(final int z) {
+		return zToTileId.get(z);
+	}
+
+	public Collection<Integer> getZLayers() {
+		return zToTileId.keySet();
+	}
+
+	public M getModelFor(final String tileId) {
+		return idToModel.get(tileId);
+	}
+
+	public Map<String,M> getModelMap() {
 		return idToModel;
 	}
 
-	public Map<String, List<SerializableValuePair<String, Double>>> getIdToErrorMap() {
-		return idToErrorMap;
+	public Map<String, Double> getErrorMapFor(final String tileId) {
+		return idToErrorMap.get(tileId);
 	}
 
 	/**
-	 * @return collection held by this results container.
+	 * @return collection held by this result-container.
 	 */
 	public ResolvedTileSpecCollection getResolvedTileSpecs() {
 		return rtsc;
 	}
+
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -1,6 +1,7 @@
 package org.janelia.render.client.newsolver.assembly;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -15,11 +16,11 @@ import org.janelia.render.client.solver.SerializableValuePair;
 
 public class ResultContainer<M> implements Serializable {
 
-	final public HashMap<String, M> idToModel = new HashMap<>();
+	final private HashMap<String, M> idToModel = new HashMap<>();
 	final private HashMap<String, TileSpec> idToTileSpec = new HashMap<>();
 	final private HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
-	final public HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
-	final public Set<TransformSpec> sharedTransformSpecs = new HashSet<>();
+	final private HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
+	final private Set<TransformSpec> sharedTransformSpecs = new HashSet<>();
 
 	public void addTileSpecs(final Collection<TileSpec> tileSpecs) {
 		for (final TileSpec tileSpec : tileSpecs) {
@@ -30,12 +31,43 @@ public class ResultContainer<M> implements Serializable {
 		}
 	}
 
+	public void recordAllErrors(final String tileId, final List<SerializableValuePair<String, Double>> errorMap) {
+		idToErrorMap.put(tileId, errorMap);
+	}
+
+	public void recordPairwiseTileError(final String pTileId, final String qTileId, final double error) {
+		idToErrorMap.computeIfAbsent(pTileId, k -> new ArrayList<>())
+				.add(new SerializableValuePair<>(qTileId, error));
+		idToErrorMap.computeIfAbsent(qTileId, k -> new ArrayList<>())
+				.add(new SerializableValuePair<>(pTileId, error));
+	}
+
+	public void recordModel(final String tileId, final M model) {
+		idToModel.put(tileId, model);
+	}
+
+	public void addSharedTransforms(final Collection<TransformSpec> transformSpecs) {
+		sharedTransformSpecs.addAll(transformSpecs);
+	}
+
 	public Map<String, TileSpec> getIdToTileSpec() {
 		return idToTileSpec;
 	}
 
 	public Map<Integer, HashSet<String>> getZLayerTileIds() {
 		return zToTileId;
+	}
+
+	public Map<String, M> getIdToModel() {
+		return idToModel;
+	}
+
+	public Map<String, List<SerializableValuePair<String, Double>>> getIdToErrorMap() {
+		return idToErrorMap;
+	}
+
+	public Set<TransformSpec> getSharedTransformSpecs() {
+		return sharedTransformSpecs;
 	}
 
 	/**

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -17,16 +17,17 @@ import org.janelia.render.client.solver.SerializableValuePair;
 public class ResultContainer<M> implements Serializable {
 
 	final private HashMap<String, M> idToModel = new HashMap<>();
-	final private HashMap<String, TileSpec> idToTileSpec = new HashMap<>();
 	final private HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
 	final private HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
 	final private Set<TransformSpec> sharedTransformSpecs = new HashSet<>();
+	final private ResolvedTileSpecCollection rtsc;
 
-	public void addTileSpecs(final Collection<TileSpec> tileSpecs) {
-		for (final TileSpec tileSpec : tileSpecs) {
+
+	public ResultContainer(final ResolvedTileSpecCollection rtsc) {
+		this.rtsc = rtsc;
+		for (final TileSpec tileSpec : rtsc.getTileSpecs()) {
 			final String tileId = tileSpec.getTileId();
 			final Integer z = tileSpec.getZ().intValue();
-			idToTileSpec.put(tileId, tileSpec);
 			zToTileId.computeIfAbsent(z, k -> new HashSet<>()).add(tileId);
 		}
 	}
@@ -51,7 +52,7 @@ public class ResultContainer<M> implements Serializable {
 	}
 
 	public Map<String, TileSpec> getIdToTileSpec() {
-		return idToTileSpec;
+		return rtsc.getTileIdToSpecMap();
 	}
 
 	public Map<Integer, HashSet<String>> getZLayerTileIds() {
@@ -71,18 +72,9 @@ public class ResultContainer<M> implements Serializable {
 	}
 
 	/**
-	 * @return collection built from this assembly's shared transforms and tile specs.
+	 * @return collection held by this results container.
 	 */
-	public ResolvedTileSpecCollection buildResolvedTileSpecs() {
-		return buildResolvedTileSpecs(idToTileSpec.values());
-	}
-
-	/**
-	 * @return collection built from this assembly's shared transforms and the specified tile specs.
-	 */
-	public ResolvedTileSpecCollection buildResolvedTileSpecs(final Collection<TileSpec> tileSpecs) {
-		final ResolvedTileSpecCollection rtsc = new ResolvedTileSpecCollection(sharedTransformSpecs, tileSpecs);
-		rtsc.removeUnreferencedTransforms();
+	public ResolvedTileSpecCollection getResolvedTileSpecs() {
 		return rtsc;
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -12,8 +12,8 @@ import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.spec.TransformSpec;
 import org.janelia.render.client.solver.SerializableValuePair;
 
-public class AssemblyMaps< M > implements Serializable
-{
+public class ResultContainer<M> implements Serializable {
+
 	final public HashMap<String, M> idToModel = new HashMap<>();
 	final public HashMap<String, TileSpec> idToTileSpec = new HashMap<>();
 	final public HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
@@ -31,8 +31,7 @@ public class AssemblyMaps< M > implements Serializable
 	 * @return collection built from this assembly's shared transforms and the specified tile specs.
 	 */
 	public ResolvedTileSpecCollection buildResolvedTileSpecs(final Collection<TileSpec> tileSpecs) {
-		final ResolvedTileSpecCollection rtsc = new ResolvedTileSpecCollection(sharedTransformSpecs,
-																			   tileSpecs);
+		final ResolvedTileSpecCollection rtsc = new ResolvedTileSpecCollection(sharedTransformSpecs, tileSpecs);
 		rtsc.removeUnreferencedTransforms();
 		return rtsc;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
@@ -15,10 +16,27 @@ import org.janelia.render.client.solver.SerializableValuePair;
 public class ResultContainer<M> implements Serializable {
 
 	final public HashMap<String, M> idToModel = new HashMap<>();
-	final public HashMap<String, TileSpec> idToTileSpec = new HashMap<>();
-	final public HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
+	final private HashMap<String, TileSpec> idToTileSpec = new HashMap<>();
+	final private HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
 	final public HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
 	final public Set<TransformSpec> sharedTransformSpecs = new HashSet<>();
+
+	public void addTileSpecs(final Collection<TileSpec> tileSpecs) {
+		for (final TileSpec tileSpec : tileSpecs) {
+			final String tileId = tileSpec.getTileId();
+			final Integer z = tileSpec.getZ().intValue();
+			idToTileSpec.put(tileId, tileSpec);
+			zToTileId.computeIfAbsent(z, k -> new HashSet<>()).add(tileId);
+		}
+	}
+
+	public Map<String, TileSpec> getIdToTileSpec() {
+		return idToTileSpec;
+	}
+
+	public Map<Integer, HashSet<String>> getZLayerTileIds() {
+		return zToTileId;
+	}
 
 	/**
 	 * @return collection built from this assembly's shared transforms and tile specs.

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/ResultContainer.java
@@ -2,16 +2,13 @@ package org.janelia.render.client.newsolver.assembly;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
-import org.janelia.alignment.spec.TransformSpec;
 import org.janelia.render.client.solver.SerializableValuePair;
 
 public class ResultContainer<M> implements Serializable {
@@ -19,7 +16,6 @@ public class ResultContainer<M> implements Serializable {
 	final private HashMap<String, M> idToModel = new HashMap<>();
 	final private HashMap<Integer, HashSet<String>> zToTileId = new HashMap<>();
 	final private HashMap<String, List<SerializableValuePair<String, Double>>> idToErrorMap = new HashMap<>();
-	final private Set<TransformSpec> sharedTransformSpecs = new HashSet<>();
 	final private ResolvedTileSpecCollection rtsc;
 
 
@@ -47,14 +43,6 @@ public class ResultContainer<M> implements Serializable {
 		idToModel.put(tileId, model);
 	}
 
-	public void addSharedTransforms(final Collection<TransformSpec> transformSpecs) {
-		sharedTransformSpecs.addAll(transformSpecs);
-	}
-
-	public Map<String, TileSpec> getIdToTileSpec() {
-		return rtsc.getTileIdToSpecMap();
-	}
-
 	public Map<Integer, HashSet<String>> getZLayerTileIds() {
 		return zToTileId;
 	}
@@ -65,10 +53,6 @@ public class ResultContainer<M> implements Serializable {
 
 	public Map<String, List<SerializableValuePair<String, Double>>> getIdToErrorMap() {
 		return idToErrorMap;
-	}
-
-	public Set<TransformSpec> getSharedTransformSpecs() {
-		return sharedTransformSpecs;
 	}
 
 	/**

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
@@ -104,14 +104,14 @@ public class XYBlockFactory extends BlockFactory implements Serializable {
 		private final double minY;
 
 		public XYDistanceWeightFunction(final BlockData<?, ?> block, final double resolution) {
-			layerDistanceMaps = new HashMap<>(block.zToTileId().size());
+			layerDistanceMaps = new HashMap<>(block.getResults().getZLayerTileIds().size());
 			this.resolution = resolution;
 
 			final Bounds stackBounds = block.boundingBox();
 			minX = stackBounds.getMinX();
 			minY = stackBounds.getMinY();
 
-			block.zToTileId().forEach((z, layerIds) -> {
+			block.getResults().getZLayerTileIds().forEach((z, layerIds) -> {
 				final List<TileSpec> layerTiles = layerIds.stream()
 						// .sorted() // to be consistent with the render order of the web service
 						.map(block.rtsc()::getTileSpec)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
@@ -21,6 +21,7 @@ import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.BlockCollection;
 import org.janelia.render.client.newsolver.BlockData;
+import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.assembly.WeightFunction;
 import org.janelia.render.client.newsolver.blocksolveparameters.BlockDataSolveParameters;
 
@@ -104,17 +105,18 @@ public class XYBlockFactory extends BlockFactory implements Serializable {
 		private final double minY;
 
 		public XYDistanceWeightFunction(final BlockData<?, ?> block, final double resolution) {
-			layerDistanceMaps = new HashMap<>(block.getResults().getZLayerTileIds().size());
+			final ResultContainer<?> results = block.getResults();
+			layerDistanceMaps = new HashMap<>(results.getZLayers().size());
 			this.resolution = resolution;
 
 			final Bounds stackBounds = block.boundingBox();
 			minX = stackBounds.getMinX();
 			minY = stackBounds.getMinY();
 
-			block.getResults().getZLayerTileIds().forEach((z, layerIds) -> {
-				final List<TileSpec> layerTiles = layerIds.stream()
+			results.getZLayers().forEach(z -> {
+				final List<TileSpec> layerTiles = results.getTileIdsForZLayer(z).stream()
 						// .sorted() // to be consistent with the render order of the web service
-						.map(block.rtsc()::getTileSpec)
+						.map(results.getResolvedTileSpecs()::getTileSpec)
 						.collect(Collectors.toList());
 				layerDistanceMaps.put(z, createLayerDistanceMap(layerTiles, resolution, stackBounds));
 			});

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/BlockDataSolveParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/BlockDataSolveParameters.java
@@ -85,7 +85,7 @@ public abstract class BlockDataSolveParameters< M, R, P extends BlockDataSolvePa
 		final double[] c = new double[3];
 		int count = 0;
 
-		for (final String tileId : blockData.getResults().getIdToModel().keySet()) {
+		for (final String tileId : blockData.getResults().getTileIds()) {
 			final TileSpec ts = blockData.rtsc().getTileSpec(tileId);
 
 			// the affine transform for the tile

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/BlockDataSolveParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/BlockDataSolveParameters.java
@@ -82,12 +82,11 @@ public abstract class BlockDataSolveParameters< M, R, P extends BlockDataSolvePa
 	public double[] centerOfMass(final BlockData<R, P> blockData)
 	{
 
-		final double[] c = new double[ 3 ];
+		final double[] c = new double[3];
 		int count = 0;
 
-		for ( final String tileId : blockData.idToNewModel().keySet() )
-		{
-			final TileSpec ts = blockData.rtsc().getTileSpec( tileId );
+		for (final String tileId : blockData.getResults().getIdToModel().keySet()) {
+			final TileSpec ts = blockData.rtsc().getTileSpec(tileId);
 
 			// the affine transform for the tile
 			final Rectangle r = ts.toTileBounds().toRectangle();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
@@ -2,7 +2,6 @@ package org.janelia.render.client.newsolver.blocksolveparameters;
 
 import java.awt.Rectangle;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 import org.janelia.alignment.spec.TileSpec;
@@ -120,17 +119,15 @@ public class FIBSEMAlignmentParameters< M extends Model< M > & Affine2D< M >, S 
 	@Override
 	public double[] centerOfMass(final BlockData<AffineModel2D, FIBSEMAlignmentParameters<M, S>> blockData)
 	{
-		if (blockData.getResults().getIdToModel() == null || blockData.getResults().getIdToModel().isEmpty())
+		if (blockData.getResults().getModelMap() == null || blockData.getResults().getModelMap().isEmpty())
 			return super.centerOfMass(blockData);
 
 		// check that all TileSpecs are part of the idToNewModel map
 		for (final TileSpec ts : blockData.rtsc().getTileSpecs())
-			if (!blockData.getResults().getIdToModel().containsKey(ts.getTileId())) {
+			if (!blockData.getResults().getModelMap().containsKey(ts.getTileId())) {
 				LOG.info("WARNING: a TileSpec is not part of the idToNewModel() - that should not happen.");
 				return super.centerOfMass(blockData);
 			}
-
-		final Map<String, AffineModel2D> models = blockData.getResults().getIdToModel();
 
 		final double[] c = new double[ 3 ];
 		int count = 0;
@@ -140,7 +137,7 @@ public class FIBSEMAlignmentParameters< M extends Model< M > & Affine2D< M >, S 
 			final Rectangle r = ts.toTileBounds().toRectangle();
 			final double[] coord = new double[] { r.getCenterX(), r.getCenterY() };
 
-			final AffineModel2D model = models.get(ts.getTileId());
+			final AffineModel2D model = blockData.getResults().getModelFor(ts.getTileId());
 			model.applyInPlace(coord);
 
 			c[0] += coord[0];

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
@@ -1,8 +1,8 @@
 package org.janelia.render.client.newsolver.blocksolveparameters;
 
-import java.awt.*;
-import java.util.HashMap;
+import java.awt.Rectangle;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.janelia.alignment.spec.TileSpec;
@@ -120,18 +120,17 @@ public class FIBSEMAlignmentParameters< M extends Model< M > & Affine2D< M >, S 
 	@Override
 	public double[] centerOfMass(final BlockData<AffineModel2D, FIBSEMAlignmentParameters<M, S>> blockData)
 	{
-		if (blockData.idToNewModel() == null || blockData.idToNewModel().isEmpty())
-			return super.centerOfMass( blockData );
+		if (blockData.getResults().getIdToModel() == null || blockData.getResults().getIdToModel().isEmpty())
+			return super.centerOfMass(blockData);
 
 		// check that all TileSpecs are part of the idToNewModel map
-		for ( final TileSpec ts : blockData.rtsc().getTileSpecs() )
-			if ( !blockData.idToNewModel().containsKey( ts.getTileId() ) )
-			{
-				LOG.info( "WARNING: a TileSpec is not part of the idToNewModel() - that should not happen." );
-				return super.centerOfMass( blockData );
+		for (final TileSpec ts : blockData.rtsc().getTileSpecs())
+			if (!blockData.getResults().getIdToModel().containsKey(ts.getTileId())) {
+				LOG.info("WARNING: a TileSpec is not part of the idToNewModel() - that should not happen.");
+				return super.centerOfMass(blockData);
 			}
 
-		final HashMap<String, AffineModel2D> models = blockData.idToNewModel();
+		final Map<String, AffineModel2D> models = blockData.getResults().getIdToModel();
 
 		final double[] c = new double[ 3 ];
 		int count = 0;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -27,7 +27,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final double renderScale;
 	private final int numCoefficients;
 	private final ZDistanceParameters zDistance;
-	private final boolean preEquilibrateIntensity;
+	private final double equilibrationWeight;
 
 	public FIBSEMIntensityCorrectionParameters(
 			final M blockSolveModel,
@@ -45,7 +45,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.renderScale,
 			 intensityAdjust.numCoefficients,
 			 intensityAdjust.zDistance,
-			 intensityAdjust.preEquilibrateIntensity);
+			 intensityAdjust.equilibrationWeight);
 	}
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -60,7 +60,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final double renderScale,
 			final int numCoefficients,
 			final ZDistanceParameters zDistance,
-			final boolean preEquilibrateIntensity) {
+			final double equilibrationWeight) {
 		// TODO: properly copy blockSolveModel
 		super(baseDataUrl, owner, project, stack, blockSolveModel);
 
@@ -70,7 +70,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.renderScale = renderScale;
 		this.numCoefficients = numCoefficients;
 		this.zDistance = zDistance;
-		this.preEquilibrateIntensity = preEquilibrateIntensity;
+		this.equilibrationWeight = equilibrationWeight;
 	}
 
 	public long maxNumberOfCachedPixels() { return maxNumberOfCachedPixels; }
@@ -79,7 +79,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public double renderScale() { return renderScale; }
 	public int numCoefficients() { return numCoefficients; }
 	public ZDistanceParameters zDistance() { return zDistance; }
-	public boolean equilibrateIntensities() { return preEquilibrateIntensity; }
+	public double equilibrationWeight() { return equilibrationWeight; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -27,6 +27,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final double renderScale;
 	private final int numCoefficients;
 	private final ZDistanceParameters zDistance;
+	private final boolean preEquilibrateIntensity;
 
 	public FIBSEMIntensityCorrectionParameters(
 			final M blockSolveModel,
@@ -43,7 +44,8 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.lambda2,
 			 intensityAdjust.renderScale,
 			 intensityAdjust.numCoefficients,
-			 intensityAdjust.zDistance);
+			 intensityAdjust.zDistance,
+			 intensityAdjust.preEquilibrateIntensity);
 	}
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -57,7 +59,8 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final double lambdaIdentity,
 			final double renderScale,
 			final int numCoefficients,
-			final ZDistanceParameters zDistance) {
+			final ZDistanceParameters zDistance,
+			final boolean preEquilibrateIntensity) {
 		// TODO: properly copy blockSolveModel
 		super(baseDataUrl, owner, project, stack, blockSolveModel);
 
@@ -67,6 +70,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.renderScale = renderScale;
 		this.numCoefficients = numCoefficients;
 		this.zDistance = zDistance;
+		this.preEquilibrateIntensity = preEquilibrateIntensity;
 	}
 
 	public long maxNumberOfCachedPixels() { return maxNumberOfCachedPixels; }
@@ -75,6 +79,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public double renderScale() { return renderScale; }
 	public int numCoefficients() { return numCoefficients; }
 	public ZDistanceParameters zDistance() { return zDistance; }
+	public boolean preEquilibrateIntensity() { return preEquilibrateIntensity; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -79,7 +79,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public double renderScale() { return renderScale; }
 	public int numCoefficients() { return numCoefficients; }
 	public ZDistanceParameters zDistance() { return zDistance; }
-	public boolean preEquilibrateIntensity() { return preEquilibrateIntensity; }
+	public boolean equilibrateIntensities() { return preEquilibrateIntensity; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -522,7 +522,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 
 		// combine tiles per layer that are be stitched first, but iterate over all z's 
 		// (also those only consisting of single tiles, they are connected in z though)
-		final ArrayList<Integer> zList = new ArrayList<>(blockData.getResults().getZLayerTileIds().keySet());
+		final ArrayList<Integer> zList = new ArrayList<>(blockData.getResults().getZLayers());
 		Collections.sort( zList );
 
 		for ( final int z : zList )
@@ -588,7 +588,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			}
 
 			// add all missing TileIds as unconnected Tiles
-			for (final String tileId : blockData.getResults().getZLayerTileIds().get(z))
+			for (final String tileId : blockData.getResults().getTileIdsForZLayer(z))
 				if ( !idTotile.containsKey( tileId ) )
 				{
 					LOG.info("stitchSectionsAndCreateGroupedTiles: block {}, unconnected tileId {}", blockData, tileId);
@@ -780,7 +780,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 						solveItem.idToTileMap().put( tileId, t );
 						solveItem.tileToIdMap().put( t, tileId );
 						solveItem.idToPreviousModel().put( tileId, inputSolveItem.idToPreviousModel().get( tileId ) );
-						newBlockData.getResults().recordModel(tileId, blockData.getResults().getIdToModel().get(tileId));
+						newBlockData.getResults().recordModel(tileId, blockData.getResults().getModelFor(tileId));
 
 						solveItem.idToStitchingModel().put(tileId, inputSolveItem.idToStitchingModel().get(tileId));
 
@@ -856,10 +856,6 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			final DoubleSummaryStatistics errors = SolveTools.computeErrors(tileConfig.getTiles());
 			LOG.info("solve: errors: {}", errors);
 		}
-
-		// create lookup for the new models
-		// TODO: this seems strange, investigate!
-		blockData.getResults().getIdToModel().clear();
 
 		final ArrayList<String> tileIds = new ArrayList<>();
 		final HashMap<String, AffineModel2D> tileIdToGroupModel = new HashMap<>();
@@ -950,8 +946,8 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 					blockData.solveTypeParameters().stitchingSolveModelInstance(pTileSpec.getZ().intValue()),
 					pTileSpec,
 					qTileSpec,
-					results.getIdToModel().get(pTileId),
-					results.getIdToModel().get(qTileId),
+					results.getModelFor(pTileId),
+					results.getModelFor(qTileId),
 					match.getMatches());
 
 			results.recordPairwiseTileError(pTileId, qTileId, vDiff);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/AffineAlignBlockWorker.java
@@ -98,27 +98,25 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 	{
 		super( startId, blockData, numThreads );
 
-		this.matchDataClient =
-				new RenderDataClient(
-						blockData.solveTypeParameters().baseDataUrl(),
-						blockData.solveTypeParameters().matchOwner(),
-						blockData.solveTypeParameters().matchCollection() );
+		final FIBSEMAlignmentParameters<M, S> parameters = blockData.solveTypeParameters();
+		this.matchDataClient = new RenderDataClient(parameters.baseDataUrl(),
+													parameters.matchOwner(),
+													parameters.matchCollection());
 
 		this.inputSolveItem = new AffineBlockDataWrapper<>( blockData );
 
-		if ( blockData.solveTypeParameters().maxNumMatches() <= 0 )
+		if (parameters.maxNumMatches() <= 0)
 			this.matchFilter = new NoMatchFilter();
 		else
-			this.matchFilter = new RandomMaxAmountFilter( blockData.solveTypeParameters().maxNumMatches() );
+			this.matchFilter = new RandomMaxAmountFilter(parameters.maxNumMatches());
 
 		// used locally
-		this.stitchFirst = blockData.solveTypeParameters().minStitchingInliersSupplier() != null;
+		this.stitchFirst = (parameters.minStitchingInliersSupplier() != null);
 		this.pairs = new ArrayList<>();
 		this.zToPairs = new HashMap<>();
 
 		// NOTE: if you choose to stitch first, you need to pre-align, otherwise, it's OK to use the initial alignment for each tile
-		if ( stitchFirst && inputSolveItem.blockData().solveTypeParameters().preAlign() == PreAlign.NONE )
-		{
+		if (stitchFirst && parameters.preAlign() == PreAlign.NONE) {
 			LOG.error("Since you choose to stitch first, you must pre-align with Translation or Rigid.");
 			throw new RuntimeException("Since you choose to stitch first, you must pre-align with Translation or Rigid.");
 		}
@@ -146,7 +144,7 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 
 		final List<AffineBlockDataWrapper<M, S>> solveItems = splitSolveItem(inputSolveItem, startId);
 
-		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems )
+		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems)
 		{
 				/*
 				java.lang.NullPointerException: Cannot invoke "org.janelia.alignment.spec.TileSpec.getZ()" because the return value of "org.janelia.alignment.spec.ResolvedTileSpecCollection.getTileSpec(String)" is null
@@ -165,12 +163,12 @@ public class AffineAlignBlockWorker<M extends Model<M> & Affine2D<M>, S extends 
 			solve( solveItem, numThreads );
 		}
 
-		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems )
+		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems)
 			computeSolveItemErrors( solveItem, canvasMatches );
 
 		// clean up
 		this.result = new ArrayList<>();
-		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems )
+		for ( final AffineBlockDataWrapper<M, S> solveItem : solveItems)
 		{
 			result.add( solveItem.blockData() );
 			solveItem.matches().clear();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -247,7 +247,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	private void connectTilesWithinPatches(final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles) {
 		final Collection<TileSpec> allTiles = blockData.rtsc().getTileSpecs();
-		final boolean equilibrateIntensities = blockData.solveTypeParameters().equilibrateIntensities();
+		final double equilibrationWeight = blockData.solveTypeParameters().equilibrationWeight();
 
 		for (final TileSpec p : allTiles) {
 			final List<? extends Tile<?>> coefficientTile = coefficientTiles.get(p.getTileId());
@@ -263,11 +263,11 @@ public class AffineIntensityCorrectionBlockWorker<M>
 					identityConnect(coefficientTile.get(top), coefficientTile.get(bot));
 				}
 			}
-			if (equilibrateIntensities) {
+			if (equilibrationWeight > 0.0) {
 				for (int i = 0; i < parameters.numCoefficients(); i++) {
 					for (int j = 0; j < parameters.numCoefficients(); j++) {
 						final int idx = getLinearIndex(i, j, parameters.numCoefficients());
-						equilibrateIntensity(coefficientTile.get(idx), averages.get(idx));
+						equilibrateIntensity(coefficientTile.get(idx), averages.get(idx), equilibrationWeight);
 					}
 				}
 			}
@@ -281,8 +281,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return y * n + x;
 	}
 
-	private void equilibrateIntensity(final Tile<?> tile, final Double average) {
-		final double weight = 1.0;
+	private void equilibrateIntensity(final Tile<?> tile, final Double average, final double weight) {
 		final List<PointMatch> matches = new ArrayList<>();
 		matches.add(new PointMatch(new Point(new double[] { average }), new Point(new double[] { 0.5 }), weight));
 		tile.connect(equilibrationTile, matches);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -73,7 +73,6 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	@Override
 	public void run() throws IOException, ExecutionException, InterruptedException, NoninvertibleModelException {
 		final List<MinimalTileSpecWrapper> wrappedTiles = AdjustBlock.wrapTileSpecs(blockData.rtsc());
-		blockData.getResults().addTileSpecs(blockData.rtsc().getTileSpecs());
 
 		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = computeCoefficients(wrappedTiles);
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -86,7 +86,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 				final AffineModel1D model = ((InterpolatedAffineModel1D<?, ?>) tile.getModel()).createAffineModel1D();
 				models.add(model);
 			});
-			blockData.idToNewModel().put(tileId, models);
+			blockData.getResults().recordModel(tileId, models);
 		});
 
 		LOG.info("AffineIntensityCorrectionBlockWorker: exit, minZ={}, maxZ={}", blockData.minZ(), blockData.maxZ());
@@ -234,7 +234,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 			}).average().orElse(Double.MAX_VALUE);
 			final List<SerializableValuePair<String, Double>> errorList = new ArrayList<>();
 			errorList.add(new SerializableValuePair<>(tileId, error));
-			blockData.idToBlockErrorMap().put(tileId, errorList);
+			blockData.getResults().recordAllErrors(tileId, errorList);
 		});
 
 		LOG.info("solveForGlobalCoefficients: exit, returning intensity coefficients for {} tiles", coefficientTiles.size());

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -36,7 +36,6 @@ import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMIntensityCorrectionParameters;
 import org.janelia.render.client.newsolver.solvers.Worker;
 import org.janelia.render.client.parameter.ZDistanceParameters;
-import org.janelia.render.client.solver.SerializableValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +46,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -231,9 +231,9 @@ public class AffineIntensityCorrectionBlockWorker<M>
 				t.updateCost();
 				return t.getDistance();
 			}).average().orElse(Double.MAX_VALUE);
-			final List<SerializableValuePair<String, Double>> errorList = new ArrayList<>();
-			errorList.add(new SerializableValuePair<>(tileId, error));
-			blockData.getResults().recordAllErrors(tileId, errorList);
+			final Map<String, Double> errorMap = new HashMap<>();
+			errorMap.put(tileId, error);
+			blockData.getResults().recordAllErrors(tileId, errorMap);
 		});
 
 		LOG.info("solveForGlobalCoefficients: exit, returning intensity coefficients for {} tiles", coefficientTiles.size());

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -73,12 +73,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	@Override
 	public void run() throws IOException, ExecutionException, InterruptedException, NoninvertibleModelException {
 		final List<MinimalTileSpecWrapper> wrappedTiles = AdjustBlock.wrapTileSpecs(blockData.rtsc());
-
-		for (final MinimalTileSpecWrapper wrappedTile : wrappedTiles) {
-			final String tileId = wrappedTile.getTileId();
-			final int z = (int) Math.round(wrappedTile.getZ());
-			blockData.zToTileId().computeIfAbsent(z, k -> new HashSet<>()).add(tileId);
-		}
+		blockData.getResults().addTileSpecs(blockData.rtsc().getTileSpecs());
 
 		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = computeCoefficients(wrappedTiles);
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -53,6 +53,13 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	)
 	public int numCoefficients = AdjustBlock.DEFAULT_NUM_COEFFICIENTS;
 
+	@Parameter(
+			names = "--preEquilibrateIntensity",
+			description = "Apply translation to every coefficient tile to make the mean intensity equal to this value (default: null)",
+			arity = 0)
+	public boolean preEquilibrateIntensity = false;
+
+
 	public void initDefaultValues() throws IllegalArgumentException {
 		this.zDistance.initDefaultValues();
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -54,10 +54,10 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	public int numCoefficients = AdjustBlock.DEFAULT_NUM_COEFFICIENTS;
 
 	@Parameter(
-			names = "--equilibrateIntensities",
-			description = "Apply translation to every coefficient tile to make the mean intensity equal to this value (default: null)",
-			arity = 0)
-	public boolean preEquilibrateIntensity = false;
+			names = "--equilibrationWeight",
+			description = "Apply equilibration to every coefficient tile to make the mean intensity more uniform (default: 0.0 = no equilibration)"
+	)
+	public double equilibrationWeight = 0.0;
 
 
 	public void initDefaultValues() throws IllegalArgumentException {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -54,7 +54,7 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	public int numCoefficients = AdjustBlock.DEFAULT_NUM_COEFFICIENTS;
 
 	@Parameter(
-			names = "--preEquilibrateIntensity",
+			names = "--equilibrateIntensities",
 			description = "Apply translation to every coefficient tile to make the mean intensity equal to this value (default: null)",
 			arity = 0)
 	public boolean preEquilibrateIntensity = false;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/intensityadjust/IntensityCorrectionClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/intensityadjust/IntensityCorrectionClient.java
@@ -14,7 +14,7 @@ import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.newsolver.BlockCollection;
 import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.DistributedIntensityCorrectionSolver;
-import org.janelia.render.client.newsolver.assembly.AssemblyMaps;
+import org.janelia.render.client.newsolver.assembly.ResultContainer;
 import org.janelia.render.client.newsolver.setup.IntensityCorrectionSetup;
 import org.janelia.render.client.newsolver.setup.RenderSetup;
 import org.janelia.render.client.newsolver.solvers.Worker;
@@ -120,7 +120,7 @@ public class IntensityCorrectionClient
 
         LOG.info("runWithContext: computed {} blocks, maxId={}", allItems.size(), maxId);
 
-        final AssemblyMaps<ArrayList<AffineModel1D>> finalizedItems = intensitySolver.assembleBlocks(allItems);
+        final ResultContainer<ArrayList<AffineModel1D>> finalizedItems = intensitySolver.assembleBlocks(allItems);
         intensitySolver.saveResultsAsNeeded(finalizedItems);
 
         LOG.info("runWithContext: exit");


### PR DESCRIPTION
This is an attempt at providing a parameter to adjust the overall uniformity during intensity correction.

**Before**: Coefficient tiles within an image tile were identity connected, parts that overlap with another image tile are matched. This ensures global smoothness of the result (i.e., no hard cuts between two image tiles).

**Now**: In addition, all coefficient tiles are connected to a single tile by a point match `"average intensity of coefficient tile" <-> 0.5`. This tile is fixed during optimization. This should skew the average intensity of every tile towards the "target intensity" `0.5`. A parameter `--equilibrationWeight` is provided to tune the weight of this match; setting this parameter to `0.0` disables this mechanism and does intensity correction as before. 