### PR TITLE
Background correction for cellmap stack

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/filter/AverageBackgroundSubtraction.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/AverageBackgroundSubtraction.java
@@ -1,0 +1,54 @@
+package org.janelia.alignment.filter;
+
+import ij.process.ImageProcessor;
+import mpicbg.trakem2.transform.TransformMeshMappingWithMasks;
+import org.janelia.alignment.loader.ImageLoader;
+import org.janelia.alignment.util.ImageProcessorCache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AverageBackgroundSubtraction implements Filter {
+	private static final ImageProcessorCache cache =
+			new ImageProcessorCache(ImageProcessorCache.DEFAULT_MAX_CACHED_PIXELS, false, false);
+
+	private String backgroundPath;
+	private double backgroundScale;
+	private float offset;
+
+	// empty constructor required to create instances from specifications
+	@SuppressWarnings("unused")
+	public AverageBackgroundSubtraction() {
+		this(null, 1.0, 0.0f);
+	}
+
+	public AverageBackgroundSubtraction(final String backgroundPath, final double backgroundScale, final float offset) {
+		this.backgroundPath = backgroundPath;
+		this.backgroundScale = backgroundScale;
+		this.offset = offset;
+	}
+
+	@Override
+	public void init(final Map<String, String> params) {
+		this.backgroundPath = Filter.getStringParameter("path", params);
+		this.backgroundScale = Filter.getDoubleParameter("scale", params);
+		this.offset = Filter.getFloatParameter("offset", params);
+	}
+
+	@Override
+	public Map<String, String> toParametersMap() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("path", backgroundPath);
+		map.put("scale", String.valueOf(backgroundScale));
+		map.put("offset", String.valueOf(offset));
+		return map;
+	}
+
+	@Override
+	public void process(final ImageProcessor ip, final double scale) {
+		final ImageProcessor background = cache.get(backgroundPath, 0, false, false, ImageLoader.LoaderType.IMAGEJ_DEFAULT, null);
+
+
+
+	}
+}

--- a/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
@@ -16,6 +16,7 @@
  */
 package org.janelia.alignment.filter;
 
+import java.lang.reflect.Constructor;
 import java.util.Map;
 
 import org.janelia.alignment.json.JsonUtils;
@@ -30,7 +31,7 @@ public class FilterSpec {
     private final String className;
     private final Map<String, String> parameters;
 
-    private transient Class clazz;
+    private transient Class<?> clazz;
 
     // no-arg constructor needed for JSON deserialization
     @SuppressWarnings("unused")
@@ -68,10 +69,11 @@ public class FilterSpec {
     public Filter buildInstance()
             throws IllegalArgumentException {
 
-        final Class clazz = getClazz();
+        final Class<?> clazz = getClazz();
         final Object instance;
         try {
-            instance = clazz.newInstance();
+            final Constructor<?> constructor = clazz.getConstructor();
+            instance = constructor.newInstance();
         } catch (final Exception e) {
             throw new IllegalArgumentException("failed to create instance of filter class '" + className + "'", e);
         }
@@ -111,7 +113,7 @@ public class FilterSpec {
         return new FilterSpec(filter.getClass().getName(), filter.toParametersMap());
     }
 
-    private Class getClazz() throws IllegalArgumentException {
+    private Class<?> getClazz() throws IllegalArgumentException {
         if (clazz == null) {
             if (className == null) {
                 throw new IllegalArgumentException("no className defined for filter spec");

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
@@ -2,6 +2,7 @@ package org.janelia.render.client;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import ij.IJ;
 import ij.ImagePlus;
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
@@ -16,7 +17,6 @@ import org.janelia.render.client.parameter.ZRangeParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.awt.Rectangle;
 import java.io.IOException;
 
@@ -112,14 +112,7 @@ public class BackgroundComputationClient {
 
 		divideByNumberOfPixels(averagePixels, numberOfPixels);
 
-		final ImagePlus imp = new ImagePlus("Background", averagePixels);
-		imp.show();
-
-		try {
-			Thread.sleep(Duration.ofMinutes(1000).toMillis());
-		} catch (final InterruptedException e) {
-			throw new RuntimeException(e);
-		}
+		IJ.save(new ImagePlus("Background", averagePixels), params.getFileName());
 	}
 
 	private ResolvedTileSpecCollection getTileSpecs() {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
@@ -1,0 +1,106 @@
+package org.janelia.render.client;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.parameter.ZRangeParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+
+/**
+ * Create and store a background image that can be used to subtract a
+ * spatially varying background from a set of images.
+ */
+public class BackgroundComputationClient {
+
+	private final Parameters params;
+	private final RenderDataClient renderClient;
+
+	public static class Parameters extends CommandLineParameters {
+		@ParametersDelegate
+		private final RenderWebServiceParameters renderParams = new RenderWebServiceParameters();
+		@ParametersDelegate
+		private final ZRangeParameters zRangeParams = new ZRangeParameters();
+		@Parameter(names = "--stack", description = "Stack for which to compute background", required = true)
+		private String stack;
+		@Parameter(names = "--regex", description = "Regular expression for matching tiles to use for background computation; all tiles are used if not given")
+		private String regex = null;
+		@Parameter(names = "--fileName", description = "Name of file to write background image to (default: background_<stack>.png)")
+		private String fileName = null;
+
+		public String getFileName() {
+			if (fileName == null) {
+				fileName = "background_" + stack + ".png";
+			}
+			return fileName;
+		}
+	}
+
+	public static void main(String[] args) {
+
+		if (args.length == 0) {
+			args = new String[] {
+					"--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+					"--owner", "cellmap",
+					"--project", "jrc_mus_thymus_1",
+					"--stack", "v2_acquire_align",
+					"--minZ", "1250",
+					"--maxZ", "1253",
+					"--regex", ".*_0-[01]-1.*",
+					"--fileName", "background_test.png"
+			};
+		}
+
+		final ClientRunner clientRunner = new ClientRunner(args) {
+			@Override
+			public void runClient(final String[] args) {
+
+				final Parameters parameters = new Parameters();
+				parameters.parse(args);
+				LOG.info("runClient: entry, parameters={}", parameters);
+
+				final BackgroundComputationClient client = new BackgroundComputationClient(parameters);
+				client.computeBackground();
+			}
+		};
+		clientRunner.run();
+	}
+
+	public BackgroundComputationClient(final Parameters parameters) {
+		this.params = parameters;
+		this.renderClient = new RenderDataClient(parameters.renderParams.baseDataUrl, parameters.renderParams.owner, parameters.renderParams.project);
+	}
+
+	public void computeBackground() {
+		final ResolvedTileSpecCollection tileSpecs = getTileSpecs();
+		final Rectangle backgroundBounds = tileSpecs.toBounds().toRectangle();
+
+		System.out.println("Fetched " + tileSpecs.getTileCount() + " tile specs, bounds: " + backgroundBounds);
+	}
+
+	private ResolvedTileSpecCollection getTileSpecs() {
+		ResolvedTileSpecCollection tileSpecs = null;
+		try {
+			tileSpecs = renderClient.getResolvedTiles(params.stack,
+													  params.zRangeParams.minZ,
+													  params.zRangeParams.maxZ,
+													  null,
+													  null,
+													  null,
+													  null,
+													  null,
+													  params.regex);
+		} catch (final IOException e) {
+			LOG.error("Could not get tile specs: ", e);
+			System.exit(1);
+		}
+		return tileSpecs;
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(BackgroundComputationClient.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/BackgroundComputationClient.java
@@ -25,6 +25,9 @@ import java.util.DoubleSummaryStatistics;
 /**
  * Create and store a background image that can be used to subtract a
  * spatially varying background from a set of images.
+ * Originally developed for the CellMap jrc_mus_thymus_1 dataset.
+ *
+ * @author Michael Innerberger
  */
 public class BackgroundComputationClient {
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solver/visualize/VisualizeTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solver/visualize/VisualizeTools.java
@@ -763,7 +763,7 @@ public class VisualizeTools
 			throw new UnsupportedOperationException("multi-channel source for tile " + tileId +
 													" is not currently supported");
 		}
-		final ChannelSpec firstChannelSpec = tileSpec.getAllChannels().get(0);
+		final ChannelSpec firstChannelSpec = allChannels.get(0);
 		final ImageAndMask imageAndMask = firstChannelSpec.getFirstMipmapImageAndMask(tileId);
 		final ImageProcessor sourceProcessor = imageProcessorCache.get(imageAndMask.getImageUrl(),
 																	   0,


### PR DESCRIPTION
I started implementing background correction as discussed:
1. average all affected tiles in the stack
2. heavily smooth the resulting image
3. subtract the resulting background image from all affected tiles (as `Filter`)

However, I see some problems with this approach (technical and conceptional):
* Currently, the `Filter.process` method only gets an `ImageProcessor`, so there is no way of matching the incoming image to the background in terms of stage coordinates.
* As is apparent from [this picture](https://github.com/JaneliaSciComp/recon_fibsem/issues/47#issuecomment-1731889642), the light region in the stack varies in spatial extent and intensity throughout the stack. Simply subtracting one background image from everything probably doesn't completely get rid of the problem.

**Alternative**: we could use the already implemented `RollingBallSubtraction` filter that uses an ImageJ plugin to do local background correction for a single image. The results of applying this filter don't look too bad (original vs. rolling paraboloid vs. rolling ball):
![original-vs-paraboloid-vs-ball](https://github.com/saalfeldlab/render/assets/20970305/c065de35-fccc-4e61-b9e1-c92c2d5d668f)

The downside would be that this is pretty computation heavy, so pre-applying the filter would be necessary, essentially duplicating the whole stack.
What are your thoughts @StephanPreibisch ?