### PR TITLE
newsolver alignment pipeline v2

### DIFF
--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
@@ -15,11 +15,12 @@ import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MipmapParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
-import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * @author Eric Trautman
  */
 public class MipmapClient
-        implements Serializable {
+        implements Serializable, AlignmentPipelineStep {
 
     public static class Parameters extends CommandLineParameters {
 
@@ -39,67 +40,77 @@ public class MipmapClient
 
         @ParametersDelegate
         MipmapParameters mipmap = new MipmapParameters();
-
-        /** @return client specific parameters populated from specified alignment pipeline parameters. */
-        public static Parameters fromPipeline(final AlignmentPipelineParameters alignmentPipelineParameters) {
-            final MultiProjectParameters multiProject = alignmentPipelineParameters.getMultiProject();
-            final Parameters derivedParameters = new Parameters();
-            derivedParameters.renderWeb = new RenderWebServiceParameters(multiProject.baseDataUrl,
-                                                                         multiProject.owner,
-                                                                         multiProject.project);
-            derivedParameters.mipmap = alignmentPipelineParameters.getMipmap();
-            derivedParameters.mipmap.setStackIdWithZIfUndefined(multiProject.stackIdWithZ);
-            return derivedParameters;
-        }
     }
 
+    /** Run the client with command line parameters. */
     public static void main(final String[] args) {
         final ClientRunner clientRunner = new ClientRunner(args) {
             @Override
             public void runClient(final String[] args) throws Exception {
-
                 final Parameters parameters = new Parameters();
                 parameters.parse(args);
-
-                final MipmapClient client = new MipmapClient(parameters);
-                client.run();
+                final MipmapClient client = new MipmapClient();
+                client.createContextAndRun(parameters);
             }
         };
         clientRunner.run();
     }
 
-    private final Parameters parameters;
-
-    public MipmapClient(final Parameters parameters) {
-        LOG.info("init: parameters={}", parameters);
-        this.parameters = parameters;
+    /** Empty constructor required for alignment pipeline steps. */
+    public MipmapClient() {
     }
 
-    public void run() throws IOException {
-        final SparkConf conf = new SparkConf().setAppName("MipmapClient");
+    /** Create a spark context and run the client with the specified parameters. */
+    public void createContextAndRun(final Parameters mipmapParameters) throws IOException {
+        final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
         try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
-            final String sparkAppId = sparkContext.getConf().getAppId();
-            LOG.info("run: appId is {}", sparkAppId);
-            runWithContext(sparkContext);
+            LOG.info("createContextAndRun: appId is {}", sparkContext.getConf().getAppId());
+            generateMipmaps(sparkContext, mipmapParameters);
         }
     }
 
-    public void runWithContext(final JavaSparkContext sparkContext)
+    /** Validates the specified pipeline parameters are sufficient. */
+    @Override
+    public void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException {
+        AlignmentPipelineParameters.validateRequiredElementExists("mipmap",
+                                                                  pipelineParameters.getMipmap());
+    }
+
+    /** Run the client as part of an alignment pipeline. */
+    public void runPipelineStep(final JavaSparkContext sparkContext,
+                                final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException, IOException {
+
+        final MultiProjectParameters multiProject = pipelineParameters.getMultiProject();
+        final Parameters clientParameters = new Parameters();
+        clientParameters.renderWeb = new RenderWebServiceParameters(multiProject.baseDataUrl,
+                                                                    multiProject.owner,
+                                                                    multiProject.project);
+        clientParameters.mipmap = pipelineParameters.getMipmap();
+        clientParameters.mipmap.setStackIdWithZIfUndefined(multiProject.stackIdWithZ);
+
+        generateMipmaps(sparkContext, clientParameters);
+    }
+
+    /** Run the client with the specified spark context and parameters. */
+    private void generateMipmaps(final JavaSparkContext sparkContext,
+                                 final Parameters clientParameters)
             throws IOException {
 
-        LOG.info("runWithContext: entry");
+        LOG.info("generateMipmaps: entry, clientParameters={}", clientParameters);
 
-        final RenderDataClient sourceDataClient = parameters.renderWeb.getDataClient();
+        final RenderDataClient sourceDataClient = clientParameters.renderWeb.getDataClient();
 
         final List<StackWithZValues> batchedList =
-                parameters.mipmap.stackIdWithZ.buildListOfStackWithBatchedZ(sourceDataClient);
+                clientParameters.mipmap.stackIdWithZ.buildListOfStackWithBatchedZ(sourceDataClient);
         final JavaRDD<StackWithZValues> rddStackIdWithZValues = sparkContext.parallelize(batchedList);
 
         final Function<StackWithZValues, Integer> mipmapFunction = stackIdWithZ -> {
             LogUtilities.setupExecutorLog4j(stackIdWithZ.toString());
             final org.janelia.render.client.MipmapClient mc =
-                    new org.janelia.render.client.MipmapClient(parameters.renderWeb,
-                                                               parameters.mipmap);
+                    new org.janelia.render.client.MipmapClient(clientParameters.renderWeb,
+                                                               clientParameters.mipmap);
             return mc.processMipmapsForZ(stackIdWithZ.getStackId(),
                                          stackIdWithZ.getFirstZ());
         };
@@ -112,12 +123,12 @@ public class MipmapClient
             total += tileCount;
         }
 
-        LOG.info("run: collected stats");
-        LOG.info("run: generated mipmaps for {} tiles", total);
+        LOG.info("generateMipmaps: collected stats");
+        LOG.info("generateMipmaps: generated mipmaps for {} tiles", total);
 
         final org.janelia.render.client.MipmapClient mc =
-                new org.janelia.render.client.MipmapClient(parameters.renderWeb,
-                                                           parameters.mipmap);
+                new org.janelia.render.client.MipmapClient(clientParameters.renderWeb,
+                                                           clientParameters.mipmap);
         final List<StackId> distinctStackIds = batchedList.stream()
                 .map(StackWithZValues::getStackId)
                 .distinct()
@@ -126,7 +137,7 @@ public class MipmapClient
             mc.updateMipmapPathBuilderForStack(stackId);
         }
 
-        LOG.info("runWithContext: exit");
+        LOG.info("generateMipmaps: exit");
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(MipmapClient.class);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
@@ -15,11 +15,11 @@ import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MipmapParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/ClusterCountClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/ClusterCountClient.java
@@ -16,7 +16,7 @@ import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.TileClusterParameters;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/MultiStagePointMatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/MultiStagePointMatchClient.java
@@ -30,7 +30,7 @@ import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.TilePairClient;
 import org.janelia.render.client.match.InMemoryTilePairClient;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
@@ -16,7 +16,7 @@ import org.janelia.alignment.multisem.StackMFOVWithZValues;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MFOVMontageMatchPatchParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
@@ -16,7 +16,7 @@ import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.UnconnectedCrossMFOVParameters;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
@@ -16,11 +16,12 @@ import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.UnconnectedCrossMFOVParameters;
 import org.janelia.render.client.spark.LogUtilities;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Eric Trautman
  */
 public class UnconnectedCrossMFOVClient
-        implements Serializable {
+        implements Serializable, AlignmentPipelineStep {
 
     public static class Parameters extends CommandLineParameters {
 
@@ -48,64 +49,77 @@ public class UnconnectedCrossMFOVClient
             javaClientParameters.core = core;
             return new org.janelia.render.client.multisem.UnconnectedCrossMFOVClient(javaClientParameters);
         }
-
-        /** @return client specific parameters populated from specified alignment pipeline parameters. */
-        public static Parameters fromPipeline(final AlignmentPipelineParameters alignmentPipelineParameters) {
-            final Parameters derivedParameters = new Parameters();
-            derivedParameters.multiProject = alignmentPipelineParameters.getMultiProject();
-            derivedParameters.core = alignmentPipelineParameters.getUnconnectedCrossMfov();
-            return derivedParameters;
-        }
-
     }
 
+    /** Run the client with command line parameters. */
     public static void main(final String[] args) {
-
         final ClientRunner clientRunner = new ClientRunner(args) {
             @Override
             public void runClient(final String[] args) throws Exception {
-
                 final Parameters parameters = new Parameters();
                 parameters.parse(args);
-
-                final UnconnectedCrossMFOVClient client = new UnconnectedCrossMFOVClient(parameters);
-                client.run();
+                final UnconnectedCrossMFOVClient client = new UnconnectedCrossMFOVClient();
+                client.createContextAndRun(parameters);
             }
         };
         clientRunner.run();
-
     }
 
-    private final Parameters parameters;
-
-    public UnconnectedCrossMFOVClient(final Parameters parameters) throws IllegalArgumentException {
-        LOG.info("init: parameters={}", parameters);
-        this.parameters = parameters;
+    /** Empty constructor required for alignment pipeline steps. */
+    public UnconnectedCrossMFOVClient() throws IllegalArgumentException {
     }
 
-    public void run() throws IOException {
-
-        final SparkConf conf = new SparkConf().setAppName("UnconnectedCrossMFOVClient");
-
+    /** Create a spark context and run the client with the specified parameters. */
+    public void createContextAndRun(final Parameters clientParameters) throws IOException {
+        final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
         try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
-            final String sparkAppId = sparkContext.getConf().getAppId();
-            LOG.info("run: appId is {}", sparkAppId);
+            LOG.info("createContextAndRun: appId is {}", sparkContext.getConf().getAppId());
+            final List<UnconnectedMFOVPairsForStack> unconnectedMFOVsForAllStacks =
+                    findUnconnectedMFOVs(sparkContext, clientParameters);
 
-            final List<UnconnectedMFOVPairsForStack> unconnectedMFOVsForAllStacks = findUnconnectedMFOVs(sparkContext);
-
-            final org.janelia.render.client.multisem.UnconnectedCrossMFOVClient jClient = parameters.buildJavaClient();
+            final org.janelia.render.client.multisem.UnconnectedCrossMFOVClient jClient = clientParameters.buildJavaClient();
             jClient.logOrStoreUnconnectedMFOVPairs(unconnectedMFOVsForAllStacks);
         }
     }
 
-    public List<UnconnectedMFOVPairsForStack> findUnconnectedMFOVs(final JavaSparkContext sparkContext)
+    /** Validates the specified pipeline parameters are sufficient. */
+    @Override
+    public void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException {
+        AlignmentPipelineParameters.validateRequiredElementExists("unconnectedCrossMfov",
+                                                                  pipelineParameters.getUnconnectedCrossMfov());
+    }
+
+    /** Run the client as part of an alignment pipeline. */
+    public void runPipelineStep(final JavaSparkContext sparkContext,
+                                final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException, IOException {
+
+        final Parameters clientParameters = new Parameters();
+        clientParameters.multiProject = pipelineParameters.getMultiProject();
+        clientParameters.core = pipelineParameters.getUnconnectedCrossMfov();
+        final List<UnconnectedMFOVPairsForStack> unconnectedMFOVsForAllStacks =
+                findUnconnectedMFOVs(sparkContext, clientParameters);
+
+        if (! unconnectedMFOVsForAllStacks.isEmpty()) {
+            final String errorMessage =
+                    "found " + unconnectedMFOVsForAllStacks.size() + " stacks with unconnected MFOVs";
+            LOG.error("runPipelineStep: {}: {}", errorMessage, unconnectedMFOVsForAllStacks);
+            throw new IOException(errorMessage);
+        } else {
+            LOG.info("runPipelineStep: all MFOVs in all stacks are connected");
+        }
+    }
+
+    private List<UnconnectedMFOVPairsForStack> findUnconnectedMFOVs(final JavaSparkContext sparkContext,
+                                                                    final Parameters clientParameters)
             throws IOException {
 
         LOG.info("findUnconnectedMFOVs: entry");
 
-        final MultiProjectParameters multiProject = parameters.multiProject;
-        final String baseDataUrl = multiProject.getBaseDataUrl();
-        final List<StackWithZValues> stackWithZValuesList = multiProject.buildListOfStackWithAllZ();
+        final MultiProjectParameters multiProjectParameters = clientParameters.multiProject;
+        final String baseDataUrl = multiProjectParameters.getBaseDataUrl();
+        final List<StackWithZValues> stackWithZValuesList = multiProjectParameters.buildListOfStackWithAllZ();
 
         LOG.info("findUnconnectedMFOVs: distributing tasks for {} stacks", stackWithZValuesList.size());
 
@@ -119,10 +133,10 @@ public class UnconnectedCrossMFOVClient
             final RenderDataClient localDataClient = new RenderDataClient(baseDataUrl,
                                                                           stackId.getOwner(),
                                                                           stackId.getProject());
-            final org.janelia.render.client.multisem.UnconnectedCrossMFOVClient jClient = parameters.buildJavaClient();
+            final org.janelia.render.client.multisem.UnconnectedCrossMFOVClient jClient = clientParameters.buildJavaClient();
 
             return jClient.findUnconnectedMFOVs(stackWithZ,
-                                                multiProject.deriveMatchCollectionNamesFromProject,
+                                                multiProjectParameters.deriveMatchCollectionNamesFromProject,
                                                 localDataClient);
         };
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineClient.java
@@ -1,36 +1,21 @@
 package org.janelia.render.client.spark.pipeline;
 
 import com.beust.jcommander.Parameter;
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.alignment.match.ConnectedTileClusterSummaryForStack;
-import org.janelia.alignment.multisem.UnconnectedMFOVPairsForStack;
-import org.janelia.alignment.spec.stack.StackWithZValues;
-import org.janelia.render.client.ClientRunner;
-import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters.PreAlign;
-import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
-import org.janelia.render.client.parameter.CommandLineParameters;
-import org.janelia.render.client.parameter.MultiProjectParameters;
-import org.janelia.render.client.spark.MipmapClient;
-import org.janelia.render.client.spark.match.ClusterCountClient;
-import org.janelia.render.client.spark.match.CopyMatchClient;
-import org.janelia.render.client.spark.match.MultiStagePointMatchClient;
-import org.janelia.render.client.spark.multisem.MFOVMontageMatchPatchClient;
-import org.janelia.render.client.spark.multisem.UnconnectedCrossMFOVClient;
-import org.janelia.render.client.spark.newsolver.DistributedAffineBlockSolverClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * Spark client for running various alignment stages in one go.
- * Parameters for the alignment stages to run are defined in a JSON file.
+ * Spark client for running an ordered list of alignment steps in one go.
+ * Parameters for the alignment steps are defined in a JSON file.
  *
  * @author Eric Trautman
  */
@@ -45,216 +30,48 @@ public class AlignmentPipelineClient
         public String pipelineJson;
     }
 
+    /** Run the client with command line parameters. */
     public static void main(final String[] args) {
-
         final ClientRunner clientRunner = new ClientRunner(args) {
             @Override
             public void runClient(final String[] args) throws Exception {
-
                 final Parameters parameters = new Parameters();
                 parameters.parse(args);
-
-                LOG.info("runClient: entry, parameters={}", parameters);
-
-                final AlignmentPipelineClient client = new AlignmentPipelineClient(parameters);
-                client.run();
-
+                final AlignmentPipelineClient client = new AlignmentPipelineClient();
+                client.createContextAndRun(parameters);
             }
         };
         clientRunner.run();
-
     }
 
-    private final Parameters parameters;
-
-    private AlignmentPipelineClient(final Parameters parameters) throws IllegalArgumentException {
-        this.parameters = parameters;
+    private AlignmentPipelineClient() {
     }
 
-    public void run() throws IOException {
-
-        final SparkConf conf = new SparkConf().setAppName("AlignmentPipelineClient");
-
+    /** Create a spark context and run the client with the specified parameters. */
+    public void createContextAndRun(final Parameters clientParameters) throws IOException, IllegalArgumentException {
+        final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
         try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
-            final String sparkAppId = sparkContext.getConf().getAppId();
-            LOG.info("run: appId is {}", sparkAppId);
+            LOG.info("createContextAndRun: appId is {}", sparkContext.getConf().getAppId());
             final AlignmentPipelineParameters parsedParameters =
-                    AlignmentPipelineParameters.fromJsonFile(parameters.pipelineJson);
-            runWithContext(sparkContext, parsedParameters);
+                    AlignmentPipelineParameters.fromJsonFile(clientParameters.pipelineJson);
+            runPipeline(sparkContext, parsedParameters);
         }
     }
 
-    public void runWithContext(final JavaSparkContext sparkContext,
-                               final AlignmentPipelineParameters alignmentPipelineParameters)
-            throws IOException, IllegalStateException {
+    private void runPipeline(final JavaSparkContext sparkContext,
+                             final AlignmentPipelineParameters alignmentPipelineParameters)
+            throws IOException, IllegalArgumentException {
 
-        LOG.info("runWithContext: entry, alignmentPipelineParameters={}", alignmentPipelineParameters.toJson());
+        LOG.info("runPipeline: entry, alignmentPipelineParameters={}", alignmentPipelineParameters.toJson());
 
-        if (alignmentPipelineParameters.hasMipmapParameters()) {
-            final MipmapClient.Parameters p =
-                    MipmapClient.Parameters.fromPipeline(alignmentPipelineParameters);
-            final MipmapClient mipmapClient = new MipmapClient(p);
-            mipmapClient.runWithContext(sparkContext);
+        final List<AlignmentPipelineStep> pipelineStepClients = alignmentPipelineParameters.buildStepClients();
+        pipelineStepClients.forEach(stepClient -> stepClient.validatePipelineParameters(alignmentPipelineParameters));
+
+        for (final AlignmentPipelineStep stepClient : pipelineStepClients) {
+            stepClient.runPipelineStep(sparkContext, alignmentPipelineParameters);
         }
 
-        if (alignmentPipelineParameters.hasMatchParameters()) {
-            final MultiStagePointMatchClient.Parameters p =
-                    MultiStagePointMatchClient.Parameters.fromPipeline(alignmentPipelineParameters);
-            final MultiStagePointMatchClient matchClient = new MultiStagePointMatchClient(p);
-            final MultiProjectParameters multiProject = alignmentPipelineParameters.getMultiProject();
-            final List<StackWithZValues> batchedList = multiProject.buildListOfStackWithBatchedZ();
-            matchClient.generatePairsAndMatchesForRunList(sparkContext,
-                                                          batchedList,
-                                                          alignmentPipelineParameters.getMatchRunList());
-        }
-
-        if (alignmentPipelineParameters.hasMfovMontagePatchParameters()) {
-            final MFOVMontageMatchPatchClient.Parameters p =
-                    MFOVMontageMatchPatchClient.Parameters.fromPipeline(alignmentPipelineParameters);
-            final MFOVMontageMatchPatchClient matchPatchClient = new MFOVMontageMatchPatchClient(p);
-            matchPatchClient.patchPairs(sparkContext, alignmentPipelineParameters.getMfovMontagePatch());
-        }
-
-        if (alignmentPipelineParameters.hasUnconnectedCrossMfovParameters()) {
-            final UnconnectedCrossMFOVClient.Parameters p =
-                    UnconnectedCrossMFOVClient.Parameters.fromPipeline(alignmentPipelineParameters);
-            final UnconnectedCrossMFOVClient unconnectedMfovClient = new UnconnectedCrossMFOVClient(p);
-
-            final List<UnconnectedMFOVPairsForStack> unconnectedMFOVsForAllStacks =
-                    unconnectedMfovClient.findUnconnectedMFOVs(sparkContext);
-
-            if (! unconnectedMFOVsForAllStacks.isEmpty()) {
-                final String errorMessage =
-                        "found " + unconnectedMFOVsForAllStacks.size() + " stacks with unconnected MFOVs";
-                LOG.error("runWithContext: {}: {}", errorMessage, unconnectedMFOVsForAllStacks);
-                throw new IllegalStateException(errorMessage);
-            } else {
-                LOG.info("runWithContext: all MFOVs in all stacks are connected");
-            }
-        }
-
-        if (alignmentPipelineParameters.hasTileClusterParameters()) {
-            final ClusterCountClient.Parameters p =
-                    ClusterCountClient.Parameters.fromPipeline(alignmentPipelineParameters);
-            final ClusterCountClient clusterCountClient = new ClusterCountClient(p);
-
-            final List<ConnectedTileClusterSummaryForStack> summaryList =
-                    clusterCountClient.findConnectedClusters(sparkContext);
-
-            final List<String> problemStackSummaryStrings = new ArrayList<>();
-            for (final ConnectedTileClusterSummaryForStack stackSummary : summaryList) {
-                if (stackSummary.hasMultipleClusters() ||
-                    stackSummary.hasUnconnectedTiles() ||
-                    stackSummary.hasTooManyConsecutiveUnconnectedEdges()) {
-                    problemStackSummaryStrings.add(stackSummary.toString());
-                }
-            }
-
-            if (! problemStackSummaryStrings.isEmpty()) {
-                throw new IllegalStateException("The following " + problemStackSummaryStrings.size() +
-                                                " stacks have match connection issues:\n" +
-                                                String.join("\n", problemStackSummaryStrings));
-            }
-        }
-
-        if (alignmentPipelineParameters.hasMatchCopyParameters()) {
-            final CopyMatchClient.Parameters p =
-                    new CopyMatchClient.Parameters(alignmentPipelineParameters.getMultiProject(),
-                                                   alignmentPipelineParameters.getMatchCopy());
-            final CopyMatchClient copyMatchClient = new CopyMatchClient(p);
-            copyMatchClient.copyMatches(sparkContext);
-        }
-
-        if (alignmentPipelineParameters.hasAffineBlockSolverSetup()) {
-            runAffineBlockSolver(sparkContext, alignmentPipelineParameters);
-        }
-
-        LOG.info("runWithContext: exit");
-    }
-
-    private static void runAffineBlockSolver(final JavaSparkContext sparkContext,
-                                             final AlignmentPipelineParameters alignmentPipelineParameters)
-            throws IOException {
-
-        final MultiProjectParameters multiProject = alignmentPipelineParameters.getMultiProject();
-        final List<AffineBlockSolverSetup> setupList = new ArrayList<>();
-        final AffineBlockSolverSetup setup = alignmentPipelineParameters.getAffineBlockSolverSetup();
-        final List<StackWithZValues> stackList = multiProject.buildListOfStackWithAllZ();
-        final int nRuns = setup.alternatingRuns.nRuns;
-
-        // TODO: push StackWithZValues idea into core solver code
-        for (final StackWithZValues stackWithZValues : stackList) {
-            setup.setValuesFromPipeline(multiProject.getBaseDataUrl(),
-                                        stackWithZValues.getStackId());
-            setupList.add(setup.clone());
-        }
-
-        final DistributedAffineBlockSolverClient affineBlockSolverClient = new DistributedAffineBlockSolverClient();
-
-        if (nRuns == 1) {
-
-            affineBlockSolverClient.runWithContext(sparkContext, setupList);
-
-        } else {
-
-            // TODO: handle alternatingRuns for multiple stacks
-            if (stackList.size() > 1) {
-                throw new IllegalArgumentException("alternatingRuns is not supported for multiple stacks");
-            }
-
-            final AffineBlockSolverSetup updatedSetup = setupList.get(0);
-            String sourceStack = updatedSetup.stack;
-            final String originalTargetStack = updatedSetup.targetStack.stack;
-
-            for (int runNumber = 1; runNumber <= nRuns; runNumber++) {
-
-                final String targetStack = getStackName(originalTargetStack, runNumber, nRuns);
-
-                final AffineBlockSolverSetup runSetup = updatedSetup.clone();
-                runSetup.stack = sourceStack;
-                runSetup.targetStack.stack = targetStack;
-                updateParameters(runSetup, runNumber);
-
-                LOG.info("runAffineBlockSolver: run {} of {}, stack={}, targetStack={}, shiftBlocks={}",
-						 runNumber, nRuns, sourceStack, targetStack, runSetup.blockPartition.shiftBlocks);
-
-                affineBlockSolverClient.runWithContext(sparkContext, Collections.singletonList(runSetup));
-
-                if ((! runSetup.alternatingRuns.keepIntermediateStacks) && (runNumber > 1))
-                    cleanUpIntermediateStack(runSetup);
-
-                sourceStack = runSetup.targetStack.stack;
-            }
-        }
-    }
-
-    private static String getStackName(final String name, final int runNumber, final int nTotalRuns) {
-        if (runNumber == nTotalRuns) {
-            return name;
-        } else {
-            return name + "_run" + runNumber;
-        }
-    }
-
-    private static void cleanUpIntermediateStack(final AffineBlockSolverSetup parameters) {
-        final RenderDataClient dataClient = parameters.renderWeb.getDataClient();
-        try {
-            dataClient.deleteStack(parameters.stack, null);
-            LOG.info("cleanUpIntermediateStack: deleted stack {}", parameters.stack);
-        } catch (final IOException e) {
-            LOG.error("cleanUpIntermediateStack: error deleting stack {}", parameters.stack, e);
-        }
-    }
-
-    private static void updateParameters(final AffineBlockSolverSetup parameters, final int runNumber) {
-        // alternate block layout
-        parameters.blockPartition.shiftBlocks = (runNumber % 2 == 1);
-
-        // don't stitch or pre-align after first run
-        if (runNumber > 1) {
-            parameters.stitchFirst = false;
-            parameters.preAlign = PreAlign.NONE;
-        }
+        LOG.info("runPipeline: exit");
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(AlignmentPipelineClient.class);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineClient.java
@@ -10,7 +10,6 @@ import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters.PreAlign;
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
-import org.janelia.render.client.parameter.AlignmentPipelineParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.MipmapClient;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -27,6 +27,7 @@ public class AlignmentPipelineParameters
         implements Serializable {
 
     private final MultiProjectParameters multiProject;
+    private final List<AlignmentPipelineStepId> pipelineSteps;
     private final MipmapParameters mipmap;
     private final List<MatchRunParameters> matchRunList;
     private final MFOVMontageMatchPatchParameters mfovMontagePatch;
@@ -44,10 +45,12 @@ public class AlignmentPipelineParameters
              null,
              null,
              null,
+             null,
              null);
     }
 
     public AlignmentPipelineParameters(final MultiProjectParameters multiProject,
+                                       final List<AlignmentPipelineStepId> pipelineSteps,
                                        final MipmapParameters mipmap,
                                        final List<MatchRunParameters> matchRunList,
                                        final MFOVMontageMatchPatchParameters mfovMontagePatch,
@@ -56,6 +59,7 @@ public class AlignmentPipelineParameters
                                        final MatchCopyParameters matchCopy,
                                        final AffineBlockSolverSetup affineBlockSolverSetup) {
         this.multiProject = multiProject;
+        this.pipelineSteps = pipelineSteps;
         this.mipmap = mipmap;
         this.matchRunList = matchRunList;
         this.mfovMontagePatch = mfovMontagePatch;
@@ -69,60 +73,46 @@ public class AlignmentPipelineParameters
         return multiProject;
     }
 
-    public boolean hasMipmapParameters() {
-        return mipmap != null;
-    }
-
     public MipmapParameters getMipmap() {
         return mipmap;
-    }
-
-    public boolean hasMatchParameters() {
-        return (matchRunList != null) && (! matchRunList.isEmpty());
     }
 
     public List<MatchRunParameters> getMatchRunList() {
         return matchRunList;
     }
 
-    public boolean hasMfovMontagePatchParameters() {
-        return (mfovMontagePatch != null);
-    }
-
     public MFOVMontageMatchPatchParameters getMfovMontagePatch() {
         return mfovMontagePatch;
-    }
-
-    public boolean hasUnconnectedCrossMfovParameters() {
-        return (unconnectedCrossMfov != null);
     }
 
     public UnconnectedCrossMFOVParameters getUnconnectedCrossMfov() {
         return unconnectedCrossMfov;
     }
 
-    public boolean hasTileClusterParameters() {
-        return (tileCluster != null);
-    }
-
     public TileClusterParameters getTileCluster() {
         return tileCluster;
-    }
-
-    public boolean hasMatchCopyParameters() {
-        return (matchCopy != null);
     }
 
     public MatchCopyParameters getMatchCopy() {
         return matchCopy;
     }
 
-    public boolean hasAffineBlockSolverSetup() {
-        return (affineBlockSolverSetup != null);
-    }
-
     public AffineBlockSolverSetup getAffineBlockSolverSetup() {
         return affineBlockSolverSetup;
+    }
+
+    public List<AlignmentPipelineStep> buildStepClients()
+            throws IllegalArgumentException {
+
+        if ((pipelineSteps == null) || pipelineSteps.isEmpty()) {
+            throw new IllegalArgumentException("no pipeline steps defined");
+        }
+
+        validateRequiredElementExists("multiProject", multiProject);
+
+        return pipelineSteps.stream()
+                            .map(AlignmentPipelineStepId::toStepClient)
+                            .collect(java.util.stream.Collectors.toList());
     }
 
     @SuppressWarnings("unused")
@@ -131,6 +121,14 @@ public class AlignmentPipelineParameters
      */
     public String toJson() {
         return JSON_HELPER.toJson(this);
+    }
+
+    public static void validateRequiredElementExists(final String elementName,
+                                                     final Object element)
+            throws IllegalArgumentException {
+        if (element == null) {
+            throw new IllegalArgumentException(elementName + " missing from pipeline parameters");
+        }
     }
 
     public static AlignmentPipelineParameters fromJson(final Reader json) {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client.parameter;
+package org.janelia.render.client.spark.pipeline;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -11,6 +11,12 @@ import org.janelia.alignment.json.JsonUtils;
 import org.janelia.alignment.match.parameters.MatchRunParameters;
 import org.janelia.alignment.util.FileUtil;
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
+import org.janelia.render.client.parameter.MFOVMontageMatchPatchParameters;
+import org.janelia.render.client.parameter.MatchCopyParameters;
+import org.janelia.render.client.parameter.MipmapParameters;
+import org.janelia.render.client.parameter.MultiProjectParameters;
+import org.janelia.render.client.parameter.TileClusterParameters;
+import org.janelia.render.client.parameter.UnconnectedCrossMFOVParameters;
 
 /**
  * Parameters for an alignment pipeline run.

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -101,6 +101,12 @@ public class AlignmentPipelineParameters
         return affineBlockSolverSetup;
     }
 
+    /**
+     * @return a list of clients for each specified pipeline step.
+     *
+     * @throws IllegalArgumentException
+     *   if no steps are defined or if any of the parameters are invalid.
+     */
     public List<AlignmentPipelineStep> buildStepClients()
             throws IllegalArgumentException {
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
@@ -13,8 +13,11 @@ public interface AlignmentPipelineStep {
 
     /**
      * Validates the specified pipeline parameters are sufficient for this step.
+     * This method quietly completes (doing nothing) if the parameters are valid
+     * but will throw an exception it finds a problem.
      *
      * @param  pipelineParameters  parameters to validate.
+     *                             Parameters are simply read and should not be mutated during validation.
      *
      * @throws IllegalArgumentException
      *   if any of the parameters are invalid or missing.

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
@@ -1,0 +1,42 @@
+package org.janelia.render.client.spark.pipeline;
+
+import java.io.IOException;
+
+import org.apache.spark.api.java.JavaSparkContext;
+
+/**
+ * Anything that can be run as part of a Spark alignment pipeline.
+ *
+ * @author Eric Trautman
+ */
+public interface AlignmentPipelineStep {
+
+    /**
+     * Validates the specified pipeline parameters are sufficient for this step.
+     *
+     * @param  pipelineParameters  parameters to validate.
+     *
+     * @throws IllegalArgumentException
+     *   if any of the parameters are invalid or missing.
+     */
+    void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException;
+
+    /**
+     * Runs the pipeline step.
+     *
+     * @param  sparkContext        spark context for the run.
+     * @param  pipelineParameters  validated parameters for entire pipeline
+     *                             (each step implementation knows how to extract its own parameters).
+     *
+     * @throws IllegalArgumentException
+     *   if any of the parameters are invalid.
+     *
+     * @throws IOException
+     *   if the run fails.
+     */
+    void runPipelineStep(final JavaSparkContext sparkContext,
+                         final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException, IOException;
+
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
@@ -1,0 +1,46 @@
+package org.janelia.render.client.spark.pipeline;
+
+import org.janelia.render.client.spark.MipmapClient;
+import org.janelia.render.client.spark.match.ClusterCountClient;
+import org.janelia.render.client.spark.match.CopyMatchClient;
+import org.janelia.render.client.spark.match.MultiStagePointMatchClient;
+import org.janelia.render.client.spark.multisem.MFOVMontageMatchPatchClient;
+import org.janelia.render.client.spark.multisem.UnconnectedCrossMFOVClient;
+import org.janelia.render.client.spark.newsolver.DistributedAffineBlockSolverClient;
+
+/**
+ * Identifier for a step in a spark alignment pipeline with a convenience {@link #toStepClient()} builder.
+ *
+ * @author Eric Trautman
+ */
+public enum AlignmentPipelineStepId {
+
+    GENERATE_MIPMAPS,
+    DERIVE_TILE_MATCHES,
+    PATCH_MFOV_MONTAGE_MATCHES,
+    FIND_UNCONNECTED_MFOVS,
+    FIND_UNCONNECTED_TILES_AND_EDGES,
+    FILTER_MATCHES,
+    ALIGN_TILES;
+
+    public AlignmentPipelineStep toStepClient()
+            throws UnsupportedOperationException {
+        switch (this) {
+            case GENERATE_MIPMAPS:
+                return new MipmapClient();
+            case DERIVE_TILE_MATCHES:
+                return new MultiStagePointMatchClient();
+            case PATCH_MFOV_MONTAGE_MATCHES:
+                return new MFOVMontageMatchPatchClient();
+            case FIND_UNCONNECTED_MFOVS:
+                return new UnconnectedCrossMFOVClient();
+            case FIND_UNCONNECTED_TILES_AND_EDGES:
+                return new ClusterCountClient();
+            case FILTER_MATCHES:
+                return new CopyMatchClient();
+            case ALIGN_TILES:
+                return new DistributedAffineBlockSolverClient();
+        }
+        throw new UnsupportedOperationException("step client not mapped for " + this);
+    }
+}

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client.parameter;
+package org.janelia.render.client.spark.pipeline;
 
 import java.io.StringReader;
 

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
@@ -18,9 +18,6 @@ public class AlignmentPipelineParametersTest {
     public void testAffineBlockSolverSetup()
             throws IOException {
         final AlignmentPipelineParameters pipelineParameters = loadTestParameters();
-
-        Assert.assertNotNull("deserialized parameters are null", pipelineParameters);
-
         final AffineBlockSolverSetup affineBlockSolverSetup = pipelineParameters.getAffineBlockSolverSetup();
         Assert.assertNotNull("affineBlockSolverSetup is null", affineBlockSolverSetup);
 
@@ -35,7 +32,6 @@ public class AlignmentPipelineParametersTest {
     public void testBuildStepClients()
             throws IOException {
         final AlignmentPipelineParameters pipelineParameters = loadTestParameters();
-
         final List<AlignmentPipelineStep> stepClients = pipelineParameters.buildStepClients();
         
         Assert.assertNotNull("stepClients is null", stepClients);
@@ -43,6 +39,9 @@ public class AlignmentPipelineParametersTest {
     }
 
     private AlignmentPipelineParameters loadTestParameters() throws IOException {
-        return AlignmentPipelineParameters.fromJsonFile("src/test/resources/pipeline/msem_alignment_pipeline.json");
+        final AlignmentPipelineParameters pipelineParameters =
+                AlignmentPipelineParameters.fromJsonFile("src/test/resources/pipeline/msem_alignment_pipeline.json");
+        Assert.assertNotNull("deserialized parameters are null", pipelineParameters);
+        return pipelineParameters;
     }
 }

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
@@ -15,10 +15,9 @@ import org.junit.Test;
 public class AlignmentPipelineParametersTest {
 
     @Test
-    public void testJson()
+    public void testAffineBlockSolverSetup()
             throws IOException {
-        final AlignmentPipelineParameters pipelineParameters =
-                AlignmentPipelineParameters.fromJsonFile("src/test/resources/pipeline/msem_alignment_pipeline.json");
+        final AlignmentPipelineParameters pipelineParameters = loadTestParameters();
 
         Assert.assertNotNull("deserialized parameters are null", pipelineParameters);
 
@@ -30,10 +29,20 @@ public class AlignmentPipelineParametersTest {
 
         Assert.assertTrue("incorrect affineBlockSolverSetup.targetStack.completeTargetStack value parsed",
                           affineBlockSolverSetup.targetStack.completeStack);
+    }
+
+    @Test
+    public void testBuildStepClients()
+            throws IOException {
+        final AlignmentPipelineParameters pipelineParameters = loadTestParameters();
 
         final List<AlignmentPipelineStep> stepClients = pipelineParameters.buildStepClients();
+        
         Assert.assertNotNull("stepClients is null", stepClients);
         Assert.assertEquals("incorrect number of stepClients", 7, stepClients.size());
     }
 
+    private AlignmentPipelineParameters loadTestParameters() throws IOException {
+        return AlignmentPipelineParameters.fromJsonFile("src/test/resources/pipeline/msem_alignment_pipeline.json");
+    }
 }

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
@@ -1,6 +1,7 @@
 package org.janelia.render.client.spark.pipeline;
 
-import java.io.StringReader;
+import java.io.IOException;
+import java.util.List;
 
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
 import org.junit.Assert;
@@ -14,9 +15,10 @@ import org.junit.Test;
 public class AlignmentPipelineParametersTest {
 
     @Test
-    public void testJson() {
+    public void testJson()
+            throws IOException {
         final AlignmentPipelineParameters pipelineParameters =
-                AlignmentPipelineParameters.fromJson(new StringReader(PIPELINE_JSON));
+                AlignmentPipelineParameters.fromJsonFile("src/test/resources/pipeline/msem_alignment_pipeline.json");
 
         Assert.assertNotNull("deserialized parameters are null", pipelineParameters);
 
@@ -24,50 +26,14 @@ public class AlignmentPipelineParametersTest {
         Assert.assertNotNull("affineBlockSolverSetup is null", affineBlockSolverSetup);
 
         Assert.assertEquals("incorrect affineBlockSolverSetup.targetStack.stackSuffix value parsed",
-                            "_align_pipe_aa", affineBlockSolverSetup.targetStack.stackSuffix);
+                            "_align_pipe_alt_aa", affineBlockSolverSetup.targetStack.stackSuffix);
 
         Assert.assertTrue("incorrect affineBlockSolverSetup.targetStack.completeTargetStack value parsed",
                           affineBlockSolverSetup.targetStack.completeStack);
+
+        final List<AlignmentPipelineStep> stepClients = pipelineParameters.buildStepClients();
+        Assert.assertNotNull("stepClients is null", stepClients);
+        Assert.assertEquals("incorrect number of stepClients", 7, stepClients.size());
     }
 
-    private static final String PIPELINE_JSON =
-            "{\n" +
-            "  \"multiProject\": {\n" +
-            "    \"baseDataUrl\" : \"http://10.40.3.113:8080/render-ws/v1\",\n" +
-            "    \"owner\" : \"hess_wafer_53\",\n" +
-            "    \"project\" : \"cut_000_to_009\",\n" +
-            "    \"stackIdWithZ\" : {\n" +
-            "      \"allStacksInProject\": false,\n" +
-            "      \"allStacksInAllProjects\": false,\n" +
-            "      \"stackNames\": [\n" +
-            "        \"c000_s095_v01\"\n" +
-            "      ]\n" +
-            "    }\n" +
-            "  },\n" +
-            "  \"affineBlockSolverSetup\": {\n" +
-            "    \"distributedSolve\": {\n" +
-            "      \"threadsWorker\": 2,\n" +
-            "      \"threadsGlobal\": 32\n" +
-            "    },\n" +
-            "    \"targetStack\": {\n" +
-            "      \"stackSuffix\": \"_align_pipe_aa\",\n" +
-            "      \"completeStack\": true\n" +
-            "    },\n" +
-            "    \"matches\": {\n" +
-            "      \"matchCollection\": \"c000_s095_v01_match_agg2\"\n" +
-            "    },\n" +
-            "    \"blockPartition\": {\n" +
-            "      \"sizeX\": 12000,\n" +
-            "      \"sizeY\": 12000\n" +
-            "    },\n" +
-            "    \"blockOptimizer\": {\n" +
-            "      \"lambdasRigid\": [ 1.0, 1.0, 0.9, 0.3, 0.01 ],\n" +
-            "      \"lambdasTranslation\": [ 1.0, 0.0, 0.0, 0.0, 0.0 ],\n" +
-            "      \"lambdasRegularization\": [ 0.0, 0.0, 0.0, 0.0, 0.0 ],\n" +
-            "      \"iterations\": [ 50, 50, 30, 25, 25 ],\n" +
-            "      \"maxPlateauWidth\": [ 25, 25, 15, 10, 10 ]\n" +
-            "    },\n" +
-            "    \"maxNumMatches\": 0\n" +
-            "  }\n" +
-            "}";
 }

--- a/render-ws-spark-client/src/test/resources/pipeline/msem_alignment_pipeline.json
+++ b/render-ws-spark-client/src/test/resources/pipeline/msem_alignment_pipeline.json
@@ -1,0 +1,370 @@
+{
+  "multiProject": {
+    "baseDataUrl" : "http://renderer-dev,int.janelia.org:8080/render-ws/v1",
+    "owner" : "hess_wafer_53",
+    "project" : "cut_000_to_009",
+    "stackIdWithZ" : {
+      "allStacksInProject": true,
+      "allStacksInAllProjects": false,
+      "zValuesPerBatch": 1
+    }
+  },
+  "pipelineSteps": [
+    "GENERATE_MIPMAPS",
+    "DERIVE_TILE_MATCHES",
+    "PATCH_MFOV_MONTAGE_MATCHES",
+    "FIND_UNCONNECTED_MFOVS",
+    "FIND_UNCONNECTED_TILES_AND_EDGES",
+    "FILTER_MATCHES",
+    "ALIGN_TILES"
+  ],
+  "mipmap" : {
+    "rootDirectory" : "/nrs/hess/data/hess_wafer_53/mipmaps",
+    "minLevel" : 1,
+    "maxLevel" : 3,
+    "format" : "tiff",
+    "forceGeneration" : false
+  },
+  "matchRunList": [
+    {
+      "runName": "montageBorderRun",
+      "matchCommon": {
+        "maxPairsPerStackBatch" : 30,
+        "featureStorage": {
+          "maxFeatureSourceCacheGb": 6
+        },
+        "maxPeakCacheGb" : 2
+      },
+      "tilePairDerivationParameters": {
+        "xyNeighborFactor": 0.3,
+        "useRowColPositions": false,
+        "zNeighborDistance": 0,
+        "excludeCornerNeighbors": false,
+        "excludeCompletelyObscuredTiles": false,
+        "excludeSameLayerNeighbors": false,
+        "excludeSameSectionNeighbors": false,
+        "excludePairsInMatchCollection": "pairsFromPriorMontageBorderRuns",
+        "minExistingMatchCount": 0
+      },
+      "matchStageParametersList": [
+        {
+          "stageName": "montageBorderPass1",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.25,
+            "steps": 3
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "SINGLE_SET",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 50.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 25,
+            "matchModelType": "TRANSLATION",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.2,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "featureRenderClip": {
+            "clipHeight": 1300,
+            "clipWidth": 1300
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          }
+        },
+        {
+          "stageName": "montageBorderPass2",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.25,
+            "steps": 3
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "SINGLE_SET",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 20.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 25,
+            "matchModelType": "TRANSLATION",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.3,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "featureRenderClip": {
+            "clipHeight": 1300,
+            "clipWidth": 1300
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          }
+        },
+        {
+          "stageName": "montageBorderPass3",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.25,
+            "steps": 3
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "SINGLE_SET",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 20.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 25,
+            "matchModelType": "TRANSLATION",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.4,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "featureRenderClip": {
+            "clipHeight": 1300,
+            "clipWidth": 1300
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          }
+        }
+      ]
+    },
+    {
+      "runName": "montageRun",
+      "matchCommon": {
+        "maxPairsPerStackBatch" : 30,
+        "featureStorage": {
+          "maxFeatureSourceCacheGb": 6
+        },
+        "maxPeakCacheGb" : 2
+      },
+      "tilePairDerivationParameters": {
+        "xyNeighborFactor": 0.6,
+        "useRowColPositions": false,
+        "zNeighborDistance": 0,
+        "excludeCornerNeighbors": false,
+        "excludeCompletelyObscuredTiles": false,
+        "excludeSameLayerNeighbors": false,
+        "excludeSameSectionNeighbors": false,
+        "excludePairsInMatchCollection": "pairsFromPriorRuns",
+        "minExistingMatchCount": 0
+      },
+      "matchStageParametersList": [
+        {
+          "stageName": "montagePass1",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.25,
+            "steps": 3
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "SINGLE_SET",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 20.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 25,
+            "matchModelType": "TRANSLATION",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.8,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "featureRenderClip": {
+            "clipHeight": 140,
+            "clipWidth": 80
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          }
+        }
+      ]
+    },
+    {
+      "runName": "crossRun",
+      "matchCommon": {
+        "maxPairsPerStackBatch" : 50,
+        "featureStorage": {
+          "maxFeatureSourceCacheGb": 6
+        },
+        "maxPeakCacheGb" : 2
+      },
+      "tilePairDerivationParameters": {
+        "xyNeighborFactor" : 0.1,
+        "useRowColPositions" : false,
+        "zNeighborDistance" : 3,
+        "excludeCornerNeighbors" : false,
+        "excludeCompletelyObscuredTiles" : true,
+        "excludeSameLayerNeighbors" : true,
+        "excludeSameSectionNeighbors" : false,
+        "excludePairsInMatchCollection": "pairsFromPriorRuns",
+        "minExistingMatchCount": 0
+      },
+      "matchStageParametersList": [
+        {
+          "stageName": "crossPass1",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.125,
+            "steps": 5
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "SINGLE_SET",
+            "matchFullScaleCoverageRadius": 150.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 50.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 20,
+            "matchModelType": "RIGID",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.22,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          },
+          "maxNeighborDistance": 3
+        },
+        {
+          "stageName": "crossPass2",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.125,
+            "steps": 5
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "AGGREGATED_CONSENSUS_SETS",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 5.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 0.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 20,
+            "matchModelType": "RIGID",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.4,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          },
+          "maxNeighborDistance": 1
+        },
+        {
+          "stageName": "crossPass3",
+          "featureExtraction": {
+            "fdSize": 4,
+            "maxScale": 1.0,
+            "minScale": 0.125,
+            "steps": 5
+          },
+          "featureMatchDerivation": {
+            "matchFilter": "AGGREGATED_CONSENSUS_SETS",
+            "matchFullScaleCoverageRadius": 300.0,
+            "matchIterations": 1000,
+            "matchMaxEpsilonFullScale": 10.0,
+            "matchMaxTrust": 4.0,
+            "matchMinCoveragePercentage": 0.0,
+            "matchMinInlierRatio": 0.0,
+            "matchMinNumInliers": 10,
+            "matchModelType": "RIGID",
+            "matchRod": 0.92
+          },
+          "featureRender": {
+            "renderScale": 0.4,
+            "renderWithFilter": true,
+            "renderWithoutMask": false
+          },
+          "geometricDescriptorAndMatch": {
+            "gdEnabled": false
+          },
+          "maxNeighborDistance": 1
+        }
+      ]
+    }
+  ],
+  "mfovMontagePatch": {
+    "sameLayerDerivedMatchWeight" : 0.15,
+    "crossLayerDerivedMatchWeight" : 0.1,
+    "secondPassDerivedMatchWeight" : 0.05,
+    "xyNeighborFactor" : 0.6
+  },
+  "unconnectedCrossMfov": {
+    "minPairsForConnection": 6
+  },
+  "matchCopy": {
+    "toCollectionSuffix": "_agg",
+    "removeExisting" : false,
+    "maxMatchesPerPairSame" : 49,
+    "matchAggregationRadiusSame" : 100.0,
+    "maxMatchesPerPairCross" : 99,
+    "matchAggregationRadiusCross" : 100.0
+  },
+  "affineBlockSolverSetup": {
+    "distributedSolve": {
+      "maxAllowedErrorGlobal": 10.0,
+      "maxIterationsGlobal": 1000,
+      "maxPlateauWidthGlobal": 200,
+      "threadsWorker": 2,
+      "threadsGlobal": 44
+    },
+    "targetStack": {
+      "stackSuffix": "_align_pipe_alt_aa",
+      "completeStack": true
+    },
+    "matches": {
+      "matchCollection": "c000_s095_v01_match_agg2"
+    },
+    "blockPartition": {
+      "sizeX": 7000,
+      "sizeY": 6000
+    },
+    "blockOptimizer": {
+      "lambdasRigid": [ 1.0, 1.0, 0.9, 0.3, 0.01 ],
+      "lambdasTranslation": [ 1.0, 0.0, 0.0, 0.0, 0.0 ],
+      "lambdasRegularization": [ 0.0, 0.0, 0.0, 0.0, 0.0 ],
+      "iterations": [ 50, 50, 30, 25, 25 ],
+      "maxPlateauWidth": [ 25, 25, 15, 10, 10 ]
+    },
+    "maxNumMatches": 0,
+    "alternatingRuns": {
+      "nRuns": 4,
+      "keepIntermediateStacks": false
+    }
+  }
+}


### PR DESCRIPTION
I started refactoring the spark alignment pipeline components to simplify future development.  The first draft of the pipeline utilized a JSON configuration file in conjunction with a hard-coded ordering of components.  This draft introduces an AlignmentPipelineStep interface that clarifies what a pipeline step must support and allows step ordering to be specified in the JSON configuration file.  

If/when we are happy with this draft, the plan is to add intensity correction and thickness correction steps to the pipeline.

For review, I recommend starting by looking first at the [AlignmentPipelineStep interface](https://github.com/saalfeldlab/render/blob/ad30a5ed8d9488292da9d38c0bada88755b7f812/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java) and how use of it simplifies the AlignmentPipelineClient.  There is also an [test/example JSON file](https://github.com/saalfeldlab/render/blob/ad30a5ed8d9488292da9d38c0bada88755b7f812/render-ws-spark-client/src/test/resources/pipeline/msem_alignment_pipeline.json) that might be useful. 