### PR TITLE
Make intensity correction faster by downsampling cross layer matches more

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -66,17 +66,16 @@ public class DistributedIntensityCorrectionSolver {
 		if (args.length == 0) {
 			final String[] testArgs = {
 					"--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
-					"--owner", "cellmap",
-					"--project", "jrc_mus_thymus_1",
-					"--stack", "v2_acquire_align",
-					"--targetStack", "v2_acquire_test_intensity_debug13",
-					"--threadsWorker", "1",
-					"--threadsGlobal", "12",
+					"--owner", "hess_wafer_53",
+					"--project", "cut_000_to_009",
+					"--stack", "c009_s310_v01_mfov_08_exact",
+					"--targetStack", "c009_s310_v01_mfov_08_ic_test_new",
+					"--threadsWorker", "2",
+					"--threadsGlobal", "1",
 					"--blockSizeZ", "6",
 					"--completeTargetStack",
 					// for entire stack minZ is 1 and maxZ is 14,503
-					"--zDistance", "0", "--minZ", "1245", "--maxZ", "1246",
-					"--equilibrationWeight", "0.5"
+					"--zDistance", "0", "--minZ", "440", "--maxZ", "441",
 			};
 			cmdLineSetup.parse(testArgs);
 		} else {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -25,6 +25,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final double lambdaTranslation;
 	private final double lambdaIdentity;
 	private final double renderScale;
+	private final double crossLayerRenderScale;
 	private final int numCoefficients;
 	private final ZDistanceParameters zDistance;
 	private final double equilibrationWeight;
@@ -43,6 +44,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.lambda1,
 			 intensityAdjust.lambda2,
 			 intensityAdjust.renderScale,
+			 intensityAdjust.crossLayerRenderScale,
 			 intensityAdjust.numCoefficients,
 			 intensityAdjust.zDistance,
 			 intensityAdjust.equilibrationWeight);
@@ -58,6 +60,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final double lambdaTranslation,
 			final double lambdaIdentity,
 			final double renderScale,
+			final double crossLayerRenderScale,
 			final int numCoefficients,
 			final ZDistanceParameters zDistance,
 			final double equilibrationWeight) {
@@ -68,6 +71,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.lambdaTranslation = lambdaTranslation;
 		this.lambdaIdentity = lambdaIdentity;
 		this.renderScale = renderScale;
+		this.crossLayerRenderScale = crossLayerRenderScale;
 		this.numCoefficients = numCoefficients;
 		this.zDistance = zDistance;
 		this.equilibrationWeight = equilibrationWeight;
@@ -77,6 +81,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public double lambdaTranslation() { return lambdaTranslation; }
 	public double lambdaIdentity() { return lambdaIdentity; }
 	public double renderScale() { return renderScale; }
+	public double crossLayerRenderScale() { return crossLayerRenderScale; }
 	public int numCoefficients() { return numCoefficients; }
 	public ZDistanceParameters zDistance() { return zDistance; }
 	public double equilibrationWeight() { return equilibrationWeight; }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -17,11 +17,8 @@ import mpicbg.models.TranslationModel1D;
 import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.RealInterval;
-import net.imglib2.img.list.ListImg;
-import net.imglib2.img.list.ListRandomAccess;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
-import net.imglib2.util.StopWatch;
 import net.imglib2.util.ValuePair;
 
 import org.janelia.alignment.spec.Bounds;
@@ -151,13 +148,13 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		final ArrayList<Future<?>> matchComputations = new ArrayList<>();
 		final int meshResolution = tiles.isEmpty() ? 64 : (int) tiles.get(0).getMeshCellSize();
 		for (final ValuePair<TileSpec, TileSpec> patchPair : patchPairs) {
-			final Matcher matchJob = new Matcher(patchPair,
-												 coefficientTiles,
-												 filter,
-												 parameters.renderScale(),
-												 parameters.numCoefficients(),
-												 meshResolution,
-												 imageProcessorCache);
+			final IntensityMatcher matchJob = new IntensityMatcher(patchPair,
+																   coefficientTiles,
+																   filter,
+																   parameters.renderScale(),
+																   parameters.numCoefficients(),
+																   meshResolution,
+																   imageProcessorCache);
 			matchComputations.add(exec.submit(matchJob));
 		}
 
@@ -228,7 +225,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return patchPairs;
 	}
 
-	private static RealInterval getBoundingBox(final TileSpec m) {
+	static RealInterval getBoundingBox(final TileSpec m) {
 		final double[] p1min = new double[]{ m.getMinX(), m.getMinY() };
 		final double[] p1max = new double[]{ m.getMaxX(), m.getMaxY() };
 		return new FinalRealInterval(p1min, p1max);
@@ -372,142 +369,4 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(AffineIntensityCorrectionBlockWorker.class);
-
-	static final private class Matcher implements Runnable
-	{
-		//final private Rectangle roi;
-		final private ValuePair<TileSpec, TileSpec> patchPair;
-		final private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles;
-		final private PointMatchFilter filter;
-		final private double scale;
-		final private int numCoefficients;
-		final int meshResolution;
-		final ImageProcessorCache imageProcessorCache;
-
-		public Matcher(
-				final ValuePair<TileSpec, TileSpec> patchPair,
-				final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
-				final PointMatchFilter filter,
-				final double scale,
-				final int numCoefficients,
-				final int meshResolution,
-				final ImageProcessorCache imageProcessorCache)
-		{
-			this.patchPair = patchPair;
-			this.coefficientTiles = coefficientTiles;
-			this.filter = filter;
-			this.scale = scale;
-			this.numCoefficients = numCoefficients;
-			this.meshResolution = meshResolution;
-			this.imageProcessorCache = imageProcessorCache;
-		}
-
-		@Override
-		public void run()
-		{
-			final TileSpec p1 = patchPair.getA();
-			final TileSpec p2 = patchPair.getB();
-
-			final StopWatch stopWatch = StopWatch.createAndStart();
-
-			LOG.info("run: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
-
-			final Rectangle box = computeIntersection(p1, p2);
-			final int w = (int) (box.width * scale + 0.5);
-			final int h = (int) (box.height * scale + 0.5);
-			final int n = w * h;
-
-			final FloatProcessor pixels1 = new FloatProcessor(w, h);
-			final FloatProcessor weights1 = new FloatProcessor(w, h);
-			final ColorProcessor subTiles1 = new ColorProcessor(w, h);
-			final FloatProcessor pixels2 = new FloatProcessor(w, h);
-			final FloatProcessor weights2 = new FloatProcessor(w, h);
-			final ColorProcessor subTiles2 = new ColorProcessor(w, h);
-
-			Render.render(p1, numCoefficients, numCoefficients, pixels1, weights1, subTiles1, box.x, box.y, scale, meshResolution, imageProcessorCache);
-			Render.render(p2, numCoefficients, numCoefficients, pixels2, weights2, subTiles2, box.x, box.y, scale, meshResolution, imageProcessorCache);
-
-			LOG.info("run: generate matrix for pair {} <-> {} and filter", p1.getTileId(), p2.getTileId());
-
-			/*
-			 * generate a matrix of all coefficients in p1 to all
-			 * coefficients in p2 to store matches
-			 */
-			final ArrayList<ArrayList<PointMatch>> list = new ArrayList<>();
-			final int dimSize = numCoefficients * numCoefficients;
-			final int matrixSize = dimSize * dimSize;
-			for (int i = 0; i < matrixSize; ++i) {
-				list.add(new ArrayList<>());
-			}
-
-			final ListImg<ArrayList<PointMatch>> matrix = new ListImg<>(list, dimSize, dimSize);
-			final ListRandomAccess<ArrayList<PointMatch>> ra = matrix.randomAccess();
-
-			/*
-			 * iterate over all pixels and feed matches into the match
-			 * matrix
-			 */
-			int label1, label2 = 0;
-			float weight1 = 0, weight2 = 0;
-			for (int i = 0; i < n; ++i) {
-				// lazily check if it pays to create a match
-				final boolean matchCanContribute = (label1 = subTiles1.get(i)) > 0
-						&& (label2 = subTiles2.get(i)) > 0
-						&& (weight1 = weights1.getf(i)) > 0
-						&& (weight2 = weights2.getf(i)) > 0;
-
-				if (matchCanContribute) {
-					final double p = pixels1.getf(i);
-					final double q = pixels2.getf(i);
-					final PointMatch pq = new PointMatch(new Point(new double[] {p}), new Point(new double[] {q}), weight1 * weight2);
-
-					/* first sub-tile label is 1 */
-					ra.setPosition(label1 - 1, 0);
-					ra.setPosition(label2 - 1, 1);
-					ra.get().add(pq);
-				}
-			}
-
-			/* filter matches */
-			final ArrayList<PointMatch> inliers = new ArrayList<>();
-			for (final ArrayList<PointMatch> candidates : matrix) {
-				inliers.clear();
-				filter.filter(candidates, inliers);
-				candidates.clear();
-				candidates.addAll(inliers);
-			}
-
-			/* connect tiles across patches */
-			final ArrayList<Tile<? extends Affine1D<?>>> p1CoefficientTiles = coefficientTiles.get(p1.getTileId());
-			final ArrayList<Tile<? extends Affine1D<?>>> p2CoefficientTiles = coefficientTiles.get(p2.getTileId());
-			int connectionCount = 0;
-
-			for (int i = 0; i < dimSize; ++i) {
-				final Tile<?> t1 = p1CoefficientTiles.get(i);
-				ra.setPosition(i, 0);
-
-				for (int j = 0; j < dimSize; ++j) {
-					ra.setPosition(j, 1);
-					final ArrayList<PointMatch> matches = ra.get();
-					if (matches.isEmpty())
-						continue;
-
-					final Tile<?> t2 = p2CoefficientTiles.get(j);
-					t1.connect(t2, ra.get());
-					connectionCount++;
-				}
-			}
-
-			stopWatch.stop();
-			LOG.info("run: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
-		}
-
-		private static Rectangle computeIntersection(final TileSpec p1, final TileSpec p2) {
-			final Interval i1 = Intervals.smallestContainingInterval(getBoundingBox(p1));
-			final Rectangle box1 = new Rectangle((int)i1.min(0), (int)i1.min(1), (int)i1.dimension(0), (int)i1.dimension(1));
-			final Interval i2 = Intervals.smallestContainingInterval(getBoundingBox(p2));
-			final Rectangle box2 = new Rectangle((int)i2.min(0), (int)i2.min(1), (int)i2.dimension(0), (int)i2.dimension(1));
-			return box1.intersection(box2);
-		}
-	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -53,7 +53,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	public AffineIntensityCorrectionBlockWorker(
 			final BlockData<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> blockData,
-			final int numThreads) throws IOException {
+			final int numThreads
+	) throws IOException {
 
 		super(blockData, numThreads);
 		parameters = blockData.solveTypeParameters();
@@ -88,7 +89,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return new ArrayList<>(List.of(blockData));
 	}
 
-	private void fetchResolvedTiles() throws IOException {
+	private void fetchResolvedTiles()
+			throws IOException {
 		final Bounds bounds = blockData.getOriginalBounds();
 		final ResolvedTileSpecCollection rtsc = renderDataClient.getResolvedTiles(
 				parameters.stack(),
@@ -100,7 +102,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		blockData.getResults().init(rtsc);
 	}
 
-	private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> computeCoefficients(final List<TileSpec> tiles) throws ExecutionException, InterruptedException {
+	private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> computeCoefficients(final List<TileSpec> tiles)
+			throws ExecutionException, InterruptedException {
 
 		LOG.info("deriveIntensityFilterData: entry");
 		if (tiles.size() < 2) {
@@ -123,7 +126,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> splitIntoCoefficientTiles(
 			final List<TileSpec> tiles,
-			final ImageProcessorCache imageProcessorCache) throws InterruptedException, ExecutionException {
+			final ImageProcessorCache imageProcessorCache
+	) throws InterruptedException, ExecutionException {
 
 		if (tiles == null || tiles.isEmpty()) {
 			LOG.info("splitIntoCoefficientTiles: skipping because there are no tiles");
@@ -172,7 +176,10 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return coefficientTiles;
 	}
 
-	private IntensityMatcher getIntensityMatcher(final List<TileSpec> tiles, final ImageProcessorCache imageProcessorCache) {
+	private IntensityMatcher getIntensityMatcher(
+			final List<TileSpec> tiles,
+			final ImageProcessorCache imageProcessorCache
+	) {
 		final PointMatchFilter filter = new RansacRegressionReduceFilter(new AffineModel1D());
 		final int meshResolution = (int) tiles.get(0).getMeshCellSize();
 		return new IntensityMatcher(filter,
@@ -184,8 +191,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	private  HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> generateCoefficientsTiles(
 			final Collection<TileSpec> patches,
-			final int nGridPoints) {
-
+			final int nGridPoints
+	) {
 		final InterpolatedAffineModel1D<InterpolatedAffineModel1D<AffineModel1D, TranslationModel1D>, IdentityModel> modelTemplate =
 				new InterpolatedAffineModel1D<>(
 						new InterpolatedAffineModel1D<>(
@@ -206,7 +213,8 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	private static ArrayList<ValuePair<TileSpec, TileSpec>> findOverlappingPatches(
 			final List<TileSpec> allPatches,
-			final ZDistanceParameters zDistance) {
+			final ZDistanceParameters zDistance
+	) {
 		// find the images that actually overlap (only for those we can extract intensity PointMatches)
 		final ArrayList<ValuePair<TileSpec, TileSpec>> patchPairs = new ArrayList<>();
 		final Set<TileSpec> unconsideredPatches = new HashSet<>(allPatches);
@@ -230,9 +238,10 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	}
 
 	@SuppressWarnings("SameParameterValue")
-	private void solveForGlobalCoefficients(final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
-											final int iterations) {
-
+	private void solveForGlobalCoefficients(
+			final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
+			final int iterations
+	) {
 		final Tile<? extends Affine1D<?>> equilibrationTile = new Tile<>(new IdentityModel());
 
 		connectTilesWithinPatches(coefficientTiles, equilibrationTile);
@@ -266,8 +275,10 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		LOG.info("solveForGlobalCoefficients: exit, returning intensity coefficients for {} tiles", coefficientTiles.size());
 	}
 
-	private void connectTilesWithinPatches(final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
-										   final Tile<? extends Affine1D<?>> equilibrationTile) {
+	private void connectTilesWithinPatches(
+			final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
+			final Tile<? extends Affine1D<?>> equilibrationTile
+	) {
 		final Collection<TileSpec> allTiles = blockData.rtsc().getTileSpecs();
 		final double equilibrationWeight = blockData.solveTypeParameters().equilibrationWeight();
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -125,6 +125,11 @@ public class AffineIntensityCorrectionBlockWorker<M>
 			final List<TileSpec> tiles,
 			final ImageProcessorCache imageProcessorCache) throws InterruptedException, ExecutionException {
 
+		if (tiles == null || tiles.isEmpty()) {
+			LOG.info("splitIntoCoefficientTiles: skipping because there are no tiles");
+			return new HashMap<>();
+		}
+
 		LOG.info("splitIntoCoefficientTiles: entry, collecting pairs for {} patches with zDistance {}", tiles.size(), parameters.zDistance());
 
 		// generate coefficient tiles for all patches
@@ -169,7 +174,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	private IntensityMatcher getIntensityMatcher(final List<TileSpec> tiles, final ImageProcessorCache imageProcessorCache) {
 		final PointMatchFilter filter = new RansacRegressionReduceFilter(new AffineModel1D());
-		final int meshResolution = tiles.isEmpty() ? 64 : (int) tiles.get(0).getMeshCellSize();
+		final int meshResolution = (int) tiles.get(0).getMeshCellSize();
 		return new IntensityMatcher(filter,
 									parameters.renderScale(),
 									parameters.numCoefficients(),

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -182,11 +182,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	) {
 		final PointMatchFilter filter = new RansacRegressionReduceFilter(new AffineModel1D());
 		final int meshResolution = (int) tiles.get(0).getMeshCellSize();
-		return new IntensityMatcher(filter,
-									parameters.renderScale(),
-									parameters.numCoefficients(),
-									meshResolution,
-									imageProcessorCache);
+		return new IntensityMatcher(filter, parameters, meshResolution, imageProcessorCache);
 	}
 
 	private  HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> generateCoefficientsTiles(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -1,0 +1,161 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
+import mpicbg.models.Affine1D;
+import mpicbg.models.Point;
+import mpicbg.models.PointMatch;
+import mpicbg.models.Tile;
+import net.imglib2.Interval;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.img.list.ListRandomAccess;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.StopWatch;
+import net.imglib2.util.ValuePair;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.util.ImageProcessorCache;
+import org.janelia.render.client.intensityadjust.intensity.PointMatchFilter;
+import org.janelia.render.client.intensityadjust.intensity.Render;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+class IntensityMatcher implements Runnable {
+	//final private Rectangle roi;
+	final private ValuePair<TileSpec, TileSpec> patchPair;
+	final private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles;
+	final private PointMatchFilter filter;
+	final private double scale;
+	final private int numCoefficients;
+	final int meshResolution;
+	final ImageProcessorCache imageProcessorCache;
+
+	public IntensityMatcher(
+			final ValuePair<TileSpec, TileSpec> patchPair,
+			final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
+			final PointMatchFilter filter,
+			final double scale,
+			final int numCoefficients,
+			final int meshResolution,
+			final ImageProcessorCache imageProcessorCache) {
+		this.patchPair = patchPair;
+		this.coefficientTiles = coefficientTiles;
+		this.filter = filter;
+		this.scale = scale;
+		this.numCoefficients = numCoefficients;
+		this.meshResolution = meshResolution;
+		this.imageProcessorCache = imageProcessorCache;
+	}
+
+	@Override
+	public void run() {
+		final TileSpec p1 = patchPair.getA();
+		final TileSpec p2 = patchPair.getB();
+
+		final StopWatch stopWatch = StopWatch.createAndStart();
+
+		LOG.info("run: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
+
+		final Rectangle box = computeIntersection(p1, p2);
+		final int w = (int) (box.width * scale + 0.5);
+		final int h = (int) (box.height * scale + 0.5);
+		final int n = w * h;
+
+		final FloatProcessor pixels1 = new FloatProcessor(w, h);
+		final FloatProcessor weights1 = new FloatProcessor(w, h);
+		final ColorProcessor subTiles1 = new ColorProcessor(w, h);
+		final FloatProcessor pixels2 = new FloatProcessor(w, h);
+		final FloatProcessor weights2 = new FloatProcessor(w, h);
+		final ColorProcessor subTiles2 = new ColorProcessor(w, h);
+
+		Render.render(p1, numCoefficients, numCoefficients, pixels1, weights1, subTiles1, box.x, box.y, scale, meshResolution, imageProcessorCache);
+		Render.render(p2, numCoefficients, numCoefficients, pixels2, weights2, subTiles2, box.x, box.y, scale, meshResolution, imageProcessorCache);
+
+		LOG.info("run: generate matrix for pair {} <-> {} and filter", p1.getTileId(), p2.getTileId());
+
+		/*
+		 * generate a matrix of all coefficients in p1 to all
+		 * coefficients in p2 to store matches
+		 */
+		final ArrayList<ArrayList<PointMatch>> list = new ArrayList<>();
+		final int dimSize = numCoefficients * numCoefficients;
+		final int matrixSize = dimSize * dimSize;
+		for (int i = 0; i < matrixSize; ++i) {
+			list.add(new ArrayList<>());
+		}
+
+		final ListImg<ArrayList<PointMatch>> matrix = new ListImg<>(list, dimSize, dimSize);
+		final ListRandomAccess<ArrayList<PointMatch>> ra = matrix.randomAccess();
+
+		/*
+		 * iterate over all pixels and feed matches into the match
+		 * matrix
+		 */
+		int label1, label2 = 0;
+		float weight1 = 0, weight2 = 0;
+		for (int i = 0; i < n; ++i) {
+			// lazily check if it pays to create a match
+			final boolean matchCanContribute = (label1 = subTiles1.get(i)) > 0
+					&& (label2 = subTiles2.get(i)) > 0
+					&& (weight1 = weights1.getf(i)) > 0
+					&& (weight2 = weights2.getf(i)) > 0;
+
+			if (matchCanContribute) {
+				final double p = pixels1.getf(i);
+				final double q = pixels2.getf(i);
+				final PointMatch pq = new PointMatch(new mpicbg.models.Point(new double[]{p}), new Point(new double[]{q}), weight1 * weight2);
+
+				/* first sub-tile label is 1 */
+				ra.setPosition(label1 - 1, 0);
+				ra.setPosition(label2 - 1, 1);
+				ra.get().add(pq);
+			}
+		}
+
+		/* filter matches */
+		final ArrayList<PointMatch> inliers = new ArrayList<>();
+		for (final ArrayList<PointMatch> candidates : matrix) {
+			inliers.clear();
+			filter.filter(candidates, inliers);
+			candidates.clear();
+			candidates.addAll(inliers);
+		}
+
+		/* connect tiles across patches */
+		final ArrayList<Tile<? extends Affine1D<?>>> p1CoefficientTiles = coefficientTiles.get(p1.getTileId());
+		final ArrayList<Tile<? extends Affine1D<?>>> p2CoefficientTiles = coefficientTiles.get(p2.getTileId());
+		int connectionCount = 0;
+
+		for (int i = 0; i < dimSize; ++i) {
+			final Tile<?> t1 = p1CoefficientTiles.get(i);
+			ra.setPosition(i, 0);
+
+			for (int j = 0; j < dimSize; ++j) {
+				ra.setPosition(j, 1);
+				final ArrayList<PointMatch> matches = ra.get();
+				if (matches.isEmpty())
+					continue;
+
+				final Tile<?> t2 = p2CoefficientTiles.get(j);
+				t1.connect(t2, ra.get());
+				connectionCount++;
+			}
+		}
+
+		stopWatch.stop();
+		LOG.info("run: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
+	}
+
+	private static Rectangle computeIntersection(final TileSpec p1, final TileSpec p2) {
+		final Interval i1 = Intervals.smallestContainingInterval(AffineIntensityCorrectionBlockWorker.getBoundingBox(p1));
+		final Rectangle box1 = new Rectangle((int) i1.min(0), (int) i1.min(1), (int) i1.dimension(0), (int) i1.dimension(1));
+		final Interval i2 = Intervals.smallestContainingInterval(AffineIntensityCorrectionBlockWorker.getBoundingBox(p2));
+		final Rectangle box2 = new Rectangle((int) i2.min(0), (int) i2.min(1), (int) i2.dimension(0), (int) i2.dimension(1));
+		return box1.intersection(box2);
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(IntensityMatcher.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -8,9 +8,7 @@ import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import net.imglib2.img.list.ListImg;
 import net.imglib2.img.list.ListRandomAccess;
-import net.imglib2.util.Pair;
 import net.imglib2.util.StopWatch;
-import net.imglib2.util.ValuePair;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.intensityadjust.intensity.PointMatchFilter;
@@ -18,9 +16,10 @@ import org.janelia.render.client.intensityadjust.intensity.Render;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 class IntensityMatcher {
 	final private PointMatchFilter filter;
@@ -137,7 +136,7 @@ class IntensityMatcher {
 		LOG.info("run: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
 	}
 
-	Pair<String, ArrayList<Double>> computeAverages(final TileSpec tile) {
+	List<Double> computeAverages(final TileSpec tile) {
 
 		final Rectangle box = boundingBox(tile);
 
@@ -166,11 +165,11 @@ class IntensityMatcher {
 			}
 		}
 
-		final ArrayList<Double> result = new ArrayList<>();
+		final List<Double> result = new ArrayList<>(averages.length);
 		for (int i = 0; i < averages.length; ++i)
 			result.add((double) (averages[i] / counts[i]));
 
-		return new ValuePair<>(tile.getTileId(), result);
+		return result;
 	}
 
 	private static Rectangle computeIntersection(final TileSpec p1, final TileSpec p2) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -13,6 +13,7 @@ import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.intensityadjust.intensity.PointMatchFilter;
 import org.janelia.render.client.intensityadjust.intensity.Render;
+import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMIntensityCorrectionParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,13 +31,12 @@ class IntensityMatcher {
 
 	public IntensityMatcher(
 			final PointMatchFilter filter,
-			final double scale,
-			final int numCoefficients,
+			final FIBSEMIntensityCorrectionParameters<?> parameters,
 			final int meshResolution,
 			final ImageProcessorCache imageProcessorCache) {
 		this.filter = filter;
-		this.scale = scale;
-		this.numCoefficients = numCoefficients;
+		this.scale = parameters.renderScale();
+		this.numCoefficients = parameters.numCoefficients();
 		this.meshResolution = meshResolution;
 		this.imageProcessorCache = imageProcessorCache;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -24,7 +24,8 @@ import java.util.List;
 
 class IntensityMatcher {
 	final private PointMatchFilter filter;
-	final private double scale;
+	final private double sameLayerScale;
+	final private double crossLayerScale;
 	final private int numCoefficients;
 	final int meshResolution;
 	final ImageProcessorCache imageProcessorCache;
@@ -35,7 +36,8 @@ class IntensityMatcher {
 			final int meshResolution,
 			final ImageProcessorCache imageProcessorCache) {
 		this.filter = filter;
-		this.scale = parameters.renderScale();
+		this.sameLayerScale = parameters.renderScale();
+		this.crossLayerScale = parameters.crossLayerRenderScale();
 		this.numCoefficients = parameters.numCoefficients();
 		this.meshResolution = meshResolution;
 		this.imageProcessorCache = imageProcessorCache;
@@ -46,6 +48,7 @@ class IntensityMatcher {
 		final StopWatch stopWatch = StopWatch.createAndStart();
 		LOG.info("run: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
 
+		final double scale = (p1.zDistanceFrom(p2) == 0) ? sameLayerScale : crossLayerScale;
 		final Rectangle box = computeIntersection(p1, p2);
 		final int w = (int) (box.width * scale + 0.5);
 		final int h = (int) (box.height * scale + 0.5);
@@ -140,15 +143,15 @@ class IntensityMatcher {
 
 		final Rectangle box = boundingBox(tile);
 
-		final int w = (int) (box.width * scale + 0.5);
-		final int h = (int) (box.height * scale + 0.5);
+		final int w = (int) (box.width * sameLayerScale + 0.5);
+		final int h = (int) (box.height * sameLayerScale + 0.5);
 		final int n = w * h;
 
 		final FloatProcessor pixels = new FloatProcessor(w, h);
 		final FloatProcessor weights = new FloatProcessor(w, h);
 		final ColorProcessor subTiles = new ColorProcessor(w, h);
 
-		Render.render(tile, numCoefficients, numCoefficients, pixels, weights, subTiles, box.x, box.y, scale, meshResolution, imageProcessorCache);
+		Render.render(tile, numCoefficients, numCoefficients, pixels, weights, subTiles, box.x, box.y, sameLayerScale, meshResolution, imageProcessorCache);
 
 		final float[] averages = new float[numCoefficients * numCoefficients];
 		final int[] counts = new int[numCoefficients * numCoefficients];

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -44,7 +44,6 @@ class IntensityMatcher {
 	public void match(final TileSpec p1, final TileSpec p2, final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles) {
 
 		final StopWatch stopWatch = StopWatch.createAndStart();
-		LOG.info("match: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
 
 		final double scale = (p1.zDistanceFrom(p2) == 0) ? sameLayerScale : crossLayerScale;
 		final Rectangle box = computeIntersection(p1, p2);
@@ -62,12 +61,9 @@ class IntensityMatcher {
 		Render.render(p1, numCoefficients, numCoefficients, pixels1, weights1, subTiles1, box.x, box.y, scale, meshResolution, imageProcessorCache);
 		Render.render(p2, numCoefficients, numCoefficients, pixels2, weights2, subTiles2, box.x, box.y, scale, meshResolution, imageProcessorCache);
 
-		LOG.info("match: generate matrix for pair {} <-> {} and filter", p1.getTileId(), p2.getTileId());
-
 		// generate a matrix of all coefficients in p1 to all coefficients in p2 to store matches
 		final int nCoefficientTiles = numCoefficients * numCoefficients;
 		final List<List<PointMatch>> matrix = getPairwiseCoefficientMatrix(nCoefficientTiles);
-
 
 		// iterate over all pixels and feed matches into the match matrix
 		int label1, label2 = 0;
@@ -119,7 +115,7 @@ class IntensityMatcher {
 		}
 
 		stopWatch.stop();
-		LOG.info("match: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
+		LOG.info("match: pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
 	}
 
 	private static List<List<PointMatch>> getPairwiseCoefficientMatrix(final int dimSize) {
@@ -141,7 +137,6 @@ class IntensityMatcher {
 
 	List<Double> computeAverages(final TileSpec tile) {
 
-		LOG.info("computeAverages: entry, tile {}", tile.getTileId());
 		final StopWatch stopWatch = StopWatch.createAndStart();
 		final Rectangle box = boundingBox(tile);
 
@@ -174,7 +169,7 @@ class IntensityMatcher {
 			result.add((double) (averages[i] / counts[i]));
 
 		stopWatch.stop();
-		LOG.info("computeAverages: exit, tile {} took {}", tile.getTileId(), stopWatch);
+		LOG.info("computeAverages: tile {} took {}", tile.getTileId(), stopWatch);
 		return result;
 	}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -85,7 +85,7 @@ class IntensityMatcher {
 				final PointMatch pq = new PointMatch(new Point(new double[]{p}), new Point(new double[]{q}), weight1 * weight2);
 
 				/* first sub-tile label is 1 */
-				final List<PointMatch> matches = get(matrix, label1 - 1, label2 - 1);
+				final List<PointMatch> matches = get(matrix, label1 - 1, label2 - 1, nCoefficientTiles);
 				matches.add(pq);
 			}
 		}
@@ -108,7 +108,7 @@ class IntensityMatcher {
 			final Tile<?> t1 = p1CoefficientTiles.get(i);
 
 			for (int j = 0; j < nCoefficientTiles; ++j) {
-				final List<PointMatch> matches = get(matrix, i, j);
+				final List<PointMatch> matches = get(matrix, i, j, nCoefficientTiles);
 				if (matches.isEmpty())
 					continue;
 
@@ -131,8 +131,8 @@ class IntensityMatcher {
 		return coefficients;
 	}
 
-	private static List<PointMatch> get(final List<List<PointMatch>> matrix, final int i, final int j) {
-		return matrix.get(i * matrix.size() + j);
+	private static List<PointMatch> get(final List<List<PointMatch>> matrix, final int i, final int j, final int size) {
+		return matrix.get(i * size + j);
 	}
 
 	private static int numberOfPixels(final int length, final double scale) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -44,7 +44,7 @@ class IntensityMatcher {
 	public void match(final TileSpec p1, final TileSpec p2, final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles) {
 
 		final StopWatch stopWatch = StopWatch.createAndStart();
-		LOG.info("run: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
+		LOG.info("match: entry, pair {} <-> {}", p1.getTileId(), p2.getTileId());
 
 		final double scale = (p1.zDistanceFrom(p2) == 0) ? sameLayerScale : crossLayerScale;
 		final Rectangle box = computeIntersection(p1, p2);
@@ -62,7 +62,7 @@ class IntensityMatcher {
 		Render.render(p1, numCoefficients, numCoefficients, pixels1, weights1, subTiles1, box.x, box.y, scale, meshResolution, imageProcessorCache);
 		Render.render(p2, numCoefficients, numCoefficients, pixels2, weights2, subTiles2, box.x, box.y, scale, meshResolution, imageProcessorCache);
 
-		LOG.info("run: generate matrix for pair {} <-> {} and filter", p1.getTileId(), p2.getTileId());
+		LOG.info("match: generate matrix for pair {} <-> {} and filter", p1.getTileId(), p2.getTileId());
 
 		// generate a matrix of all coefficients in p1 to all coefficients in p2 to store matches
 		final int nCoefficientTiles = numCoefficients * numCoefficients;
@@ -119,7 +119,7 @@ class IntensityMatcher {
 		}
 
 		stopWatch.stop();
-		LOG.info("run: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
+		LOG.info("match: exit, pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
 	}
 
 	private static List<List<PointMatch>> getPairwiseCoefficientMatrix(final int dimSize) {
@@ -141,6 +141,8 @@ class IntensityMatcher {
 
 	List<Double> computeAverages(final TileSpec tile) {
 
+		LOG.info("computeAverages: entry, tile {}", tile.getTileId());
+		final StopWatch stopWatch = StopWatch.createAndStart();
 		final Rectangle box = boundingBox(tile);
 
 		final int w = numberOfPixels(box.width, sameLayerScale);
@@ -171,6 +173,8 @@ class IntensityMatcher {
 		for (int i = 0; i < averages.length; ++i)
 			result.add((double) (averages[i] / counts[i]));
 
+		stopWatch.stop();
+		LOG.info("computeAverages: exit, tile {} took {}", tile.getTileId(), stopWatch);
 		return result;
 	}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -34,14 +34,19 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 
 	@Parameter(
 			names = { "--maxPixelCacheGb" },
-			description = "Maximum number of gigabytes of pixels to cache"
+			description = "Maximum number of gigabytes of pixels to cache (default: 1Gb)"
 	)
 	public Integer maxPixelCacheGb = 1;
 
 	@Parameter(
 			names = "--renderScale",
-			description = "Scale for rendered tiles used during intensity comparison")
+			description = "Scale for rendered tiles in the same layer used during intensity comparison (default: 0.1)")
 	public double renderScale = 0.1;
+
+	@Parameter(
+			names = "--crossLayerRenderScale",
+			description = "Scale for rendered tiles in different layers used during intensity comparison (default: same as renderScale)")
+	public double crossLayerRenderScale = 0.0;
 
 	@ParametersDelegate
 	public ZDistanceParameters zDistance = new ZDistanceParameters();
@@ -62,6 +67,9 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 
 	public void initDefaultValues() throws IllegalArgumentException {
 		this.zDistance.initDefaultValues();
+		if (crossLayerRenderScale == 0.0) {
+			crossLayerRenderScale = renderScale;
+		}
 	}
 
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -45,8 +45,8 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 
 	@Parameter(
 			names = "--crossLayerRenderScale",
-			description = "Scale for rendered tiles in different layers used during intensity comparison (default: same as renderScale)")
-	public double crossLayerRenderScale = 0.0;
+			description = "Scale for rendered tiles in different layers used during intensity comparison. If not given, the same scale as --renderScale is used.")
+	public Double crossLayerRenderScale = null;
 
 	@ParametersDelegate
 	public ZDistanceParameters zDistance = new ZDistanceParameters();
@@ -67,7 +67,7 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 
 	public void initDefaultValues() throws IllegalArgumentException {
 		this.zDistance.initDefaultValues();
-		if (crossLayerRenderScale == 0.0) {
+		if (crossLayerRenderScale == null) {
 			crossLayerRenderScale = renderScale;
 		}
 	}


### PR DESCRIPTION
I added a parameter to the intensity matching process that allows to specify a different render scale for cross layer matches than for same layer matches. So far, the bottleneck were matches between tiles in the same position but on different layers, since they have a significantly larger overlap (the time was spent in outlier detection since there were a lot of matches).

### Details
This might seem like a big change, but the only novelty was [introducing and handling the additional scale parameter](https://github.com/saalfeldlab/render/commit/e870102af27c82f5273aa2e5877a92564ee49e10). All other changes were made while cleaning up. In particular, I:
- extracted the formerly nested `Matcher` class into its own file and moved the average computation there as well;
- removed unnecessary ImgLib2 calls (some `RealInterval...` for the bounding box of a tile and `ListImage` for the matching process).

For further clean up, we should probably think about making the actual rendering process into a class with state instead of a static `Render.render` method.

### Verification
I tested the new parameter with 2 layers of c009_s310_v01_mfov_08 and `--crossLayerRenderScale 0.02` (as opposed to the default scale `0.1`). [Here](http://renderer.int.janelia.org:8080/ng/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B45306.85546875%2C7255.81005859375%2C440%5D%2C%22crossSectionScale%22:8.780986177504422%2C%22projectionScale%22:32768%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22render://http://renderer.int.janelia.org:8080/hess_wafer_53/cut_000_to_009/c009_s310_v01_mfov_08_ic_test%22%2C%22subsources%22:%7B%22default%22:true%2C%22bounds%22:true%7D%2C%22enableDefaultSubsources%22:false%7D%2C%22tab%22:%22source%22%2C%22name%22:%22c009_s310_v01_mfov_08_ic_test%22%7D%5D%2C%22selectedLayer%22:%7B%22layer%22:%22c009_s310_v01_mfov_08_ic_test%22%7D%2C%22layout%22:%22xy%22%7D) is a neuroglancer view of the two layers, which look good to me.

### Improvement
At scale `0.1`, matching two tiles that partially overlap takes about 150-300ms, while matching tiles that completely overlap takes roughly 1900ms. At scale `0.02`, matching tiles that completely overlap only takes about 200-300ms.
This reduced the runtime from 9:38min (where matching took 6:45min) to 5:00min (where matching took 3:10min). The additional gain in runtime probably comes from the fact that there are fewer matching tile pairs, since the overlap of some tiles across layers is too small to produce matches at scale `0.02`.