### PR TITLE
Fix duplicate tile pairs bug

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/Utils.java
+++ b/render-app/src/main/java/org/janelia/alignment/Utils.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -410,5 +411,8 @@ public class Utils {
         }
         return uri;
     }
+
+    public static final Comparator<String> NULLS_FIRST_STRING_COMPARATOR =
+            Comparator.nullsFirst(Comparator.naturalOrder());
 
 }

--- a/render-app/src/main/java/org/janelia/alignment/match/CanvasId.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/CanvasId.java
@@ -8,8 +8,8 @@ import org.janelia.alignment.json.JsonUtils;
 
 import jakarta.annotation.Nonnull;
 
-import static org.janelia.alignment.match.MontageRelativePosition.LEFT;
-import static org.janelia.alignment.match.MontageRelativePosition.TOP;
+import static org.janelia.alignment.Utils.NULLS_FIRST_STRING_COMPARATOR;
+import static org.janelia.alignment.match.MontageRelativePosition.*;
 
 /**
  * Key identifiers for a canvas.
@@ -170,8 +170,7 @@ public class CanvasId
     public static final double[] ZERO_OFFSETS = { 0.0, 0.0 };
 
     private static final Comparator<CanvasId> CANVAS_ID_COMPARATOR = Comparator
-            .comparing(CanvasId::getGroupId, Comparator.nullsFirst(Comparator.naturalOrder()))
-            .thenComparing(CanvasId::getId, Comparator.nullsFirst(Comparator.naturalOrder()))
-            .thenComparing(CanvasId::getRelativePosition, Comparator.nullsFirst(Comparator.naturalOrder()));
-
+            .comparing(CanvasId::getGroupId, NULLS_FIRST_STRING_COMPARATOR)
+            .thenComparing(CanvasId::getId, NULLS_FIRST_STRING_COMPARATOR)
+            .thenComparing(CanvasId::getRelativePosition, NULLS_FIRST_POSITION_COMPARATOR);
 }

--- a/render-app/src/main/java/org/janelia/alignment/match/CanvasId.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/CanvasId.java
@@ -1,9 +1,12 @@
 package org.janelia.alignment.match;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Objects;
 
 import org.janelia.alignment.json.JsonUtils;
+
+import jakarta.annotation.Nonnull;
 
 import static org.janelia.alignment.match.MontageRelativePosition.LEFT;
 import static org.janelia.alignment.match.MontageRelativePosition.TOP;
@@ -116,6 +119,10 @@ public class CanvasId
         }
     }
 
+    public CanvasId withRelativePosition(final MontageRelativePosition relativePosition) {
+        return new CanvasId(groupId, id, relativePosition);
+    }
+
     public CanvasId withoutRelativePosition() {
         return new CanvasId(groupId, id);
     }
@@ -136,23 +143,12 @@ public class CanvasId
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(id, groupId, relativePosition);
+        return Objects.hash(id, groupId, relativePosition);
     }
 
     @Override
-    public int compareTo(final CanvasId that) {
-        int result = this.groupId.compareTo(that.groupId);
-        if (result == 0) {
-            result = this.id.compareTo(that.id);
-            if (result == 0) {
-                if (this.relativePosition == null) {
-                    result = that.relativePosition == null ? 0 : -1;
-                } else if (that.relativePosition != null) {
-                    result = this.relativePosition.compareTo(that.relativePosition);
-                }
-            }
-        }
-        return result;
+    public int compareTo(@Nonnull final CanvasId that) {
+        return CANVAS_ID_COMPARATOR.compare(this, that);
     }
 
     @Override
@@ -172,5 +168,10 @@ public class CanvasId
             new JsonUtils.Helper<>(CanvasId.class);
 
     public static final double[] ZERO_OFFSETS = { 0.0, 0.0 };
+
+    private static final Comparator<CanvasId> CANVAS_ID_COMPARATOR = Comparator
+            .comparing(CanvasId::getGroupId, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .thenComparing(CanvasId::getId, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .thenComparing(CanvasId::getRelativePosition, Comparator.nullsFirst(Comparator.naturalOrder()));
 
 }

--- a/render-app/src/main/java/org/janelia/alignment/match/MontageRelativePosition.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/MontageRelativePosition.java
@@ -13,38 +13,38 @@ public enum MontageRelativePosition {
     TOP, BOTTOM, LEFT, RIGHT;
 
     /**
-     * Uses minX and minY of each canvas to determine their relative positions.
+     * Uses minX and minY of each canvas to determine their relative position.
      * Orientation (left/right vs. top/bottom) is chosen based upon the largest
      * dimensional distance.
      *
      * @param  pBounds  first canvas bounds.
      * @param  qBounds  second canvas bounds.
      *
-     * @return relative positions of the specified canvases.
+     * @return relative position of the pBounds canvas.
      */
-    public static MontageRelativePosition[] getRelativePositions(final Bounds pBounds,
-                                                                 final Bounds qBounds) {
+    public static MontageRelativePosition of(final Bounds pBounds,
+                                             final Bounds qBounds) {
 
-        final MontageRelativePosition[] relativePositions;
+        final MontageRelativePosition relativePosition;
 
         final double deltaX = pBounds.getMinX() - qBounds.getMinX();
         final double deltaY = pBounds.getMinY() - qBounds.getMinY();
 
         if (Math.abs(deltaX) > Math.abs(deltaY)) {
             if (deltaX > 0) {
-                relativePositions = new MontageRelativePosition[] {RIGHT, LEFT };
+                relativePosition = MontageRelativePosition.RIGHT;
             } else {
-                relativePositions = new MontageRelativePosition[] {LEFT, RIGHT };
+                relativePosition = MontageRelativePosition.LEFT;
             }
         } else {
             if (deltaY > 0) {
-                relativePositions = new MontageRelativePosition[] {BOTTOM, TOP };
+                relativePosition = MontageRelativePosition.BOTTOM;
             } else {
-                relativePositions = new MontageRelativePosition[] {TOP, BOTTOM };
+                relativePosition = MontageRelativePosition.TOP;
             }
         }
 
-        return relativePositions;
+        return relativePosition;
     }
 
     public MontageRelativePosition getOpposite() {

--- a/render-app/src/main/java/org/janelia/alignment/match/MontageRelativePosition.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/MontageRelativePosition.java
@@ -1,5 +1,7 @@
 package org.janelia.alignment.match;
 
+import java.util.Comparator;
+
 import org.janelia.alignment.spec.Bounds;
 
 /**
@@ -57,4 +59,6 @@ public enum MontageRelativePosition {
         return opposite;
     }
 
+    public static final Comparator<MontageRelativePosition> NULLS_FIRST_POSITION_COMPARATOR =
+            Comparator.nullsFirst(Comparator.naturalOrder());
 }

--- a/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
@@ -3,6 +3,8 @@ package org.janelia.alignment.match;
 import java.io.Serializable;
 import java.util.Objects;
 
+import org.janelia.alignment.spec.TileBounds;
+
 /**
  * A pair of canvas identifiers with {@linkplain Comparable natural ordering}.
  *
@@ -55,6 +57,41 @@ public class OrderedCanvasIdPair
         this.absoluteDeltaZ = deltaZ == null ? null : Math.abs(deltaZ);
     }
 
+    /**
+     * @param  oneTileBounds      identifiers and bounds for one canvas identifier.
+     * @param  anotherTileBounds  identifiers and bounds for another canvas identifier.
+     *
+     * @return an ordered pair where each CanvasId includes relative position information
+     *         based upon the specified tile bounds.
+     *         Assumes that the bounds are for the same layer so the pair's deltaZ is set to null.
+     *
+     * @throws IllegalArgumentException
+     *   if both tile identifiers are the same.
+     */
+    public static OrderedCanvasIdPair withRelativePositions(final TileBounds oneTileBounds,
+                                                            final TileBounds anotherTileBounds)
+            throws IllegalArgumentException {
+
+        final CanvasId oneCanvasId = new CanvasId(oneTileBounds.getSectionId(), oneTileBounds.getTileId());
+        final CanvasId anotherCanvasId = new CanvasId(anotherTileBounds.getSectionId(), anotherTileBounds.getTileId());
+
+        final int comparisonResult = oneCanvasId.compareTo(anotherCanvasId);
+        final MontageRelativePosition[] positions = MontageRelativePosition.getRelativePositions(oneTileBounds,
+                                                                                                 anotherTileBounds);
+        final OrderedCanvasIdPair pair;
+        if (comparisonResult < 0) {
+            pair = new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[0]),
+                                           anotherCanvasId.withRelativePosition(positions[1]),
+                                           null);
+        } else {
+            // flip relative position values since p and q will be flipped by constructor normalization
+            pair = new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[1]),
+                                           anotherCanvasId.withRelativePosition(positions[0]),
+                                           null);
+        }
+        return pair;
+    }
+
     public CanvasId getP() {
         return p;
     }
@@ -96,11 +133,6 @@ public class OrderedCanvasIdPair
 
     @Override
     public String toString() {
-        if ((p.getGroupId() == null) && (q.getGroupId() == null)) {
-            return "[\"" + p.getId() + "\", \"" + q.getId() + "\"]";
-        } else {
-            return "{\"p\": [\"" + p.getGroupId() + "\", \"" + p.getId() + "\"], \"q\": [\"" +
-                   q.getGroupId() + "\", \"" + q.getId() + "\"]}";
-        }
+            return "{\"p\": \"" + p + "\", \"q\": \"" + q + "\"}";
     }
 }

--- a/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
@@ -75,21 +75,27 @@ public class OrderedCanvasIdPair
         final CanvasId oneCanvasId = new CanvasId(oneTileBounds.getSectionId(), oneTileBounds.getTileId());
         final CanvasId anotherCanvasId = new CanvasId(anotherTileBounds.getSectionId(), anotherTileBounds.getTileId());
 
-        final int comparisonResult = oneCanvasId.compareTo(anotherCanvasId);
         final MontageRelativePosition[] positions = MontageRelativePosition.getRelativePositions(oneTileBounds,
                                                                                                  anotherTileBounds);
-        final OrderedCanvasIdPair pair;
-        if (comparisonResult < 0) {
-            pair = new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[0]),
-                                           anotherCanvasId.withRelativePosition(positions[1]),
-                                           null);
-        } else {
-            // flip relative position values since p and q will be flipped by constructor normalization
-            pair = new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[1]),
-                                           anotherCanvasId.withRelativePosition(positions[0]),
-                                           null);
+        final int comparisonResult = oneCanvasId.compareTo(anotherCanvasId);
+        // if the tile identifiers are not in natural order ...
+        if (comparisonResult > 0) {
+            final MontageRelativePosition[] flippedPositions =
+                    MontageRelativePosition.getRelativePositions(anotherTileBounds,
+                                                                 oneTileBounds);
+            // and if both tiles are in the same position relative to each other ...
+            if (positions[0].equals(flippedPositions[0])) {
+                // then flip the positions to maintain consistency with natural order
+                positions[0] = flippedPositions[1]; // NOTE: this is flipping because both are same
+                positions[1] = flippedPositions[0];
+            }
+        } else if (comparisonResult == 0) {
+            throw new IllegalArgumentException("both IDs are the same: '" + oneCanvasId + "'");
         }
-        return pair;
+
+        return new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[0]),
+                                       anotherCanvasId.withRelativePosition(positions[1]),
+                                       null);
     }
 
     public CanvasId getP() {

--- a/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
@@ -77,26 +77,23 @@ public class OrderedCanvasIdPair
         final CanvasId oneCanvasId = new CanvasId(oneTileBounds.getSectionId(), oneTileBounds.getTileId());
         final CanvasId anotherCanvasId = new CanvasId(anotherTileBounds.getSectionId(), anotherTileBounds.getTileId());
 
-        final MontageRelativePosition[] positions = MontageRelativePosition.getRelativePositions(oneTileBounds,
-                                                                                                 anotherTileBounds);
+        MontageRelativePosition oneToAnother = MontageRelativePosition.of(oneTileBounds, anotherTileBounds);
+
         final int comparisonResult = oneCanvasId.compareTo(anotherCanvasId);
         // if the tile identifiers are not in natural order ...
         if (comparisonResult > 0) {
-            final MontageRelativePosition[] flippedPositions =
-                    MontageRelativePosition.getRelativePositions(anotherTileBounds,
-                                                                 oneTileBounds);
+            final MontageRelativePosition anotherToOne = MontageRelativePosition.of(anotherTileBounds, oneTileBounds);
             // and if both tiles are in the same position relative to each other ...
-            if (positions[0].equals(flippedPositions[0])) {
-                // then flip the positions to maintain consistency with natural order
-                positions[0] = flippedPositions[1]; // NOTE: this is flipping because both are same
-                positions[1] = flippedPositions[0];
+            if (oneToAnother.equals(anotherToOne)) {
+                // then flip the first position to maintain consistency with natural order
+                oneToAnother = oneToAnother.getOpposite();
             }
         } else if (comparisonResult == 0) {
             throw new IllegalArgumentException("both IDs are the same: '" + oneCanvasId + "'");
         }
 
-        return new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(positions[0]),
-                                       anotherCanvasId.withRelativePosition(positions[1]),
+        return new OrderedCanvasIdPair(oneCanvasId.withRelativePosition(oneToAnother),
+                                       anotherCanvasId.withRelativePosition(oneToAnother.getOpposite()),
                                        null);
     }
 

--- a/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
@@ -63,15 +63,15 @@ public class OrderedCanvasIdPair
      * @param  oneTileBounds      identifiers and bounds for one canvas identifier.
      * @param  anotherTileBounds  identifiers and bounds for another canvas identifier.
      *
-     * @return an ordered pair where each CanvasId includes relative position information
+     * @return an ordered pair where each CanvasId includes montage relative position information
      *         based upon the specified tile bounds.
      *         Assumes that the bounds are for the same layer so the pair's deltaZ is set to null.
      *
      * @throws IllegalArgumentException
      *   if both tile identifiers are the same.
      */
-    public static OrderedCanvasIdPair withRelativePositions(final TileBounds oneTileBounds,
-                                                            final TileBounds anotherTileBounds)
+    public static OrderedCanvasIdPair withRelativeMontagePositions(final TileBounds oneTileBounds,
+                                                                   final TileBounds anotherTileBounds)
             throws IllegalArgumentException {
 
         final CanvasId oneCanvasId = new CanvasId(oneTileBounds.getSectionId(), oneTileBounds.getTileId());

--- a/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/OrderedCanvasIdPair.java
@@ -21,6 +21,8 @@ public class OrderedCanvasIdPair
 
     private final Double absoluteDeltaZ;
 
+    // TODO: merge absoluteDeltaZ with montageRelativePosition into a single relativePosition class ( see https://github.com/saalfeldlab/render/pull/163#discussion_r1421439483 )
+
     // no-arg constructor needed for JSON deserialization
     @SuppressWarnings("unused")
     private OrderedCanvasIdPair() {

--- a/render-app/src/main/java/org/janelia/alignment/spec/TileBoundsRTree.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/TileBoundsRTree.java
@@ -304,7 +304,7 @@ public class TileBoundsRTree {
 
                         final OrderedCanvasIdPair pair;
                         if (includeRelativePosition) {
-                            pair = OrderedCanvasIdPair.withRelativePositions(fromTile, toTile);
+                            pair = OrderedCanvasIdPair.withRelativeMontagePositions(fromTile, toTile);
                         } else {
                             final Double deltaZ = fromTile.getZ() - toTile.getZ();
                             pair = new OrderedCanvasIdPair(p,

--- a/render-app/src/main/java/org/janelia/alignment/spec/TileBoundsRTree.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/TileBoundsRTree.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.janelia.alignment.match.CanvasId;
-import org.janelia.alignment.match.MontageRelativePosition;
 import org.janelia.alignment.match.OrderedCanvasIdPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -197,7 +196,7 @@ public class TileBoundsRTree {
                                                        final boolean excludeSameSectionNeighbors) {
 
         String firstTileId = null;
-        if (sourceTileBoundsList.size() > 0) {
+        if (! sourceTileBoundsList.isEmpty()) {
             firstTileId = sourceTileBoundsList.get(0).getTileId();
         }
 
@@ -293,7 +292,6 @@ public class TileBoundsRTree {
 
         final CanvasId p = new CanvasId(fromTile.getSectionId(), pTileId);
         String qTileId;
-        MontageRelativePosition[] relativePositions;
         for (final TileBounds toTile : toTiles) {
             qTileId = toTile.getTileId();
             if (! pTileId.equals(qTileId)) {
@@ -304,21 +302,16 @@ public class TileBoundsRTree {
                         isNeighborCenterInRange(fromMinX, fromMaxX, toTile.getMinX(), toTile.getMaxX()) ||
                         isNeighborCenterInRange(fromMinY, fromMaxY, toTile.getMinY(), toTile.getMaxY())) {
 
+                        final OrderedCanvasIdPair pair;
                         if (includeRelativePosition) {
-                            relativePositions = MontageRelativePosition.getRelativePositions(fromTile, toTile);
-                            pairs.add(
-                                    new OrderedCanvasIdPair(
-                                            new CanvasId(fromTile.getSectionId(), pTileId, relativePositions[0]),
-                                            new CanvasId(toTile.getSectionId(), qTileId, relativePositions[1]),
-                                            null));
+                            pair = OrderedCanvasIdPair.withRelativePositions(fromTile, toTile);
                         } else {
                             final Double deltaZ = fromTile.getZ() - toTile.getZ();
-                            pairs.add(
-                                    new OrderedCanvasIdPair(
-                                            p,
-                                            new CanvasId(toTile.getSectionId(), qTileId),
-                                            deltaZ));
+                            pair = new OrderedCanvasIdPair(p,
+                                                           new CanvasId(toTile.getSectionId(), qTileId),
+                                                           deltaZ);
                         }
+                        pairs.add(pair);
                     }
 
                 }

--- a/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
@@ -24,7 +24,7 @@ public class OrderedCanvasIdPairTest {
     }
 
     @Test
-    public void testWithRelativePositions() {
+    public void testWithRelativeMontagePositions() {
         final String tileAId = "tileA";
         final TileBounds boundsA = new TileBounds(tileAId,"1.0", 1.0,
                                                   10.0, 11.0,
@@ -34,8 +34,8 @@ public class OrderedCanvasIdPairTest {
                                                   boundsA.getMinX() + 5.0, boundsA.getMinY(),
                                                   boundsA.getMaxX() + 5.0, boundsA.getMaxY());
 
-        final OrderedCanvasIdPair leftRightPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
-                                                                                            boundsB);
+        final OrderedCanvasIdPair leftRightPair = OrderedCanvasIdPair.withRelativeMontagePositions(boundsA,
+                                                                                                   boundsB);
         validatePair("leftRightPair", leftRightPair, tileAId, MontageRelativePosition.LEFT);
 
         final String sameBoundsTileId = "tileSameBounds";
@@ -43,14 +43,14 @@ public class OrderedCanvasIdPairTest {
                                                      boundsA.getMinX(), boundsA.getMinY(),
                                                      boundsA.getMaxX(), boundsA.getMaxY());
 
-        final OrderedCanvasIdPair orderedSameBoundsPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
-                                                                                                    sameBounds);
+        final OrderedCanvasIdPair orderedSameBoundsPair = OrderedCanvasIdPair.withRelativeMontagePositions(boundsA,
+                                                                                                           sameBounds);
         validatePair("orderedSameBoundsPair", orderedSameBoundsPair, tileAId, MontageRelativePosition.TOP);
 
-        final OrderedCanvasIdPair reversedSamBoundsPair = OrderedCanvasIdPair.withRelativePositions(sameBounds,
-                                                                                                    boundsA);
+        final OrderedCanvasIdPair reversedSameBoundsPair = OrderedCanvasIdPair.withRelativeMontagePositions(sameBounds,
+                                                                                                           boundsA);
         Assert.assertEquals("same bounds pairs should be the same",
-                            orderedSameBoundsPair, reversedSamBoundsPair);
+                            orderedSameBoundsPair, reversedSameBoundsPair);
     }
 
     private CanvasId getCanvasId(final int tileIndex) {

--- a/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
@@ -38,8 +38,8 @@ public class OrderedCanvasIdPairTest {
                                                                                             boundsB);
         validatePair("leftRightPair", leftRightPair, tileAId, MontageRelativePosition.LEFT);
 
-        final String tileOverlapId = "tileOverlap";
-        final TileBounds boundsOverlap = new TileBounds(tileOverlapId, boundsA.getSectionId(), boundsA.getZ(),
+        final String sameBoundsTileId = "sameBoundsTile";
+        final TileBounds boundsOverlap = new TileBounds(sameBoundsTileId, boundsA.getSectionId(), boundsA.getZ(),
                                                         boundsA.getMinX(), boundsA.getMinY(),
                                                         boundsA.getMaxX(), boundsA.getMaxY());
 

--- a/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
@@ -38,18 +38,19 @@ public class OrderedCanvasIdPairTest {
                                                                                             boundsB);
         validatePair("leftRightPair", leftRightPair, tileAId, MontageRelativePosition.LEFT);
 
-        final String sameBoundsTileId = "sameBoundsTile";
-        final TileBounds boundsOverlap = new TileBounds(sameBoundsTileId, boundsA.getSectionId(), boundsA.getZ(),
-                                                        boundsA.getMinX(), boundsA.getMinY(),
-                                                        boundsA.getMaxX(), boundsA.getMaxY());
+        final String sameBoundsTileId = "tileSameBounds";
+        final TileBounds sameBounds = new TileBounds(sameBoundsTileId, boundsA.getSectionId(), boundsA.getZ(),
+                                                     boundsA.getMinX(), boundsA.getMinY(),
+                                                     boundsA.getMaxX(), boundsA.getMaxY());
 
-        final OrderedCanvasIdPair orderedOverlapPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
-                                                                                                 boundsOverlap);
-        validatePair("orderedOverlapPair", orderedOverlapPair, tileAId, MontageRelativePosition.TOP);
+        final OrderedCanvasIdPair orderedSameBoundsPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
+                                                                                                    sameBounds);
+        validatePair("orderedSameBoundsPair", orderedSameBoundsPair, tileAId, MontageRelativePosition.TOP);
 
-        final OrderedCanvasIdPair reversedOverlapPair = OrderedCanvasIdPair.withRelativePositions(boundsOverlap,
-                                                                                                  boundsA);
-        Assert.assertEquals("overlap pairs should be the same", orderedOverlapPair, reversedOverlapPair);
+        final OrderedCanvasIdPair reversedSamBoundsPair = OrderedCanvasIdPair.withRelativePositions(sameBounds,
+                                                                                                    boundsA);
+        Assert.assertEquals("same bounds pairs should be the same",
+                            orderedSameBoundsPair, reversedSamBoundsPair);
     }
 
     private CanvasId getCanvasId(final int tileIndex) {

--- a/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/match/OrderedCanvasIdPairTest.java
@@ -1,5 +1,6 @@
 package org.janelia.alignment.match;
 
+import org.janelia.alignment.spec.TileBounds;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,8 +23,49 @@ public class OrderedCanvasIdPairTest {
         Assert.assertEquals("invalid canvasId for q in pair " + pair, pair.getQ(), getCanvasId(9));
     }
 
+    @Test
+    public void testWithRelativePositions() {
+        final String tileAId = "tileA";
+        final TileBounds boundsA = new TileBounds(tileAId,"1.0", 1.0,
+                                                  10.0, 11.0,
+                                                  20.0, 21.0);
+        final String tileBId = "tileB";
+        final TileBounds boundsB = new TileBounds(tileBId, boundsA.getSectionId(), boundsA.getZ(),
+                                                  boundsA.getMinX() + 5.0, boundsA.getMinY(),
+                                                  boundsA.getMaxX() + 5.0, boundsA.getMaxY());
+
+        final OrderedCanvasIdPair leftRightPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
+                                                                                            boundsB);
+        validatePair("leftRightPair", leftRightPair, tileAId, MontageRelativePosition.LEFT);
+
+        final String tileOverlapId = "tileOverlap";
+        final TileBounds boundsOverlap = new TileBounds(tileOverlapId, boundsA.getSectionId(), boundsA.getZ(),
+                                                        boundsA.getMinX(), boundsA.getMinY(),
+                                                        boundsA.getMaxX(), boundsA.getMaxY());
+
+        final OrderedCanvasIdPair orderedOverlapPair = OrderedCanvasIdPair.withRelativePositions(boundsA,
+                                                                                                 boundsOverlap);
+        validatePair("orderedOverlapPair", orderedOverlapPair, tileAId, MontageRelativePosition.TOP);
+
+        final OrderedCanvasIdPair reversedOverlapPair = OrderedCanvasIdPair.withRelativePositions(boundsOverlap,
+                                                                                                  boundsA);
+        Assert.assertEquals("overlap pairs should be the same", orderedOverlapPair, reversedOverlapPair);
+    }
+
     private CanvasId getCanvasId(final int tileIndex) {
         return new CanvasId("99.0", "tile-" + tileIndex);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void validatePair(final String context,
+                              final OrderedCanvasIdPair pair,
+                              final String expectedPTileId,
+                              final MontageRelativePosition expectedPPosition) {
+        final CanvasId p = pair.getP();
+        Assert.assertEquals(context + ", invalid p.id for pair " + pair,
+                            expectedPTileId, p.getId());
+        Assert.assertEquals(context + ", invalid p.relativePosition for " + pair,
+                            expectedPPosition, p.getRelativePosition());
     }
 
 }

--- a/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
@@ -245,10 +245,10 @@ public class TileBoundsRTreeTest {
     private List<OrderedCanvasIdPair> buildExpectedPairs(final double pZ,
                                                          final int pTileIndex,
                                                          final double qZ,
-                                                         final int... qTileIndexes) {
+                                                         final int... qTileIndices) {
         final List<OrderedCanvasIdPair> expectedPairs = new ArrayList<>();
         final CanvasId pCanvasId = new CanvasId(String.valueOf(pZ), getTileId(pTileIndex, pZ));
-        for (final int qTileIndex : qTileIndexes) {
+        for (final int qTileIndex : qTileIndices) {
             final CanvasId qCanvasId = new CanvasId(String.valueOf(qZ), getTileId(qTileIndex, qZ));
             final double deltaZ = Math.abs(pZ - qZ);
             expectedPairs.add(new OrderedCanvasIdPair(pCanvasId,

--- a/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
@@ -106,6 +106,32 @@ public class TileBoundsRTreeTest {
     }
 
     @Test
+    public void testGetCircleNeighborsWithFullyOverlappingTiles() {
+        final TileBounds z1tile0Bounds = getTileBounds(0, z);
+        final TileBounds fullyOverlappingTileBounds = new TileBounds(getTileId(1, z),
+                                                                     String.valueOf(z), z,
+                                                                     z1tile0Bounds.getMinX(),
+                                                                     z1tile0Bounds.getMinY(),
+                                                                     z1tile0Bounds.getMaxX(),
+                                                                     z1tile0Bounds.getMaxY());
+        final List<TileBounds> sourceTileBoundsList = Arrays.asList(z1tile0Bounds, fullyOverlappingTileBounds);
+        final TileBoundsRTree testTree = new TileBoundsRTree(z, sourceTileBoundsList);
+        final List<TileBoundsRTree> neighborTrees = new ArrayList<>();
+        final Set<OrderedCanvasIdPair> neighborPairs = testTree.getCircleNeighbors(sourceTileBoundsList,
+                                                                                   neighborTrees,
+                                                                                   0.6,
+                                                                                   null,
+                                                                                   false,
+                                                                                   false,
+                                                                                   false);
+
+        final Set<OrderedCanvasIdPair> expectedPairs = new TreeSet<>();
+        expectedPairs.add(OrderedCanvasIdPair.withRelativePositions(z1tile0Bounds, fullyOverlappingTileBounds));
+
+        validatePairs("fully overlapping tiles", expectedPairs, neighborPairs);
+    }
+
+    @Test
     public void testGetCanvasIdPairs() {
 
         final Double z = 99.0;

--- a/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/spec/TileBoundsRTreeTest.java
@@ -77,7 +77,7 @@ public class TileBoundsRTreeTest {
                                                                                     false);
 
         final Set<OrderedCanvasIdPair> expectedPairs = new TreeSet<>();
-        expectedPairs.add(OrderedCanvasIdPair.withRelativePositions(z1tile0Bounds, z1tile1Bounds));
+        expectedPairs.add(OrderedCanvasIdPair.withRelativeMontagePositions(z1tile0Bounds, z1tile1Bounds));
         expectedPairs.addAll(buildExpectedPairs(1.0, 0, 2.0, 0, 1, 3, 4));
         expectedPairs.addAll(buildExpectedPairs(1.0, 0, 3.0, 0, 1, 3, 4));
         expectedPairs.addAll(buildExpectedPairs(1.0, 1, 2.0, 0, 1, 2, 3, 4, 5));
@@ -126,7 +126,7 @@ public class TileBoundsRTreeTest {
                                                                                    false);
 
         final Set<OrderedCanvasIdPair> expectedPairs = new TreeSet<>();
-        expectedPairs.add(OrderedCanvasIdPair.withRelativePositions(z1tile0Bounds, fullyOverlappingTileBounds));
+        expectedPairs.add(OrderedCanvasIdPair.withRelativeMontagePositions(z1tile0Bounds, fullyOverlappingTileBounds));
 
         validatePairs("fully overlapping tiles", expectedPairs, neighborPairs);
     }


### PR DESCRIPTION
when deriving an OrderedCanvasIdPair withRelativePositions from two tiles with the same bounds.