### PR TITLE
Alternating solver for intensity correction

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
@@ -30,7 +30,7 @@ public class FilterSpec {
     private final String className;
     private final Map<String, String> parameters;
 
-    private transient Class clazz;
+    private transient Class<?> clazz;
 
     // no-arg constructor needed for JSON deserialization
     @SuppressWarnings("unused")
@@ -68,10 +68,10 @@ public class FilterSpec {
     public Filter buildInstance()
             throws IllegalArgumentException {
 
-        final Class clazz = getClazz();
+        final Class<?> clazz = getClazz();
         final Object instance;
         try {
-            instance = clazz.newInstance();
+            instance = clazz.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new IllegalArgumentException("failed to create instance of filter class '" + className + "'", e);
         }
@@ -111,7 +111,7 @@ public class FilterSpec {
         return new FilterSpec(filter.getClass().getName(), filter.toParametersMap());
     }
 
-    private Class getClazz() throws IllegalArgumentException {
+    private Class<?> getClazz() throws IllegalArgumentException {
         if (clazz == null) {
             if (className == null) {
                 throw new IllegalArgumentException("no className defined for filter spec");

--- a/render-app/src/main/java/org/janelia/alignment/filter/LinearIntensityMap8BitFilter.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/LinearIntensityMap8BitFilter.java
@@ -28,6 +28,25 @@ public class LinearIntensityMap8BitFilter
         super(numberOfRegionRows, numberOfRegionColumns, coefficientsPerRegion, coefficients);
     }
 
+    /**
+     * Merges the current filter with another filter such that the result of the merge is equivalent to applying the
+     * other filter first and then the current filter.
+     *
+     * @param otherFilter An instance of LinearIntensityMap8BitFilter that should be applied first.
+     */
+    public void after(final LinearIntensityMap8BitFilter otherFilter) {
+        final double[][] otherCoefficients = otherFilter.getCoefficients();
+
+        for (int i = 0; i < coefficients.length; ++i) {
+            final double[] ab = coefficients[i];
+            final double[] otherAb = otherCoefficients[i];
+
+            // chaining of two linear functions of the form y = ax + b
+            ab[1] = ab[1] + ab[0] * otherAb[1];
+            ab[0] = ab[0] * otherAb[0];
+        }
+    }
+
 
     /**
      * Adapted from render-java-ws-client module implementation of:

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/Render.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/Render.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
 
+import org.janelia.alignment.filter.FilterSpec;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.solver.visualize.VisualizeTools;
@@ -198,6 +199,12 @@ public class Render
 		// get the entire images at full scale
 		final ImageProcessorWithMasks impOriginal =
 				VisualizeTools.getUntransformedProcessorWithMasks(patch, imageProcessorCache);
+
+		// apply filters if there are any
+		final FilterSpec filterSpec = patch.getFilterSpec();
+		if (filterSpec != null) {
+			filterSpec.buildInstance().process(impOriginal.ip, scale);
+		}
 
 		/* assemble coordinate transformations and add bounding box offset */
 		//final CoordinateTransformList< CoordinateTransform > ctl = new CoordinateTransformList< CoordinateTransform >();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/Render.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/Render.java
@@ -207,8 +207,6 @@ public class Render
 		}
 
 		/* assemble coordinate transformations and add bounding box offset */
-		//final CoordinateTransformList< CoordinateTransform > ctl = new CoordinateTransformList< CoordinateTransform >();
-		//ctl.add( patch.getA() ); 
 		final CoordinateTransformList< CoordinateTransform > ctl = patch.getTransformList();
 		final AffineModel2D affineScale = new AffineModel2D();
 		affineScale.set( scale, 0, 0, scale, -x * scale, -y * scale );
@@ -219,11 +217,7 @@ public class Render
 		// TODO: the last parameter is an integer division; should this be a float dvision instead?
 		final double s = sampleAverageScale( ctl, width, height, width / meshResolution );
 		final int mipmapLevel = bestMipmapLevel( s );
-		//System.out.println( s +  " " + mipmapLevel );
 		final ImageProcessor ipMipmap = Downsampler.downsampleImageProcessor( impOriginal.ip, mipmapLevel );
-
-		//new ImagePlus( "impOriginal.ip", impOriginal.ip ).show();
-		//new ImagePlus( "ipMipmap", ipMipmap ).show();
 
 		/* create a target */
 		final ImageProcessor tp = ipMipmap.createProcessor( targetImage.getWidth(), targetImage.getHeight() );
@@ -272,11 +266,8 @@ public class Render
 			alphaPixels = ( byte[] )target.outside.getPixels();
 
 		/* convert */
-		//FloatProcessor fp = impOriginal.ip.convertToFloatProcessor();
-		//fp.resetMinAndMax();
-		final double min = 0;//fp.getMin();//patch.getMin();
-		final double max = 255;//fp.getMax();//patch.getMax();
-		//System.out.println( min + ", " + max );
+		final double min = 0;
+		final double max = 255;
 		final double a = 1.0 / ( max - min );
 		final double b = 1.0 / 255.0;
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solver/visualize/VisualizeTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solver/visualize/VisualizeTools.java
@@ -741,6 +741,7 @@ public class VisualizeTools
 		return imp;
 	}
 
+	// TODO: this does not only visualize but also load data; move it somewhere else?
 	public static ImageProcessorWithMasks getUntransformedProcessorWithMasks(final TileSpec tileSpec,
 																			 final ImageProcessorCache imageProcessorCache) {
 		final String tileId = tileSpec.getTileId();


### PR DESCRIPTION
In the spirit of the alternating solver for alignment (see #160), I added a similar solver for intensity correction. It works in exactly the same way as the analogue for alignment, but two changes to the existing code were necessary:
- The rendering method that is used to match intensities between tiles didn't take into account existing intensity filters. It does now. I put this into `Render.render` rather than `VisualizeTools.getUntransformedProcessorWithMasks` to preserve my notion of "untransformed" (meaning also no filters).
- A `LinearIntensityMap8BitFilter` can now absorb a second filter to emulate chaining of linear functions.

### Results
I tested the implementation on one layer of wafer_53 with a 3x3 XY-block layout; see pictures below.
While I can still see some tile boundaries after one run, the results after two runs look qualitatively very close to the baseline (intensity correction without blocks).

- Original layer: ![ng-no-ic](https://github.com/saalfeldlab/render/assets/20970305/6772a0e9-7013-498d-86ed-25dd56d2f696)
- Reference IC (no blocks): ![ng-baseline](https://github.com/saalfeldlab/render/assets/20970305/2b3bc1ea-6ee0-4b8b-ab79-56857e1e19db)
- One run of blocked IC: ![ng-1run](https://github.com/saalfeldlab/render/assets/20970305/ffc24aab-78dc-4618-b873-79f4d85320cc)
- Two consecutive runs of blocked IC: ![ng-2runs](https://github.com/saalfeldlab/render/assets/20970305/a1102e0f-5f94-4296-9c57-def82554f77b)





