### PR TITLE
Document process for resuming alternating solve runs

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/spec/stack/StackIdNamingGroup.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/stack/StackIdNamingGroup.java
@@ -36,7 +36,7 @@ public class StackIdNamingGroup
     }
 
     public Predicate<String> projectFilter() {
-        return hasProjectPattern() ? (s -> true) : Pattern.compile(projectPattern).asMatchPredicate();
+        return hasProjectPattern() ? Pattern.compile(projectPattern).asMatchPredicate() : (s -> true);
     }
 
     public boolean hasStackPattern() {
@@ -44,7 +44,7 @@ public class StackIdNamingGroup
     }
 
     public Predicate<String> stackFilter() {
-        return hasStackPattern() ? (s -> true) : Pattern.compile(stackPattern).asMatchPredicate();
+        return hasStackPattern() ? Pattern.compile(stackPattern).asMatchPredicate(): (s -> true);
     }
 
     @Override

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
@@ -136,7 +136,7 @@ public class StackIdWithZParameters
         return batchedList;
     }
 
-    private List<StackId> getEligibleStackIds(final RenderDataClient renderDataClient)
+    public List<StackId> getEligibleStackIds(final RenderDataClient renderDataClient)
             throws IOException {
 
         final StackIdNamingGroup defaultGroup = new StackIdNamingGroup(projectPattern, stackPattern);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
@@ -136,7 +136,7 @@ public class StackIdWithZParameters
         return batchedList;
     }
 
-    public List<StackId> getEligibleStackIds(final RenderDataClient renderDataClient)
+    private List<StackId> getEligibleStackIds(final RenderDataClient renderDataClient)
             throws IOException {
 
         final StackIdNamingGroup defaultGroup = new StackIdNamingGroup(projectPattern, stackPattern);

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/parameter/StackIdWithZParametersTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/parameter/StackIdWithZParametersTest.java
@@ -40,34 +40,6 @@ public class StackIdWithZParametersTest {
     private final RenderDataClient mockDataClient = new MockRenderDataClient(owner, projectA, stackIds);
 
     @Test
-    public void testGetEligibleStackIds() throws IOException {
-
-        final StackIdWithZParameters params = new StackIdWithZParameters();
-
-        params.projectPattern = ".*ProjectA$";
-        List<StackId> eligibleStackIds = params.getEligibleStackIds(mockDataClient);
-        Assert.assertEquals("all stacks should be returned with default project pattern",
-                            12, eligibleStackIds.size());
-
-        params.projectPattern = null;
-        params.stackPattern = "stack1.*";
-        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
-        Assert.assertEquals("only default project stacks should be returned with default stack pattern",
-                            6, eligibleStackIds.size());
-
-        params.stackPattern = null;
-        params.setNamingGroup(new StackIdNamingGroup(".*ProjectB$", null));
-        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
-        Assert.assertEquals("all stacks should be returned with naming group project pattern",
-                            12, eligibleStackIds.size());
-
-        params.setNamingGroup(new StackIdNamingGroup(null, "stack2.*"));
-        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
-        Assert.assertEquals("only default project stacks should be returned with naming group stack pattern",
-                            6, eligibleStackIds.size());
-    }
-
-    @Test
     public void testGetStackIdList() throws IOException {
 
         final StackIdWithZParameters params = new StackIdWithZParameters();

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/parameter/StackIdWithZParametersTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/parameter/StackIdWithZParametersTest.java
@@ -1,0 +1,127 @@
+package org.janelia.render.client.parameter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackIdNamingGroup;
+import org.janelia.render.client.RenderDataClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the {@link StackIdWithZParameters} class.
+ *
+ * @author Eric Trautman
+ */
+public class StackIdWithZParametersTest {
+
+    private final String owner = "testOwner";
+    private final String projectA = "testProjectA";
+    private final String projectB = "testProjectB";
+
+    private final List<StackId> stackIds = Arrays.asList(
+            new StackId(owner, projectA, "stack1"),
+            new StackId(owner, projectA, "stack2"),
+            new StackId(owner, projectA, "stack1_align"),
+            new StackId(owner, projectA, "stack2_align"),
+            new StackId(owner, projectA, "stack1_align_ic"),
+            new StackId(owner, projectA, "stack2_align_ic"),
+            new StackId(owner, projectB, "stack1"),
+            new StackId(owner, projectB, "stack2"),
+            new StackId(owner, projectB, "stack1_align"),
+            new StackId(owner, projectB, "stack2_align"),
+            new StackId(owner, projectB, "stack1_align_ic"),
+            new StackId(owner, projectB, "stack2_align_ic")
+    );
+
+    private final RenderDataClient mockDataClient = new MockRenderDataClient(owner, projectA, stackIds);
+
+    @Test
+    public void testGetEligibleStackIds() throws IOException {
+
+        final StackIdWithZParameters params = new StackIdWithZParameters();
+
+        params.projectPattern = ".*ProjectA$";
+        List<StackId> eligibleStackIds = params.getEligibleStackIds(mockDataClient);
+        Assert.assertEquals("all stacks should be returned with default project pattern",
+                            12, eligibleStackIds.size());
+
+        params.projectPattern = null;
+        params.stackPattern = "stack1.*";
+        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
+        Assert.assertEquals("only default project stacks should be returned with default stack pattern",
+                            6, eligibleStackIds.size());
+
+        params.stackPattern = null;
+        params.setNamingGroup(new StackIdNamingGroup(".*ProjectB$", null));
+        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
+        Assert.assertEquals("all stacks should be returned with naming group project pattern",
+                            12, eligibleStackIds.size());
+
+        params.setNamingGroup(new StackIdNamingGroup(null, "stack2.*"));
+        eligibleStackIds = params.getEligibleStackIds(mockDataClient);
+        Assert.assertEquals("only default project stacks should be returned with naming group stack pattern",
+                            6, eligibleStackIds.size());
+    }
+
+    @Test
+    public void testGetStackIdList() throws IOException {
+
+        final StackIdWithZParameters params = new StackIdWithZParameters();
+
+        params.projectPattern = ".*ProjectA$";
+        List<StackId> stackIdList = params.getStackIdList(mockDataClient);
+        Assert.assertEquals("incorrect number of stacks returned for default project pattern",
+                            6, stackIdList.size());
+
+        params.projectPattern = null;
+        params.stackPattern = "stack1.*";
+        stackIdList = params.getStackIdList(mockDataClient);
+        Assert.assertEquals("incorrect number of stacks returned default stack pattern",
+                            3, stackIdList.size());
+
+        params.projectPattern = ".*ProjectA$";
+        params.stackPattern = null;
+        params.setNamingGroup(new StackIdNamingGroup(".*ProjectB$", null));
+        stackIdList = params.getStackIdList(mockDataClient);
+        Assert.assertEquals("incorrect number of stacks returned for naming group project pattern",
+                            6, stackIdList.size());
+
+        final int projectBStackCount = (int) stackIdList.stream()
+                .filter(stackId -> stackId.getProject().equals(projectB)).count();
+        Assert.assertEquals("all stacks should be from project B (naming group should override default)",
+                            6, projectBStackCount);
+    }
+
+    private static class MockRenderDataClient extends RenderDataClient {
+
+        final List<StackId> ownerStackIds;
+
+        public MockRenderDataClient(final String owner,
+                                    final String project,
+                                    final List<StackId> stackIds) {
+            super("notApplicable", owner, project);
+            this.ownerStackIds = stackIds.stream()
+                    .filter(stackId -> stackId.getOwner().equals(owner)).collect(Collectors.toList());
+        }
+
+        @Override
+        public List<StackId> getOwnerStacks() {
+            return ownerStackIds;
+        }
+
+        @Override
+        public List<StackId> getProjectStacks() {
+            return getStackIds(getProject());
+        }
+
+        @Override
+        public List<StackId> getStackIds(final String project) {
+            return ownerStackIds.stream()
+                    .filter(stackId -> stackId.getProject().equals(project)).collect(Collectors.toList());
+        }
+    }
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -97,7 +97,7 @@ public class DistributedAffineBlockSolverClient
         final AffineBlockSolverSetup setup = pipelineParameters.getAffineBlockSolverSetup();
         final List<StackWithZValues> stackList = multiProject.buildListOfStackWithAllZ();
         final int nRuns = setup.alternatingRuns.nRuns;
-        final boolean keepIntermediateStacks = setup.alternatingRuns.keepIntermediateStacks;
+        final boolean cleanUpIntermediateStacks = ! setup.alternatingRuns.keepIntermediateStacks;
 
         final String matchSuffix = pipelineParameters.getMatchCopyToCollectionSuffix();
         for (final StackWithZValues stackWithZValues : stackList) {
@@ -128,7 +128,7 @@ public class DistributedAffineBlockSolverClient
                 affineBlockSolverClient.alignSetupList(sparkContext, setupListForRun);
 
                 // clean-up intermediate stacks for prior runs if requested
-                if (keepIntermediateStacks && (runIndex > 0)) {
+                if (cleanUpIntermediateStacks && (runIndex > 0)) {
                     setupListForRun.forEach(DistributedAffineBlockSolverClient::cleanUpIntermediateStack);
                 }
             }


### PR DESCRIPTION
To conserve compute resources, we would like to first (optimisitcally) solve with a smaller number of alternating runs (e.g. 2) and then have the option to resume the process with additional runs later if necessary.  I initially considered adding naming/suffix parameters to AlternatingRunParaemeters, but realized that things get messy trying to avoid naming conflicts with existing stacks since prior runs may or may not have kept intermediate stacks.  I decided it was easier to leave the current process as-is and handle resumes by specifying the previous aligned stacks as source stacks.  This will produce stacks with ugly aggregated names but it avoids conflicts and the stacks can be renamed later with a script if desired.

To resume a run, you specify the previous aligned result as a "raw" source and set shiftBlocks to true if there were an odd number of prior runs:
```
  "pipelineStackGroups": {
    "raw": {
      "projectPattern": "^cut_000_to_009$",
      "stackPattern": "^c..._s..._v01_align$"   // instead of "^c..._s..._v01$"
    },
    ...
  },
  "pipelineSteps": [
    "ALIGN_TILES"
  ],
  ...
  "affineBlockSolverSetup": {
    ...
    "blockPartition": {
      ...
      "shiftBlocks": false                      // set to true if odd number of prior runs
    },
    "alternatingRuns": {
      "nRuns": 2,
      "keepIntermediateStacks": false
    }
  },

```

Here are what the stack names might look like when resuming a run that had 2 prior runs:
```
first run:
  source: c009_s310_v01 ->
    c009_s310_v01_align_run1
    c009_s310_v01_align_run2 (or c009_s310_v01_align if keepIntermediateStacks false)

resumed run:
  source: c009_s310_v01_align_run2 ->
    c009_s310_v01_align_run2_align_run1
    c009_s310_v01_align_run2_align_run2 (or c009_s310_v01_align_run2_align if keepIntermediateStacks false)
```

Let me know if you think this approach is reasonable or if you think there is a better way.

Although I did not end up adding any code to support resuming alternating runs, I did improve the spark distribute affine solve parallelization and fixed a couple of bugs so there is a little related code to review :).