### PR TITLE
Restore old solver behavior

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
@@ -17,6 +17,8 @@ public abstract class BlockFactory implements Serializable {
 
 	public abstract WeightFunction createWeightFunction(final BlockData<?, ?> block);
 
+	public abstract MergingStrategy getMergingStrategy();
+
 	protected <M, R, P extends BlockDataSolveParameters<M, R, P>> BlockCollection<M, R, P> blockCollectionFromLayout(
 			final List<Bounds> blockLayout,
 			final ParameterProvider<M, R, P> parameterProvider) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/BlockFactory.java
@@ -11,12 +11,36 @@ import org.janelia.render.client.newsolver.assembly.WeightFunction;
 import org.janelia.render.client.newsolver.blocksolveparameters.BlockDataSolveParameters;
 import org.janelia.render.client.newsolver.setup.BlockPartitionParameters;
 
+/**
+ * Abstract class representing a factory for creating blocks.
+ *
+ * @author Michael Innerberger
+ */
 public abstract class BlockFactory implements Serializable {
+
+	/**
+	 * Define a collection of blocks.
+	 *
+	 * @param blockSolveParameterProvider Provider for block solve parameters.
+	 * @param shiftBlocks Flag indicating whether blocks should be shifted.
+	 * @return A collection of blocks.
+	 */
 	public abstract <M, R, P extends BlockDataSolveParameters<M, R, P>> BlockCollection<M, R, P> defineBlockCollection(
 			final ParameterProvider<M, R, P> blockSolveParameterProvider, final boolean shiftBlocks);
 
+	/**
+	 * Create a weight function for a block.
+	 *
+	 * @param block The block for which the weight function is to be created.
+	 * @return The weight function for the block.
+	 */
 	public abstract WeightFunction createWeightFunction(final BlockData<?, ?> block);
 
+	/**
+	 * Get the strategy for merging blocks.
+	 *
+	 * @return The {@link MergingStrategy}.
+	 */
 	public abstract MergingStrategy getMergingStrategy();
 
 	protected <M, R, P extends BlockDataSolveParameters<M, R, P>> BlockCollection<M, R, P> blockCollectionFromLayout(
@@ -34,6 +58,13 @@ public abstract class BlockFactory implements Serializable {
 
 	protected abstract BlockTileBoundsFilter getBlockTileFilter();
 
+	/**
+	 * Create a block factory from block sizes.
+	 *
+	 * @param range The bounds of the whole stack to be divided
+	 * @param blockPartition The partition parameters for the blocks.
+	 * @return A block factory.
+	 */
 	public static BlockFactory fromBlockSizes(
 			final Bounds range,
 			final BlockPartitionParameters blockPartition)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/MergingStrategy.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/MergingStrategy.java
@@ -1,0 +1,6 @@
+package org.janelia.render.client.newsolver.blockfactories;
+
+public enum MergingStrategy {
+	RANDOM_PICK,
+	LINEAR_BLENDING;
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
@@ -83,6 +83,11 @@ public class XYBlockFactory extends BlockFactory implements Serializable {
 	}
 
 	@Override
+	public MergingStrategy getMergingStrategy() {
+		return MergingStrategy.RANDOM_PICK;
+	}
+
+	@Override
 	public WeightFunction createWeightFunction(final BlockData<?, ?> block) {
 		// the render scale needs to be fairly small so that the entire MFOV area fits into one image
 		// TODO: @minnerbe to consider parameterizing scale (so can be set based upon stack bounds)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYBlockFactory.java
@@ -30,6 +30,16 @@ import org.slf4j.LoggerFactory;
 
 import static org.janelia.render.client.newsolver.blockfactories.BlockLayoutCreator.In;
 
+
+/**
+ * Factory for creating blocks by dividing a stack in x and y.
+ * The blocks created by this factory have a linear weight function based on
+ * the distance from the block center. Blocks should be merged using random
+ * picking and used within an alternating block solve strategy with multiple
+ * steps.
+ *
+ * @author Stephan Preibisch
+ */
 public class XYBlockFactory extends BlockFactory implements Serializable {
 
 	private static final long serialVersionUID = -2022190797935740332L;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYZBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYZBlockFactory.java
@@ -12,6 +12,15 @@ import java.util.stream.Collectors;
 
 import static org.janelia.render.client.newsolver.blockfactories.BlockLayoutCreator.In;
 
+/**
+ * Factory for creating blocks by dividing a stack in x, y, and z.
+ * The blocks created by this factory have a linear weight function based on
+ * the distance from the block center. Blocks should be merged using random
+ * picking and used within an alternating block solve strategy with multiple
+ * steps.
+ *
+ * @author Michael Innerberger
+ */
 public class XYZBlockFactory extends BlockFactory implements Serializable {
 
 	private static final long serialVersionUID = 4436386605961332810L;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYZBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/XYZBlockFactory.java
@@ -67,6 +67,11 @@ public class XYZBlockFactory extends BlockFactory implements Serializable {
 	}
 
 	@Override
+	public MergingStrategy getMergingStrategy() {
+		return MergingStrategy.RANDOM_PICK;
+	}
+
+	@Override
 	public WeightFunction createWeightFunction(final BlockData<?, ?> block) {
 		final WeightFunction xyWeightFunction = new XYBlockFactory.XYDistanceWeightFunction(block, 0.01);
 		final WeightFunction zWeightFunction = new ZBlockFactory.ZDistanceWeightFunction(block, 0.01);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/ZBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/ZBlockFactory.java
@@ -54,6 +54,11 @@ public class ZBlockFactory extends BlockFactory implements Serializable
 	}
 
 	@Override
+	public MergingStrategy getMergingStrategy() {
+		return MergingStrategy.LINEAR_BLENDING;
+	}
+
+	@Override
 	public WeightFunction createWeightFunction(final BlockData<?, ?> block) {
 		return new ZDistanceWeightFunction(block, 0.01);
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/ZBlockFactory.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blockfactories/ZBlockFactory.java
@@ -12,8 +12,17 @@ import org.janelia.render.client.newsolver.blocksolveparameters.BlockDataSolvePa
 
 import static org.janelia.render.client.newsolver.blockfactories.BlockLayoutCreator.In;
 
-public class ZBlockFactory extends BlockFactory implements Serializable
-{
+/**
+ * Factory for creating blocks by dividing a stack in z.
+ * The blocks created by this factory have a linear weight function in z
+ * and can be merged using linear blending. Therefore, this factory should
+ * not be used in alternating block solving, since already one step should
+ * produce a good result.
+ *
+ * @author Stephan Preibisch
+ */
+public class ZBlockFactory extends BlockFactory implements Serializable {
+
 	private static final long serialVersionUID = 4169473785487008894L;
 
 	final int minZ, maxZ, blockSize;


### PR DESCRIPTION
I added a way of restoring the "old" way of alignment and intensity correction, based on the type of partitioning:
- z-partitioning: linearly blend the blocks, one solve is sufficient (old way).
- xy(z)-partitioning: pick random and solve multiple times alternatingly (new way).

The current design based on the `MergingStrategy` enum is somewhat ad hoc. However, I think that in order to introduce this feature more cleanly/naturally, other design issues have to be addressed first. Therefore, I would suggest to postpone implementing a "cleaner" solution to a later general refactoring step.