### PR TITLE
streak extraction filter

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -61,6 +61,15 @@ public class ConfigurableMaskStreakCorrector
         this.regionsToClear = regionsToClear;
     }
 
+    public ConfigurableMaskStreakCorrector(final ConfigurableMaskStreakCorrector corrector) {
+        super(corrector.getNumThreads());
+        this.fftWidth = corrector.fftWidth;
+        this.fftHeight = corrector.fftHeight;
+        this.extraX = corrector.extraX;
+        this.extraY = corrector.extraY;
+        this.regionsToClear = corrector.regionsToClear;
+    }
+
     public Img<FloatType> createMask(final Dimensions dim) {
 
         if (dim.dimension(0) != fftWidth || dim.dimension( 1) != fftHeight) {
@@ -151,8 +160,13 @@ public class ConfigurableMaskStreakCorrector
         final double avg = StreakCorrector.avgIntensity(img);
         LOG.debug("process: average intensity is {}", avg);
 
+        // remove streaking (but it'll introduce a wave pattern)
         final Img<UnsignedByteType> imgCorr = fftBandpassCorrection(img, false);
+
+        // create the wave pattern introduced by the filtering above
         final Img<FloatType> patternCorr = createPattern(imgCorr.dimensionsAsLongArray(), avg);
+
+        // removes the wave pattern from the corrected image
         final RandomAccessibleInterval<UnsignedByteType> fixed =
                 Converters.convertRAI(imgCorr,
                                       patternCorr,

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -43,13 +43,19 @@ public class ConfigurableMaskStreakExtractor
         final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedImagePlus);
 
         // subtract fixed from original to get streaks - has to be FloatType since there may be negative values
-        final RandomAccessibleInterval<FloatType> originalMinusFixed =
+        final RandomAccessibleInterval<FloatType> streaks =
                 Converters.convertRAI(original,
                                       fixed,
                                       (i1,i2,o) -> o.set(i1.get() - i2.get()),
                                       new FloatType());
 
-        final ImagePlus streaksImagePlus = ImageJFunctions.wrapFloat(originalMinusFixed, "streaks");
+        convertStreaksToByteProcessor(streaks, ip);
+    }
+
+    private static void convertStreaksToByteProcessor(final RandomAccessibleInterval<FloatType> streaks,
+                                                      final ImageProcessor ip) {
+
+        final ImagePlus streaksImagePlus = ImageJFunctions.wrapFloat(streaks, "streaks");
         final ImageProcessor streaksFloatImageProcessor = streaksImagePlus.getProcessor();
 
         // reset min and max before converting to byte processor so that streaks are more easily viewed

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -1,0 +1,63 @@
+package org.janelia.alignment.destreak;
+
+import ij.ImagePlus;
+import ij.process.ImageProcessor;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+
+/**
+ * Extension of {@link ConfigurableMaskStreakCorrector} filter that produces an image containing
+ * extracted streaks instead of a de-streaked image.  This implementation was created to support
+ * analysis of Christopher Bleck's tough resin experiments.
+ * The streak extraction process is very slow and involves multiple image copies and conversions,
+ * therefore this filter should primarily be used for distributed client-side processing
+ * (as opposed to using it for dynamic server-side processing).
+ */
+public class ConfigurableMaskStreakExtractor
+        extends ConfigurableMaskStreakCorrector {
+
+    public ConfigurableMaskStreakExtractor() {
+    }
+
+    public ConfigurableMaskStreakExtractor(final ConfigurableMaskStreakCorrector corrector) {
+        super(corrector);
+    }
+
+    @Override
+    public void process(final ImageProcessor ip,
+                        final double scale) {
+
+        // save original image for later subtraction
+        final ImagePlus originalImagePlus = new ImagePlus("original", ip.duplicate());
+        final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalImagePlus);
+
+        // de-streak image
+        super.process(ip, scale);
+
+        final ImagePlus fixedImagePlus = new ImagePlus("fixed", ip);
+        final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedImagePlus);
+
+        // subtract fixed from original to get streaks - has to be FloatType since there may be negative values
+        final RandomAccessibleInterval<FloatType> originalMinusFixed =
+                Converters.convertRAI(original,
+                                      fixed,
+                                      (i1,i2,o) -> o.set(i1.get() - i2.get()),
+                                      new FloatType());
+
+        final ImagePlus streaksImagePlus = ImageJFunctions.wrapFloat(originalMinusFixed, "streaks");
+        final ImageProcessor streaksFloatImageProcessor = streaksImagePlus.getProcessor();
+
+        // reset min and max before converting to byte processor so that streaks are more easily viewed
+        streaksFloatImageProcessor.resetMinAndMax();
+
+        final ImageProcessor streaksImageProcessor = streaksFloatImageProcessor.convertToByteProcessor();
+        for (int i = 0; i < streaksImageProcessor.getPixelCount(); i++) {
+            ip.set(i, streaksImageProcessor.get(i));
+        }
+    }
+}

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -36,6 +36,10 @@ public abstract class StreakCorrector {
         this.numThreads = numThreads;
     }
 
+    public int getNumThreads() {
+        return numThreads;
+    }
+
     public abstract Img<FloatType> createMask(final Dimensions dim );
 
     /**

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -13,7 +13,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
-import net.imglib2.multithreading.SimpleMultiThreading;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
 
@@ -101,7 +100,7 @@ public class ConfigurableStreakCorrectorTest {
 
     // TODO: to simplify clear region derivation, loop through correction process with different extraX|Y values and create scrollable stack from results
 
-    @SuppressWarnings({"ConstantConditions", "deprecation"})
+    @SuppressWarnings({"ConstantConditions"})
     public static void main(final String[] args) {
 
         new ImageJ();
@@ -110,8 +109,6 @@ public class ConfigurableStreakCorrectorTest {
         displayStreakCorrection(toughResinSrcPath,
                                 TOUGH_RESIN_CORRECTOR,
                                 true);
-
-        SimpleMultiThreading.threadHaltUnClean();
     }
 
     public static void displayStreakCorrection(final String srcPath,

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -23,9 +23,11 @@ import net.imglib2.type.numeric.real.FloatType;
  *
  * @author Eric Trautman
  */
+@SuppressWarnings("JavadocLinkAsPlainText")
 public class ConfigurableStreakCorrectorTest {
 
     public static final int[][] Z0422_17_VNC_1_REGIONS_TO_CLEAR = {
+            // x, y, w, h
             {6043, 5459, 113, 3},
             {5960, 5458, 83, 5},
             {5798, 5456, 162, 9},
@@ -43,20 +45,39 @@ public class ConfigurableStreakCorrectorTest {
                                                 6,
                                                 Z0422_17_VNC_1_REGIONS_TO_CLEAR);
 
-    public static final int[][] LEAF_3R_REGIONS_TO_CLEAR = {
-
-    		//{0, 3945, 4971, 28},
-    		{0, 3945, 4503, 28},
-    		{4503, 3953, 452, 15}
+    public static final int[][] TOUGH_RESIN_REGIONS_TO_CLEAR = {
+            // x, y, w, h
+            {0, 5715, 1000, 20},
+            {1000, 5700, 5160, 50}
     };
 
-    public static final ConfigurableMaskStreakCorrector LEAF_3R_CORRECTOR =
+    public static final ConfigurableMaskStreakCorrector TOUGH_RESIN_CORRECTOR =
             new ConfigurableMaskStreakCorrector(8,
-                                                5041,
-                                                7920,
+                                                6161,
+                                                11440,
                                                 0,
                                                 0,
-                                                LEAF_3R_REGIONS_TO_CLEAR);
+                                                TOUGH_RESIN_REGIONS_TO_CLEAR);
+
+    /**
+     * Source images for each imaging experiment were created like this:
+     * <pre>
+     * TILE_ID="23-10-23_084007_0-0-0.2177.0"
+     * PROJECT_URL="http://renderer.int.janelia.org:8080/render-ws/v1/owner/fibsem/project/jrc_tough_resin_RD_part2"
+     * TILE_URL="${PROJECT_URL}/stack/v1_acquire/tile/${TILE_ID}/tiff-image?excludeMask=true&excludeAllTransforms=true"
+     * curl -o src/${TILE_ID}.tif "${TILE_URL}"
+     * </pre>
+     */
+    public static final String[] TOUGH_RESIN_FILE_NAMES = {
+            "23-10-13_000031_0-0-0.213.0.tif",  // 3nA_3p0MHz, region might be a little too tall in y
+            "23-10-14_113315_0-0-0.848.0.tif",  // 3nA_2p0MHz, region might be a little too tall in y
+            "23-10-16_080039_0-0-0.1424.0.tif", // 3nA_1p0MHz, skipped a couple of smaller bands
+            "23-10-19_053141_0-0-0.1881.0.tif", // 3nA_0p5MHz, skipped a couple of smaller bands
+            "23-10-23_084007_0-0-0.2177.0.tif", // 2nA_0p5MHz, skipped a couple of smaller bands
+            "23-10-26_081956_0-0-0.2373.0.tif", // 2nA_1p0MHz, skipped a couple of smaller bands
+            "23-10-30_081056_0-0-0.3003.0.tif", // 2nA_2p0MHz, region might be a little too tall in y
+            "23-11-01_072630_0-0-0.3598.0.tif"  // 2nA_3p0MHz, region might be a little too tall in y
+    };
 
     @Test
     public void testParameterSerializationAndParsing() {
@@ -85,15 +106,25 @@ public class ConfigurableStreakCorrectorTest {
 
         new ImageJ();
 
-        final ImagePlus imp =
-                new ImagePlus("/nrs/stern/em_data/jrc_22ak351-leaf-3r/streaks/leaf-3r-streak-tile.tif" );
+        final String toughResinSrcPath = getToughResinPath(0); // change index to test different images
+        displayStreakCorrection(toughResinSrcPath,
+                                TOUGH_RESIN_CORRECTOR,
+                                true);
+
+        SimpleMultiThreading.threadHaltUnClean();
+    }
+
+    public static void displayStreakCorrection(final String srcPath,
+                                               final ConfigurableMaskStreakCorrector corrector,
+                                               final boolean displayCorrectionData) {
+
+        final ImagePlus imp = new ImagePlus(srcPath);
         imp.setProcessor(imp.getProcessor().convertToByteProcessor());
 
-        final boolean displayCorrectionData = true;
         if (displayCorrectionData) {
 
             // original code from Preibisch that displays correction data
-            final Img<UnsignedByteType> img = ImageJFunctions.wrapByte(imp );
+            final Img<UnsignedByteType> img = ImageJFunctions.wrapByte(imp);
 
             ImageJFunctions.show( img ).setTitle( "input" );
             final double avg = StreakCorrector.avgIntensity(img);
@@ -104,12 +135,10 @@ public class ConfigurableStreakCorrectorTest {
             final boolean showFFTAndBandpass = true;
 
             // remove streaking (but it'll introduce a wave pattern)
-            final Img<UnsignedByteType> imgCorr =
-                    LEAF_3R_CORRECTOR.fftBandpassCorrection(img,
-                                                            showFFTAndBandpass);
+            final Img<UnsignedByteType> imgCorr = corrector.fftBandpassCorrection(img, showFFTAndBandpass);
 
             // create the wave pattern introduced by the filtering above
-            final Img<FloatType> patternCorr = LEAF_3R_CORRECTOR.createPattern(imgCorr.dimensionsAsLongArray(), avg);
+            final Img<FloatType> patternCorr = corrector.createPattern(imgCorr.dimensionsAsLongArray(), avg);
 
             // removes the wave pattern from the corrected image
             final RandomAccessibleInterval<UnsignedByteType> fixed =
@@ -127,11 +156,13 @@ public class ConfigurableStreakCorrectorTest {
         } else {
 
             // simply display fixed result (using same logic copied into process method without correction display)
-            LEAF_3R_CORRECTOR.process(imp.getProcessor(), 1.0);
+            corrector.process(imp.getProcessor(), 1.0);
             imp.show();
 
         }
+    }
 
-        SimpleMultiThreading.threadHaltUnClean();
+    public static String getToughResinPath(final int fileNameIndex) {
+        return "/Users/trautmane/Desktop/bleck-streak/src/" + TOUGH_RESIN_FILE_NAMES[fileNameIndex];
     }
 }

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakExtractorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakExtractorTest.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
-import net.imglib2.multithreading.SimpleMultiThreading;
-
 public class ConfigurableStreakExtractorTest {
 
     @Test
@@ -25,7 +23,7 @@ public class ConfigurableStreakExtractorTest {
         Assert.assertEquals("data strings should match", expectedDataString, actualDataString);
     }
 
-    @SuppressWarnings({"ConstantConditions", "deprecation"})
+    @SuppressWarnings({"ConstantConditions"})
     public static void main(final String[] args) {
 
         new ImageJ();
@@ -41,8 +39,6 @@ public class ConfigurableStreakExtractorTest {
 
         extractor.process(imp.getProcessor(), 1.0);
         imp.show();
-
-        SimpleMultiThreading.threadHaltUnClean();
     }
 
 }

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakExtractorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakExtractorTest.java
@@ -1,0 +1,48 @@
+package org.janelia.alignment.destreak;
+
+import ij.ImageJ;
+import ij.ImagePlus;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.imglib2.multithreading.SimpleMultiThreading;
+
+public class ConfigurableStreakExtractorTest {
+
+    @Test
+    public void testParameterSerialization() {
+        final Map<String, String> parametersMap =
+                ConfigurableStreakCorrectorTest.TOUGH_RESIN_CORRECTOR.toParametersMap();
+
+        final ConfigurableMaskStreakExtractor deserializedExtractor = new ConfigurableMaskStreakExtractor();
+        deserializedExtractor.init(parametersMap);
+
+        final String expectedDataString = ConfigurableStreakCorrectorTest.TOUGH_RESIN_CORRECTOR.toDataString();
+        final String actualDataString = deserializedExtractor.toDataString();
+        Assert.assertEquals("data strings should match", expectedDataString, actualDataString);
+    }
+
+    @SuppressWarnings({"ConstantConditions", "deprecation"})
+    public static void main(final String[] args) {
+
+        new ImageJ();
+
+        // change index to test different images
+        final String srcPath = ConfigurableStreakCorrectorTest.getToughResinPath(1);
+
+        final ConfigurableMaskStreakExtractor extractor =
+                new ConfigurableMaskStreakExtractor(ConfigurableStreakCorrectorTest.TOUGH_RESIN_CORRECTOR);
+
+        final ImagePlus imp = new ImagePlus(srcPath);
+        imp.setProcessor(imp.getProcessor().convertToByteProcessor());
+
+        extractor.process(imp.getProcessor(), 1.0);
+        imp.show();
+
+        SimpleMultiThreading.threadHaltUnClean();
+    }
+
+}


### PR DESCRIPTION
Add streak extraction filter for use in analysis of tough resin FIBSEM experiments.
See https://github.com/JaneliaSciComp/recon_fibsem/issues/57 .