### PR TITLE
Newsolver move global solve to workers

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -1,6 +1,7 @@
 package org.janelia.render.client.newsolver;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,11 +41,10 @@ import org.slf4j.LoggerFactory;
 
 import static org.janelia.render.client.newsolver.solvers.affine.AlignmentModel.AlignmentModelBuilder;
 
-public class DistributedAffineBlockSolver
+public class DistributedAffineBlockSolver implements Serializable
 {
 	final AffineBlockSolverSetup solverSetup;
 	final RenderSetup renderSetup;
-	BlockCollection<?, AffineModel2D, ? extends FIBSEMAlignmentParameters<?, ?>> col;
 	BlockFactory blockFactory;
 
 	public DistributedAffineBlockSolver(
@@ -297,9 +297,7 @@ public class DistributedAffineBlockSolver
 		this.blockFactory = BlockFactory.fromBlockSizes(renderSetup.getBounds(), solverSetup.blockPartition);
 		
 		// create all blocks
-		final BlockCollection<M, AffineModel2D, FIBSEMAlignmentParameters<M, S>> col = setupBlockCollection(this.blockFactory, blockModel, stitchingModel);
-		this.col = col;
-		return col;
+		return setupBlockCollection(this.blockFactory, blockModel, stitchingModel);
 	}
 
 	protected <M extends Model<M> & Affine2D<M>, S extends Model<S> & Affine2D<S>>

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/RenderSetup.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/RenderSetup.java
@@ -88,7 +88,7 @@ public class RenderSetup
 		}
 
 		final ZFilter zFilter = new ZFilter(layerRange.minZ, layerRange.maxZ, null);
-		final List<SectionData> allSectionDataList = renderDataClient.getStackSectionData(stack, null, null );
+		final List<SectionData> allSectionDataList = renderDataClient.getStackSectionData(stack, null, null);
 
 		runParams.pGroupList = new ArrayList<>(allSectionDataList.size());
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZSpacingParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZSpacingParameters.java
@@ -62,6 +62,13 @@ public class ZSpacingParameters
     public boolean solveExisting;
 
     @Parameter(
+            names = "--skipSolve",
+            description = "Specify to simply derive cross correlation data and skip solve " +
+                          "(will be ignored if --solveExisting is also specified).",
+            arity = 0)
+    public boolean skipSolve;
+
+    @Parameter(
             names = "--optionsJson",
             description = "JSON file containing thickness correction options (omit to use default values)")
     public String optionsJson;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZSpacingParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZSpacingParameters.java
@@ -19,6 +19,9 @@ import org.janelia.thickness.inference.Options;
 public class ZSpacingParameters
         implements Serializable {
 
+    // TODO: refactor this class (and possibly the clients that use it) to separate cross correlation
+    //       from thickness correction since we now use cross correlation independently for quality control
+
     @Parameter(
             names = "--scale",
             description = "Scale to render each layer",

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/zspacing/ZPositionCorrectionClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/zspacing/ZPositionCorrectionClient.java
@@ -203,7 +203,7 @@ public class ZPositionCorrectionClient {
                     if (parameters.poorCorrelationThreshold != null) {
                         client.savePoorCrossCorrelationData(ccData);
                     }
-                    if (parameters.hasBatchInfo()) {
+                    if (parameters.hasBatchInfo() || parameters.zSpacing.skipSolve) {
                         client.saveCrossCorrelationData(ccData);
                     } else {
                         client.estimateAndSaveZCoordinates(ccData);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -276,7 +276,7 @@ public class DistributedAffineBlockSolverClient
             parallelism = Math.max(numberOfWorkerExecutors, 2);
 
             LOG.info("deriveParallelismValues: updated values, threadsGlobal={}, threadsWorker={}, parallelism={}",
-                     driverCores, executorCores, parallelism);
+                     firstSetupSolveParameters.threadsGlobal, firstSetupSolveParameters.threadsWorker, parallelism);
         }
 
         return parallelism;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -254,7 +254,9 @@ public class DistributedAffineBlockSolverClient
             final int executorCores = sparkConf.getInt("spark.executor.cores", 1);
 
             setupList.forEach(setup -> {
-                setup.distributedSolve.threadsGlobal = driverCores;
+                // If only one setup, global solve will be run on driver so set threadsGlobal to driver core count.
+                // Otherwise, global solve is run on executors so set threadsGlobal to executor core count.
+                setup.distributedSolve.threadsGlobal = setupList.size() == 1 ? driverCores : executorCores;
                 setup.distributedSolve.threadsWorker = executorCores;
             });
 


### PR DESCRIPTION
Refactor globallySolveMultipleSetups to run global solves in parallel on spark workers instead of serially on spark driver. This significantly improves processing time for multi-SEM runs that have tens or even hundreds of solves for relatively small similarly sized stacks. Single stack (setup) runs still perform the global solve on the driver to allow you to use/specify different resource sizing for the global solve (e.g. if you have many small blocks - smaller concurrent block solve - but need a big global solve).