### PR TITLE
Sparkify intensity correction

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/FilterSpec.java
@@ -1,21 +1,6 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
 package org.janelia.alignment.filter;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import org.janelia.alignment.json.JsonUtils;
@@ -25,7 +10,7 @@ import org.janelia.alignment.json.JsonUtils;
  *
  * @author Eric Trautman
  */
-public class FilterSpec {
+public class FilterSpec implements Serializable {
 
     private final String className;
     private final Map<String, String> parameters;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderDataClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderDataClient.java
@@ -1015,6 +1015,50 @@ public class RenderDataClient {
 
     /**
      * @param  stack           name of stack.
+     * @param  minZ            minimum z value for all tiles (or null for no minimum).
+     * @param  maxZ            maximum z value for all tiles (or null for no maximum).
+     * @param  groupId         group id for all tiles (or null).
+     * @param  minX            minimum x value for all tiles (or null for no minimum).
+     * @param  maxX            maximum x value for all tiles (or null for no maximum).
+     * @param  minY            minimum y value for all tiles (or null for no minimum).
+     * @param  maxY            maximum y value for all tiles (or null for no maximum).
+     * @param  matchPattern    only return tiles with ids that match this pattern (null for all tiles).
+     * @param  handleNotFound  if true, return empty object when 404 is returned for request instead of just raising exception.
+     *
+     * @return the set of resolved tiles and transforms that match the specified criteria.
+     *
+     * @throws IOException
+     *   if the request fails for any reason.
+     */
+    public ResolvedTileSpecCollection getResolvedTiles(final String stack,
+                                                       final Double minZ,
+                                                       final Double maxZ,
+                                                       final String groupId,
+                                                       final Double minX,
+                                                       final Double maxX,
+                                                       final Double minY,
+                                                       final Double maxY,
+                                                       final String matchPattern,
+                                                       final boolean handleNotFound)
+            throws IOException {
+
+        ResolvedTileSpecCollection result;
+        try {
+            result = getResolvedTiles(stack, minZ, maxZ, groupId, minX, maxX, minY, maxY, matchPattern);
+        } catch (final IOException e) {
+            final String msg = e.getMessage();
+            if (handleNotFound && (msg != null) && msg.contains(EXCEPTION_MSG_PREFIX_FOR_404)) {
+                LOG.info("getResolvedTiles: handling request exception: {}", msg);
+                result = new ResolvedTileSpecCollection(new ArrayList<>(), new ArrayList<>());
+            } else {
+                throw e;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @param  stack           name of stack.
      * @param  bounds          optional bounds values for all tiles (null to exclude bounds).
      * @param  collectionName  name of match collection.
      * @param  groupId         group id for all tiles (or null).

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/AlternatingSolveUtils.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/AlternatingSolveUtils.java
@@ -1,0 +1,57 @@
+package org.janelia.render.client.newsolver;
+
+import java.io.IOException;
+
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters;
+import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Common shared utilities for alternating alignment or intensity correction runs.
+ */
+public class AlternatingSolveUtils {
+
+    /**
+     * Tries to remove the specified stack and simply logs an error if that fails.
+     */
+    public static void cleanUpIntermediateStack(final RenderWebServiceParameters renderWeb,
+                                                final String stack) {
+        final RenderDataClient dataClient = renderWeb.getDataClient();
+        try {
+            dataClient.deleteStack(stack, null);
+            LOG.info("cleanUpIntermediateStack: deleted stack {}", stack);
+        } catch (final IOException e) {
+            LOG.error("cleanUpIntermediateStack: error deleting stack {}", stack, e);
+        }
+    }
+
+    public static String getStackNameForRun(final String name,
+                                            final int runNumber,
+                                            final int nTotalRuns) {
+        return runNumber == nTotalRuns ? name : name + "_run" + runNumber;
+    }
+
+    /**
+     * Update parameters for the next run in an alternating run sequence.
+     *
+     * @param  setupParameters   parameters to update.
+     * @param  currentRunNumber  number of current run (first runNumber is 1).
+     */
+    public static void updateParametersForNextRun(final AffineBlockSolverSetup setupParameters,
+                                                  final int currentRunNumber) {
+        // alternate block layout
+        // first run (runNumber 1) and all other odd number runs should be un-shifted
+        setupParameters.blockPartition.shiftBlocks = (currentRunNumber % 2 == 0);
+
+        // don't stitch or pre-align after first run
+        if (currentRunNumber > 1) {
+            setupParameters.stitchFirst = false;
+            setupParameters.preAlign = FIBSEMAlignmentParameters.PreAlign.NONE;
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlternatingSolveUtils.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,10 +46,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.janelia.render.client.newsolver.DistributedAffineBlockSolver.getRandomIndex;
 
 
-public class DistributedIntensityCorrectionSolver {
+public class DistributedIntensityCorrectionSolver implements Serializable {
 	final IntensityCorrectionSetup solverSetup;
 	final RenderSetup renderSetup;
-	BlockCollection<?, ArrayList<AffineModel1D>, ? extends FIBSEMIntensityCorrectionParameters<?>> blocks;
 	BlockFactory blockFactory;
 
 	public DistributedIntensityCorrectionSolver(
@@ -107,7 +107,7 @@ public class DistributedIntensityCorrectionSolver {
 
 		final ResultContainer<ArrayList<AffineModel1D>> finalizedItems = solver.assembleBlocks(allItems);
 
-		saveResultsAsNeeded(finalizedItems, solver.solverSetup);
+		saveResultsAsNeeded(finalizedItems, cmdLineSetup);
 	}
 
 	public ArrayList<BlockData<ArrayList<AffineModel1D>, ?>> solveBlocksUsingThreadPool(final BlockCollection<?, ArrayList<AffineModel1D>, ?> blockCollection) {
@@ -330,11 +330,7 @@ public class DistributedIntensityCorrectionSolver {
 	public <M> BlockCollection<M, ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> setupSolve() {
 		this.blockFactory = BlockFactory.fromBlockSizes(renderSetup.getBounds(), solverSetup.blockPartition);
 		final FIBSEMIntensityCorrectionParameters<M> defaultSolveParams = getDefaultParameters();
-		final BlockCollection<M, ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> col =
-				blockFactory.defineBlockCollection(() -> defaultSolveParams, solverSetup.blockPartition.shiftBlocks);
-
-		this.blocks = col;
-		return col;
+		return blockFactory.defineBlockCollection(() -> defaultSolveParams, solverSetup.blockPartition.shiftBlocks);
 	}
 
 	protected <M> FIBSEMIntensityCorrectionParameters<M> getDefaultParameters() {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -108,7 +108,7 @@ public class DistributedIntensityCorrectionSolver {
 		LOG.info("solveBlocksUsingThreadPool: entry, threadsGlobal={}", solverSetup.distributedSolve.threadsGlobal);
 
 		final ArrayList<Callable<List<BlockData<ArrayList<AffineModel1D>, ?>>>> workers = new ArrayList<>();
-		blockCollection.allBlocks().forEach(block -> workers.add(() -> createAndRunWorker(block)));
+		blockCollection.allBlocks().forEach(block -> workers.add(() -> createAndRunWorker(block, solverSetup)));
 
 		final ArrayList<BlockData<ArrayList<AffineModel1D>, ?>> allItems = new ArrayList<>();
 		final ExecutorService taskExecutor = Executors.newFixedThreadPool(solverSetup.distributedSolve.threadsGlobal);
@@ -126,7 +126,8 @@ public class DistributedIntensityCorrectionSolver {
 		return allItems;
 	}
 
-	private List<BlockData<ArrayList<AffineModel1D>, ?>> createAndRunWorker(final BlockData<ArrayList<AffineModel1D>, ?> block)
+	public static List<BlockData<ArrayList<AffineModel1D>, ?>> createAndRunWorker(final BlockData<ArrayList<AffineModel1D>, ?> block,
+																				  final IntensityCorrectionSetup solverSetup)
 			throws IOException, ExecutionException, InterruptedException, NoninvertibleModelException {
 
 		final Worker<ArrayList<AffineModel1D>, ?> worker = block.createWorker(solverSetup.distributedSolve.threadsWorker);
@@ -201,7 +202,7 @@ public class DistributedIntensityCorrectionSolver {
 		return fusedModels;
 	}
 
-	// TODO: refactor this to use 1D version of AlingmentModel if and when it exists
+	// TODO: refactor this to use 1D version of AlignmentModel if and when it exists
 	private static ArrayList<AffineModel1D> interpolateModels(final List<ArrayList<AffineModel1D>> tiledModels, final List<Double> weights) {
 		if (tiledModels.isEmpty() || tiledModels.size() != weights.size())
 			throw new IllegalArgumentException("models and weights must be non-empty and of the same size");

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
@@ -3,6 +3,9 @@ package org.janelia.render.client.newsolver.setup;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
+import org.janelia.alignment.json.JsonUtils;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.parameter.AlgorithmicIntensityAdjustParameters;
 import org.janelia.render.client.parameter.AlternatingRunParameters;
 import org.janelia.render.client.parameter.CommandLineParameters;
@@ -58,4 +61,52 @@ public class IntensityCorrectionSetup extends CommandLineParameters {
 
 		this.intensityAdjust.initDefaultValues();
 	}
+
+	/**
+	 * @param  baseDataUrl                            base web service URL for data.
+	 * @param  stackWithZValues                       identifies stack and z layers to align.
+	 *
+	 * @param  deriveMatchCollectionNamesFromProject  indicates whether derived match collection names
+	 *                                                should be derived from the stack's project
+	 *                                                (default is to derive from stack name).
+	 *
+	 * @param  matchSuffix                            suffix to append to derived match collection names
+	 *                                                (specify empty string to omit suffix).
+	 *                                                Suffix is needed when match aggregation is performed
+	 *                                                by an earlier pipeline step.
+	 * @return a clone of this setup populated with the specified parameters.
+	 */
+	public IntensityCorrectionSetup buildPipelineClone(final String baseDataUrl,
+													   final StackWithZValues stackWithZValues,
+													   final boolean deriveMatchCollectionNamesFromProject,
+													   final String matchSuffix) {
+
+		final IntensityCorrectionSetup clone = clone();
+
+		clone.renderWeb.baseDataUrl = baseDataUrl;
+
+		final StackId sourceStackId = stackWithZValues.getStackId();
+		clone.renderWeb.owner = sourceStackId.getOwner();
+		clone.renderWeb.project = sourceStackId.getProject();
+		clone.intensityAdjust.stack = sourceStackId.getStack();
+
+		clone.layerRange.minZ = stackWithZValues.getFirstZ();
+		clone.layerRange.maxZ = stackWithZValues.getLastZ();
+
+		// TODO: should we log a warning and/or abort if the zValues have "holes" and don't cover the entire zRange?
+
+		clone.targetStack.setValuesFromPipeline(sourceStackId, "_ic");
+
+		return clone;
+	}
+
+	/** (Slowly) creates a clone of this setup by serializing it to and from JSON. */
+	@SuppressWarnings("MethodDoesntCallSuperMethod")
+	public IntensityCorrectionSetup clone() {
+		final String json = JSON_HELPER.toJson(this);
+		return JSON_HELPER.fromJson(json);
+	}
+
+	private static final JsonUtils.Helper<IntensityCorrectionSetup> JSON_HELPER =
+			new JsonUtils.Helper<>(IntensityCorrectionSetup.class);
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
@@ -63,23 +63,13 @@ public class IntensityCorrectionSetup extends CommandLineParameters {
 	}
 
 	/**
-	 * @param  baseDataUrl                            base web service URL for data.
-	 * @param  stackWithZValues                       identifies stack and z layers to align.
+	 * @param  baseDataUrl       base web service URL for data.
+	 * @param  stackWithZValues  identifies stack and z layers to align.
 	 *
-	 * @param  deriveMatchCollectionNamesFromProject  indicates whether derived match collection names
-	 *                                                should be derived from the stack's project
-	 *                                                (default is to derive from stack name).
-	 *
-	 * @param  matchSuffix                            suffix to append to derived match collection names
-	 *                                                (specify empty string to omit suffix).
-	 *                                                Suffix is needed when match aggregation is performed
-	 *                                                by an earlier pipeline step.
 	 * @return a clone of this setup populated with the specified parameters.
 	 */
 	public IntensityCorrectionSetup buildPipelineClone(final String baseDataUrl,
-													   final StackWithZValues stackWithZValues,
-													   final boolean deriveMatchCollectionNamesFromProject,
-													   final String matchSuffix) {
+													   final StackWithZValues stackWithZValues) {
 
 		final IntensityCorrectionSetup clone = clone();
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/ADDSolverClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/ADDSolverClient.java
@@ -1,9 +1,8 @@
 package org.janelia.render.client.newsolver.solvers;
 
 import org.janelia.render.client.ClientRunner;
-import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.DistributedAffineBlockSolver;
-import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters.PreAlign;
+import org.janelia.render.client.newsolver.AlternatingSolveUtils;
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,45 +77,18 @@ public class ADDSolverClient {
 		for (int runNumber = 1; runNumber <= nRuns; runNumber++) {
 			LOG.info("solveAlternating: run {} of {}; parameters={}", runNumber, nRuns, parameters);
 
-			parameters.targetStack.stack = getStackName(targetStackName, runNumber, nRuns);
+			parameters.targetStack.stack = AlternatingSolveUtils.getStackNameForRun(targetStackName, runNumber, nRuns);
 			DistributedAffineBlockSolver.run(parameters);
 
-			if ((! parameters.alternatingRuns.keepIntermediateStacks) && (runNumber > 1))
-				cleanUpIntermediateStack(parameters);
+			if ((! parameters.alternatingRuns.keepIntermediateStacks) && (runNumber > 1)) {
+				AlternatingSolveUtils.cleanUpIntermediateStack(parameters.renderWeb, parameters.stack);
+			}
 
-			updateParameters(parameters);
+			AlternatingSolveUtils.updateParametersForNextRun(parameters, runNumber);
+			parameters.stack = parameters.targetStack.stack;
 		}
 	}
 
-	private static String getStackName(final String name, final int runNumber, final int nTotalRuns) {
-		if (runNumber == nTotalRuns) {
-			return name;
-		} else {
-			return name + "_run" + runNumber;
-		}
-	}
-
-	private static void cleanUpIntermediateStack(final AffineBlockSolverSetup parameters) {
-		final RenderDataClient dataClient = parameters.renderWeb.getDataClient();
-		try {
-			dataClient.deleteStack(parameters.stack, null);
-			LOG.info("cleanUpIntermediateStack: deleted stack {}", parameters.stack);
-		} catch (final IOException e) {
-			LOG.error("cleanUpIntermediateStack: error deleting stack {}", parameters.stack, e);
-		}
-	}
-
-	private static void updateParameters(final AffineBlockSolverSetup parameters) {
-		// alternate block layout
-		parameters.blockPartition.shiftBlocks = !parameters.blockPartition.shiftBlocks;
-
-		// get data from previous run
-		parameters.stack = parameters.targetStack.stack;
-
-		// don't stitch or pre-align after first run
-		parameters.stitchFirst = false;
-		parameters.preAlign = PreAlign.NONE;
-	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(ADDSolverClient.class);
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -20,6 +20,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+
+/*
+ * Class for matching the intensity of two tiles. After matching, the tiles are
+ * connected and the matches are filtered. Tiles within the same layer (i.e.,
+ * partially overlapping) can be downscaled differently from tiles in different
+ * layers (i.e., almost completely overlapping).
+ * Also, computation of averages for a tile is done here.
+ *
+ * @author Michael Innerberger
+ */
 class IntensityMatcher {
 	final private PointMatchFilter filter;
 	final private double sameLayerScale;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/StackIdWithZParameters.java
@@ -108,6 +108,11 @@ public class StackIdWithZParameters
         }
         final List<StackWithZValues> batchedList = new ArrayList<>();
         final List<StackId> stackIdList = getStackIdList(renderDataClient);
+
+        if (stackIdList.isEmpty()) {
+            throw new IllegalArgumentException("no stacks match parameters: " + this);
+        }
+
         for (final StackId stackId : stackIdList) {
             final RenderDataClient projectClient = renderDataClient.buildClientForProject(stackId.getProject());
             final List<Double> stackZValues = projectClient.getStackZValues(stackId.getStack(),
@@ -130,10 +135,22 @@ public class StackIdWithZParameters
         }
 
         if (batchedList.isEmpty()) {
-            throw new IllegalArgumentException("no stack z-layers match parameters");
+            throw new IllegalArgumentException("no stack z-layers match parameters: " + this);
         }
 
         return batchedList;
+    }
+
+    @Override
+    public String toString() {
+        return "{projectPattern='" + projectPattern + '\'' +
+               ", stackNames=" + stackNames +
+               ", stackPattern='" + stackPattern + '\'' +
+               ", layerRange=" + layerRange +
+               ", zValues=" + zValues +
+               ", zValuesPerBatch=" + zValuesPerBatch +
+               ", namingGroup=" + namingGroup +
+               '}';
     }
 
     private List<StackId> getEligibleStackIds(final RenderDataClient renderDataClient)

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZRangeParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/ZRangeParameters.java
@@ -42,4 +42,10 @@ public class ZRangeParameters
                           maxZ == null ? defaultBounds.getMaxZ() : Math.min(maxZ, defaultBounds.getMaxZ()));
     }
 
+    @Override
+    public String toString() {
+        return "{minZ=" + minZ +
+               ", maxZ=" + maxZ +
+               '}';
+    }
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/MipmapClient.java
@@ -21,6 +21,7 @@ import org.janelia.render.client.parameter.MipmapParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,11 @@ public class MipmapClient
     }
 
     /** Run the client with the specified spark context and parameters. */
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.GENERATE_MIPMAPS;
+    }
+
     private void generateMipmaps(final JavaSparkContext sparkContext,
                                  final Parameters clientParameters)
             throws IOException {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/intensityadjust/IntensityCorrectionClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/intensityadjust/IntensityCorrectionClient.java
@@ -110,7 +110,7 @@ public class IntensityCorrectionClient
         LOG.info("runWithContext: computed {} blocks", allItems.size());
 
         final ResultContainer<ArrayList<AffineModel1D>> finalizedItems = intensitySolver.assembleBlocks(allItems);
-        intensitySolver.saveResultsAsNeeded(finalizedItems);
+        DistributedIntensityCorrectionSolver.saveResultsAsNeeded(finalizedItems, cmdLineSetup);
 
         LOG.info("runWithContext: exit");
     }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/ClusterCountClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/ClusterCountClient.java
@@ -23,6 +23,7 @@ import org.janelia.render.client.parameter.TileClusterParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,6 +112,11 @@ public class ClusterCountClient
                                   " stacks have match connection issues:\n" +
                                   String.join("\n", problemStackSummaryStrings));
         }
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.FIND_UNCONNECTED_TILES_AND_EDGES;
     }
 
     private List<ConnectedTileClusterSummaryForStack> findConnectedClusters(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/CopyMatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/CopyMatchClient.java
@@ -22,6 +22,7 @@ import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +95,11 @@ public class CopyMatchClient
         final Parameters clientParameters = new Parameters(pipelineParameters.getMultiProject(pipelineParameters.getRawNamingGroup()),
                                                            pipelineParameters.getMatchCopy());
         copyMatches(sparkContext, clientParameters);
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.FILTER_MATCHES;
     }
 
     private void copyMatches(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/MultiStagePointMatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/match/MultiStagePointMatchClient.java
@@ -37,6 +37,7 @@ import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,6 +112,11 @@ public class MultiStagePointMatchClient
                                           multiProjectParameters,
                                           batchedList,
                                           pipelineParameters.getMatchRunList());
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.DERIVE_TILE_MATCHES;
     }
 
     private void generatePairsAndMatchesForRunList(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
@@ -22,6 +22,7 @@ import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +93,11 @@ public class MFOVMontageMatchPatchClient
                    pipelineParameters.getMfovMontagePatch());
     }
 
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.PATCH_MFOV_MONTAGE_MATCHES;
+    }
 
     private void patchPairs(final JavaSparkContext sparkContext,
                             final MultiProjectParameters multiProjectParameters,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/UnconnectedCrossMFOVClient.java
@@ -22,6 +22,7 @@ import org.janelia.render.client.parameter.UnconnectedCrossMFOVParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +110,11 @@ public class UnconnectedCrossMFOVClient
         } else {
             LOG.info("runPipelineStep: all MFOVs in all stacks are connected");
         }
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.FIND_UNCONNECTED_MFOVS;
     }
 
     private List<UnconnectedMFOVPairsForStack> findUnconnectedMFOVs(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -32,6 +32,7 @@ import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +139,11 @@ public class DistributedAffineBlockSolverClient
 
         }
 
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.ALIGN_TILES;
     }
 
     @Nonnull

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -42,7 +42,7 @@ import scala.Tuple2;
  * Spark client for running a DistributedAffineBlockSolve.
  */
 public class DistributedAffineBlockSolverClient
-        extends DistributedAlternatingDomainDecompositionSolver implements Serializable, AlignmentPipelineStep {
+        implements Serializable, AlignmentPipelineStep {
 
     /**
      * Run the client with command line parameters.
@@ -131,7 +131,8 @@ public class DistributedAffineBlockSolverClient
 
                 // clean-up intermediate stacks for prior runs if requested
                 if (cleanUpIntermediateStacks && (runIndex > 0)) {
-                    setupListForRun.forEach(item -> cleanUpIntermediateStack(item.renderWeb, item.stack));
+                    setupListForRun.forEach(s -> DistributedSolveUtils.cleanUpIntermediateStack(s.renderWeb,
+                                                                                                s.stack));
                 }
             }
 
@@ -157,7 +158,9 @@ public class DistributedAffineBlockSolverClient
 
                 final AffineBlockSolverSetup runSetup = updatedSetup.clone();
                 runSetup.stack = runSourceStack;
-                runSetup.targetStack.stack = getStackName(originalTargetStack, runNumber, nRuns);
+                runSetup.targetStack.stack = DistributedSolveUtils.getStackNameForRun(originalTargetStack,
+                                                                                      runNumber,
+                                                                                      nRuns);
                 updateParameters(runSetup, runNumber);
 
                 setupListForRun.add(runSetup);
@@ -181,7 +184,7 @@ public class DistributedAffineBlockSolverClient
         final List<DistributedSolveParameters> solveParameters = setupList.stream()
                 .map(setup -> setup.distributedSolve)
                 .collect(Collectors.toList());
-        final int parallelism = deriveParallelismValues(sparkContext, solveParameters);
+        final int parallelism = DistributedSolveUtils.deriveParallelismValues(sparkContext, solveParameters);
 
         final List<DistributedAffineBlockSolver> solverList = new ArrayList<>();
         final List<Tuple2<Integer, BlockData<AffineModel2D, ?>>> inputBlocksWithSetupIndexes = new ArrayList<>();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -206,14 +206,6 @@ public class DistributedAffineBlockSolverClient
 
     // TODO: these methods are very close to those in ADDSolverClient, need to refactor to reuse as much as possible
 
-    private static String getStackName(final String name, final int runNumber, final int nTotalRuns) {
-        if (runNumber == nTotalRuns) {
-            return name;
-        } else {
-            return name + "_run" + runNumber;
-        }
-    }
-
     private static void updateParameters(final AffineBlockSolverSetup parameters, final int runNumber) {
         // alternate block layout
         parameters.blockPartition.shiftBlocks = (runNumber % 2 == 1);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAffineBlockSolverClient.java
@@ -21,7 +21,6 @@ import org.apache.spark.storage.StorageLevel;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
-import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.BlockCollection;
 import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.DistributedAffineBlockSolver;
@@ -132,7 +131,7 @@ public class DistributedAffineBlockSolverClient
 
                 // clean-up intermediate stacks for prior runs if requested
                 if (cleanUpIntermediateStacks && (runIndex > 0)) {
-                    setupListForRun.forEach(DistributedAffineBlockSolverClient::cleanUpIntermediateStack);
+                    setupListForRun.forEach(item -> cleanUpIntermediateStack(item.renderWeb, item.stack));
                 }
             }
 
@@ -212,16 +211,6 @@ public class DistributedAffineBlockSolverClient
             return name;
         } else {
             return name + "_run" + runNumber;
-        }
-    }
-
-    private static void cleanUpIntermediateStack(final AffineBlockSolverSetup parameters) {
-        final RenderDataClient dataClient = parameters.renderWeb.getDataClient();
-        try {
-            dataClient.deleteStack(parameters.stack, null);
-            LOG.info("cleanUpIntermediateStack: deleted stack {}", parameters.stack);
-        } catch (final IOException e) {
-            LOG.error("cleanUpIntermediateStack: error deleting stack {}", parameters.stack, e);
         }
     }
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
@@ -74,4 +74,12 @@ public abstract class DistributedAlternatingDomainDecompositionSolver {
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(DistributedAlternatingDomainDecompositionSolver.class);
+
+	protected static String getStackName(final String name, final int runNumber, final int nTotalRuns) {
+		if (runNumber == nTotalRuns) {
+			return name;
+		} else {
+			return name + "_run" + runNumber;
+		}
+	}
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
@@ -2,10 +2,13 @@ package org.janelia.render.client.spark.newsolver;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 public abstract class DistributedAlternatingDomainDecompositionSolver {
@@ -58,6 +61,16 @@ public abstract class DistributedAlternatingDomainDecompositionSolver {
 		}
 
 		return parallelism;
+	}
+
+	protected static void cleanUpIntermediateStack(final RenderWebServiceParameters renderWeb, final String stack) {
+		final RenderDataClient dataClient = renderWeb.getDataClient();
+		try {
+			dataClient.deleteStack(stack, null);
+			LOG.info("cleanUpIntermediateStack: deleted stack {}", stack);
+		} catch (final IOException e) {
+			LOG.error("cleanUpIntermediateStack: error deleting stack {}", stack, e);
+		}
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(DistributedAlternatingDomainDecompositionSolver.class);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedAlternatingDomainDecompositionSolver.java
@@ -1,0 +1,64 @@
+package org.janelia.render.client.spark.newsolver;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public abstract class DistributedAlternatingDomainDecompositionSolver {
+
+	protected static int deriveParallelismValues(final JavaSparkContext sparkContext,
+												 final List<DistributedSolveParameters> solveParameters) {
+
+		// From https://spark.apache.org/docs/3.4.1/configuration.html#execution-behavior ...
+		//   For these cluster managers, spark.default.parallelism is:
+		//   - Local mode: number of cores on the local machine
+		//   - Mesos fine grained mode: 8
+		//   - Others: total number of cores on all executor nodes or 2, whichever is larger.
+		int parallelism = sparkContext.defaultParallelism();
+		final DistributedSolveParameters firstSolveParameters = solveParameters.get(0);
+
+		LOG.info("deriveParallelismValues: entry, threadsGlobal={}, threadsWorker={}, parallelism={}",
+				 firstSolveParameters.threadsGlobal, firstSolveParameters.threadsWorker, parallelism);
+
+		if (firstSolveParameters.deriveThreadsUsingSparkConfig) {
+
+			final SparkConf sparkConf = sparkContext.getConf();
+			final int driverCores = sparkConf.getInt("spark.driver.cores", 1);
+			final int executorCores = sparkConf.getInt("spark.executor.cores", 1);
+
+			// If only one setup, global solve will be run on driver so set threadsGlobal to driver core count.
+			// Otherwise, global solve is run on executors so set threadsGlobal to executor core count.
+			final int threadsGlobal = solveParameters.size() == 1 ? driverCores : executorCores;
+
+			solveParameters.forEach(param -> {
+				param.threadsGlobal = threadsGlobal;
+				param.threadsWorker = executorCores;
+			});
+
+			try {
+				final int sleepSeconds = 15;
+				LOG.info("deriveParallelismValues: sleeping {} seconds to give workers a chance to connect", sleepSeconds);
+				Thread.sleep(sleepSeconds * 1000L);
+			} catch (final InterruptedException e) {
+				LOG.warn("deriveParallelismValues: interrupted while sleeping", e);
+			}
+
+			// set parallelism to number of worker executors
+			// see https://stackoverflow.com/questions/51342460/getexecutormemorystatus-size-not-outputting-correct-num-of-executors
+			final int numberOfExecutorsIncludingDriver = sparkContext.sc().getExecutorMemoryStatus().size();
+			final int numberOfWorkerExecutors = numberOfExecutorsIncludingDriver - 1;
+			parallelism = Math.max(numberOfWorkerExecutors, 2);
+
+			LOG.info("deriveParallelismValues: updated values, threadsGlobal={}, threadsWorker={}, parallelism={}",
+					 firstSolveParameters.threadsGlobal, firstSolveParameters.threadsWorker, parallelism);
+		}
+
+		return parallelism;
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(DistributedAlternatingDomainDecompositionSolver.class);
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -21,6 +21,7 @@ import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
@@ -300,6 +301,11 @@ public class DistributedIntensityCorrectionBlockSolverClient
 
 		}
 
+	}
+
+	@Override
+	public AlignmentPipelineStepId getDefaultStepId() {
+		return AlignmentPipelineStepId.CORRECT_INTENSITY;
 	}
 
 	private List<List<IntensityCorrectionSetup>> buildSetupListsForRuns(final int nRuns,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -259,7 +259,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 	public void runPipelineStep(final JavaSparkContext sparkContext, final AlignmentPipelineParameters pipelineParameters)
 			throws IllegalArgumentException, IOException {
 
-		final MultiProjectParameters multiProject = pipelineParameters.getMultiProject(pipelineParameters.getRawNamingGroup());
+		final MultiProjectParameters multiProject = pipelineParameters.getMultiProject(pipelineParameters.getAlignedNamingGroup());
 		final List<IntensityCorrectionSetup> setupList = new ArrayList<>();
 		final IntensityCorrectionSetup setup = pipelineParameters.getIntensityCorrectionSetup();
 		final List<StackWithZValues> stackList = multiProject.buildListOfStackWithAllZ();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -40,7 +40,7 @@ import java.util.stream.IntStream;
  * @author Michael Innerberger
  */
 public class DistributedIntensityCorrectionBlockSolverClient
-		extends DistributedAlternatingDomainDecompositionSolver implements Serializable, AlignmentPipelineStep {
+        implements Serializable, AlignmentPipelineStep {
 
 	/**
 	 * Run the client with command line parameters.
@@ -84,7 +84,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 		final List<DistributedSolveParameters> solveParameters = setupList.stream()
 				.map(setup -> setup.distributedSolve)
 				.collect(Collectors.toList());
-		final int parallelism = deriveParallelismValues(sparkContext, solveParameters);
+		final int parallelism = DistributedSolveUtils.deriveParallelismValues(sparkContext, solveParameters);
 
 		final List<DistributedIntensityCorrectionSolver> solverList = new ArrayList<>();
 		final List<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> inputBlocksWithSetupIndexes = new ArrayList<>();
@@ -294,7 +294,9 @@ public class DistributedIntensityCorrectionBlockSolverClient
 
 				// clean-up intermediate stacks for prior runs if requested
 				if (cleanUpIntermediateStacks && (runIndex > 0)) {
-					setupListForRun.forEach(item -> cleanUpIntermediateStack(item.renderWeb, item.intensityAdjust.stack));
+					setupListForRun.forEach(
+							s -> DistributedSolveUtils.cleanUpIntermediateStack(s.renderWeb,
+																				s.intensityAdjust.stack));
 				}
 			}
 
@@ -319,7 +321,9 @@ public class DistributedIntensityCorrectionBlockSolverClient
 
 				final IntensityCorrectionSetup runSetup = updatedSetup.clone();
 				runSetup.intensityAdjust.stack = runSourceStack;
-				runSetup.targetStack.stack = getStackName(originalTargetStack, runNumber, nRuns);
+				runSetup.targetStack.stack = DistributedSolveUtils.getStackNameForRun(originalTargetStack,
+																					  runNumber,
+																					  nRuns);
 				updateParameters(runSetup, runNumber);
 
 				setupListForRun.add(runSetup);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -1,0 +1,343 @@
+package org.janelia.render.client.spark.newsolver;
+
+import mpicbg.models.AffineModel1D;
+import mpicbg.models.NoninvertibleModelException;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.storage.StorageLevel;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackWithZValues;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.newsolver.BlockCollection;
+import org.janelia.render.client.newsolver.BlockData;
+import org.janelia.render.client.newsolver.DistributedIntensityCorrectionSolver;
+import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
+import org.janelia.render.client.newsolver.setup.IntensityCorrectionSetup;
+import org.janelia.render.client.newsolver.setup.RenderSetup;
+import org.janelia.render.client.parameter.MultiProjectParameters;
+import org.janelia.render.client.spark.LogUtilities;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/*
+ * Spark client for running a distributed intensity correction block solve.
+ *
+ * @author Michael Innerberger
+ */
+public class DistributedIntensityCorrectionBlockSolverClient
+		extends DistributedAlternatingDomainDecompositionSolver implements Serializable, AlignmentPipelineStep {
+
+	/**
+	 * Run the client with command line parameters.
+	 */
+	public static void main(final String[] args) {
+		final ClientRunner clientRunner = new ClientRunner(args) {
+			@Override
+			public void runClient(final String[] args)
+					throws Exception {
+				final IntensityCorrectionSetup parameters = new IntensityCorrectionSetup();
+				parameters.parse(args);
+				final DistributedIntensityCorrectionBlockSolverClient client = new DistributedIntensityCorrectionBlockSolverClient();
+				client.createContextAndRun(parameters);
+			}
+		};
+		clientRunner.run();
+	}
+
+	/**
+	 * Empty constructor required for alignment pipeline steps.
+	 */
+	public DistributedIntensityCorrectionBlockSolverClient() {}
+
+	/**
+	 * Create a spark context and run the client with the specified setup.
+	 */
+	public void createContextAndRun(final IntensityCorrectionSetup intensityCorrectionSetup)
+			throws IOException {
+		final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
+		try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+			LOG.info("createContextAndRun: appId is {}", sparkContext.getConf().getAppId());
+			alignSetupList(sparkContext, Collections.singletonList(intensityCorrectionSetup));
+		}
+	}
+
+	private void alignSetupList(final JavaSparkContext sparkContext, final List<IntensityCorrectionSetup> setupList)
+			throws IOException {
+
+		LOG.info("alignSetupList: entry, setupList={}", setupList);
+
+		final List<DistributedSolveParameters> solveParameters = setupList.stream()
+				.map(setup -> setup.distributedSolve)
+				.collect(Collectors.toList());
+		final int parallelism = deriveParallelismValues(sparkContext, solveParameters);
+
+		final List<DistributedIntensityCorrectionSolver> solverList = new ArrayList<>();
+		final List<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> inputBlocksWithSetupIndexes = new ArrayList<>();
+
+		buildSolversAndInputBlocks(setupList, solverList, inputBlocksWithSetupIndexes);
+
+		final JavaPairRDD<Integer, BlockData<ArrayList<AffineModel1D>, ?>> rddInputBlocks =
+				sparkContext.parallelizePairs(inputBlocksWithSetupIndexes, parallelism);
+
+		final JavaPairRDD<Integer, BlockData<ArrayList<AffineModel1D>, ?>> rddOutputBlocks =
+				rddInputBlocks.flatMapToPair(tuple2 -> solveInputBlock(setupList, tuple2._1, tuple2._2));
+
+		if (setupList.size() > 1) {
+			globallySolveMultipleSetups(setupList, rddOutputBlocks, solverList);
+		} else {
+			final List<BlockData<ArrayList<AffineModel1D>, ?>> outputBlocks = rddOutputBlocks.values().collect();
+			globallySolveOneSetup(setupList, 0, solverList, outputBlocks);
+		}
+
+		LOG.info("alignSetupList: exit");
+	}
+
+	private static void buildSolversAndInputBlocks(final List<IntensityCorrectionSetup> setupList,
+												   final List<DistributedIntensityCorrectionSolver> solverList,
+												   final List<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> allInputBlocksWithSetupIndexes)
+			throws IOException {
+
+		for (int setupIndex = 0; setupIndex < setupList.size(); setupIndex++) {
+			final IntensityCorrectionSetup setup = setupList.get(setupIndex);
+
+			final RenderSetup renderSetup = RenderSetup.setupSolve(setup);
+			final DistributedIntensityCorrectionSolver solver = new DistributedIntensityCorrectionSolver(setup, renderSetup);
+			solverList.add(solver);
+
+			final BlockCollection<?, ArrayList<AffineModel1D>, ?> blockCollection = solver.setupSolve();
+
+			final List<BlockData<ArrayList<AffineModel1D>, ?>> allInputBlocksForSetup = new ArrayList<>(blockCollection.allBlocks());
+
+			LOG.info("buildSolversAndInputBlocks: setup index {}, created {} input blocks: {}",
+					 setupIndex, allInputBlocksForSetup.size(), allInputBlocksForSetup);
+
+			for (final BlockData<ArrayList<AffineModel1D>, ?> block : allInputBlocksForSetup) {
+				allInputBlocksWithSetupIndexes.add(new Tuple2<>(setupIndex, block));
+			}
+		}
+	}
+
+	private static Iterator<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> solveInputBlock(final List<IntensityCorrectionSetup> setupList,
+																									 final int setupIndex,
+																									 final BlockData<ArrayList<AffineModel1D>, ?> inputBlock)
+			throws NoninvertibleModelException, IOException, ExecutionException, InterruptedException {
+
+		LogUtilities.setupExecutorLog4j(""); // block info already in most log calls so leave context empty
+
+		final IntensityCorrectionSetup setup = setupList.get(setupIndex);
+		final List<BlockData<ArrayList<AffineModel1D>, ?>> outputBlockList =
+				DistributedIntensityCorrectionSolver.createAndRunWorker(inputBlock, setup);
+
+		final List<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> outputBlocksWithSetupIndexes =
+				new ArrayList<>(outputBlockList.size());
+		for (final BlockData<ArrayList<AffineModel1D>, ?> outputBlock : outputBlockList) {
+			outputBlocksWithSetupIndexes.add(new Tuple2<>(setupIndex, outputBlock));
+		}
+
+		return outputBlocksWithSetupIndexes.iterator();
+	}
+
+	private static void globallySolveMultipleSetups(final List<IntensityCorrectionSetup> setupList,
+													final JavaPairRDD<Integer, BlockData<ArrayList<AffineModel1D>, ?>> rddOutputBlocks,
+													final List<DistributedIntensityCorrectionSolver> solverList) {
+
+		LOG.info("globallySolveMultipleSetups: entry, solving {} setups", setupList.size());
+
+		// 1. Persist the solved output blocks so that they don't need to be recalculated during combination.
+		//
+		//    The MEMORY_AND_DISK storage level indicates that the RDD is stored as deserialized Java objects
+		//    in the JVM. If the RDD does not fit in memory, partitions that don't fit are stored on disk
+		//    and then read from disk when they're needed.
+		rddOutputBlocks.persist(StorageLevel.MEMORY_AND_DISK());
+
+		// 2. Combine the solved output blocks for each setup (stack) into a list so that the list of blocks
+		//    can be solved globally on a Spark executor.  Doing the global solve on executor/workers allows
+		//    global solves for different stacks to be run concurrently.
+		final JavaPairRDD<Integer, List<BlockData<ArrayList<AffineModel1D>, ?>>> outputBlocksForSetupRdd =
+				rddOutputBlocks.combineByKey(
+						// createCombiner
+						block -> {
+							final List<BlockData<ArrayList<AffineModel1D>, ?>> list = new ArrayList<>();
+							list.add(block);
+							return list;
+						},
+						// mergeValue
+						(list, block) -> {
+							list.add(block);
+							return list;
+						},
+						// mergeCombiners
+						(list1, list2) -> {
+							list1.addAll(list2);
+							return list1;
+						}
+				);
+
+		// 3. Run the global solve for each setup (stack) in parallel.
+		final JavaRDD<StackId> globallySolvedTargetStackIdsRdd =
+				outputBlocksForSetupRdd.map(
+						setupIndexWithOutputBlocks -> runGlobalSolveOnExecutors(setupList,
+																				solverList,
+																				setupIndexWithOutputBlocks));
+
+		// 4. Collect the target stack ids for each setup (stack) that was globally solved.
+		final List<String> globallySolvedTargetStackDevStrings =
+				globallySolvedTargetStackIdsRdd.collect().stream()
+						.sorted()
+						.map(StackId::toDevString)
+						.collect(Collectors.toList());
+
+		LOG.info("globallySolveMultipleSetups: exit, globally solved {} setups stacks: {}",
+				 globallySolvedTargetStackDevStrings.size(), globallySolvedTargetStackDevStrings);
+	}
+
+	private static StackId runGlobalSolveOnExecutors(final List<IntensityCorrectionSetup> setupList,
+													 final List<DistributedIntensityCorrectionSolver> solverList,
+													 final Tuple2<Integer, List<BlockData<ArrayList<AffineModel1D>, ?>>> setupIndexWithOutputBlocks)
+			throws IOException {
+
+		final int setupIndex = setupIndexWithOutputBlocks._1;
+		final List<BlockData<ArrayList<AffineModel1D>, ?>> outputBlocks = setupIndexWithOutputBlocks._2;
+
+		LogUtilities.setupExecutorLog4j("setupIndex" + setupIndex); // add setup index to log context
+
+		globallySolveOneSetup(setupList, setupIndex, solverList, outputBlocks);
+
+		final IntensityCorrectionSetup setup = setupList.get(setupIndex);
+
+		return new StackId(setup.targetStack.owner, setup.targetStack.project, setup.targetStack.stack);
+	}
+
+	private static void globallySolveOneSetup(final List<IntensityCorrectionSetup> setupList,
+											  final Integer setupIndex,
+											  final List<DistributedIntensityCorrectionSolver> solverList,
+											  final List<BlockData<ArrayList<AffineModel1D>, ?>> outputBlocksForSetup)
+			throws IOException {
+
+		final IntensityCorrectionSetup setup = setupList.get(setupIndex);
+		final DistributedIntensityCorrectionSolver solver = solverList.get(setupIndex);
+
+		LOG.info("globallySolveOneSetup: setup index {}, solving {} blocks with {} threads",
+				 setupIndex, outputBlocksForSetup.size(), setup.distributedSolve.threadsGlobal);
+
+		DistributedIntensityCorrectionSolver.solveCombineAndSaveBlocks(setup,
+															   outputBlocksForSetup,
+															   solver);
+	}
+
+	/**
+	 * Validates the specified pipeline parameters are sufficient for this step.
+	 */
+	@Override
+	public void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+			throws IllegalArgumentException {
+		AlignmentPipelineParameters.validateRequiredElementExists("intensityCorrectionSetup",
+																  pipelineParameters.getIntensityCorrectionSetup());
+	}
+
+	/**
+	 * Runs the client as part of an alignment pipeline.
+	 */
+	@Override
+	public void runPipelineStep(final JavaSparkContext sparkContext, final AlignmentPipelineParameters pipelineParameters)
+			throws IllegalArgumentException, IOException {
+
+		final MultiProjectParameters multiProject = pipelineParameters.getMultiProject(pipelineParameters.getRawNamingGroup());
+		final List<IntensityCorrectionSetup> setupList = new ArrayList<>();
+		final IntensityCorrectionSetup setup = pipelineParameters.getIntensityCorrectionSetup();
+		final List<StackWithZValues> stackList = multiProject.buildListOfStackWithAllZ();
+		final int nRuns = setup.alternatingRuns.nRuns;
+		final boolean cleanUpIntermediateStacks = ! setup.alternatingRuns.keepIntermediateStacks;
+
+		final String matchSuffix = pipelineParameters.getMatchCopyToCollectionSuffix();
+		for (final StackWithZValues stackWithZValues : stackList) {
+			setupList.add(setup.buildPipelineClone(multiProject.getBaseDataUrl(),
+												   stackWithZValues,
+												   multiProject.deriveMatchCollectionNamesFromProject,
+												   matchSuffix));
+		}
+
+		final DistributedIntensityCorrectionBlockSolverClient intensityCorrectionSolverClient = new DistributedIntensityCorrectionBlockSolverClient();
+
+		if (nRuns == 1) {
+
+			intensityCorrectionSolverClient.alignSetupList(sparkContext, setupList);
+
+		} else {
+
+			// Different stacks can be aligned in parallel, but each run must be done sequentially.
+			// So, for each run, create a list of setups that will be aligned in parallel.
+			final List<List<IntensityCorrectionSetup>> setupListsForRuns = buildSetupListsForRuns(nRuns, setupList);
+
+			// loop through each run and align the stacks in parallel ...
+			for (int runIndex = 0; runIndex < nRuns; runIndex++) {
+
+				final List<IntensityCorrectionSetup> setupListForRun = setupListsForRuns.get(runIndex);
+
+				// align all stacks for this run
+				intensityCorrectionSolverClient.alignSetupList(sparkContext, setupListForRun);
+
+				// clean-up intermediate stacks for prior runs if requested
+				if (cleanUpIntermediateStacks && (runIndex > 0)) {
+					setupListForRun.forEach(item -> cleanUpIntermediateStack(item.renderWeb, item.intensityAdjust.stack));
+				}
+			}
+
+		}
+
+	}
+
+	private List<List<IntensityCorrectionSetup>> buildSetupListsForRuns(final int nRuns,
+																		final List<IntensityCorrectionSetup> setupList) {
+
+		final List<List<IntensityCorrectionSetup>> setupListsForRuns = new ArrayList<>(nRuns);
+		IntStream.range(0, nRuns).forEach(i -> setupListsForRuns.add(new ArrayList<>(setupList.size())));
+
+		for (final IntensityCorrectionSetup updatedSetup : setupList) {
+
+			String runSourceStack = updatedSetup.intensityAdjust.stack;
+			final String originalTargetStack = updatedSetup.targetStack.stack;
+
+			for (int runNumber = 1; runNumber <= nRuns; runNumber++) {
+
+				final List<IntensityCorrectionSetup> setupListForRun = setupListsForRuns.get(runNumber - 1);
+
+				final IntensityCorrectionSetup runSetup = updatedSetup.clone();
+				runSetup.intensityAdjust.stack = runSourceStack;
+				runSetup.targetStack.stack = getStackName(originalTargetStack, runNumber, nRuns);
+				updateParameters(runSetup, runNumber);
+
+				setupListForRun.add(runSetup);
+
+				LOG.info("buildSetupListsForRuns: added setup for stack {}, run {}, targetStack={}, shiftBlocks={}",
+						 runSourceStack, runNumber, runSetup.targetStack.stack, runSetup.blockPartition.shiftBlocks);
+
+				runSourceStack = runSetup.targetStack.stack;
+			}
+		}
+
+		return setupListsForRuns;
+	}
+
+	private static void updateParameters(final IntensityCorrectionSetup parameters, final int runNumber) {
+		// alternate block layout
+		parameters.blockPartition.shiftBlocks = (runNumber % 2 == 0);
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(DistributedIntensityCorrectionBlockSolverClient.class);
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -73,14 +73,14 @@ public class DistributedIntensityCorrectionBlockSolverClient
 		final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
 		try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
 			LOG.info("createContextAndRun: appId is {}", sparkContext.getConf().getAppId());
-			alignSetupList(sparkContext, Collections.singletonList(intensityCorrectionSetup));
+			intensityCorrectSetupList(sparkContext, Collections.singletonList(intensityCorrectionSetup));
 		}
 	}
 
-	private void alignSetupList(final JavaSparkContext sparkContext, final List<IntensityCorrectionSetup> setupList)
+	private void intensityCorrectSetupList(final JavaSparkContext sparkContext, final List<IntensityCorrectionSetup> setupList)
 			throws IOException {
 
-		LOG.info("alignSetupList: entry, setupList={}", setupList);
+		LOG.info("intensityCorrectSetupList: entry, setupList={}", setupList);
 
 		final List<DistributedSolveParameters> solveParameters = setupList.stream()
 				.map(setup -> setup.distributedSolve)
@@ -105,7 +105,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 			globallySolveOneSetup(setupList, 0, solverList, outputBlocks);
 		}
 
-		LOG.info("alignSetupList: exit");
+		LOG.info("intensityCorrectSetupList: exit");
 	}
 
 	private static void buildSolversAndInputBlocks(final List<IntensityCorrectionSetup> setupList,
@@ -274,7 +274,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 
 		if (nRuns == 1) {
 
-			intensityCorrectionSolverClient.alignSetupList(sparkContext, setupList);
+			intensityCorrectionSolverClient.intensityCorrectSetupList(sparkContext, setupList);
 
 		} else {
 
@@ -288,7 +288,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 				final List<IntensityCorrectionSetup> setupListForRun = setupListsForRuns.get(runIndex);
 
 				// align all stacks for this run
-				intensityCorrectionSolverClient.alignSetupList(sparkContext, setupListForRun);
+				intensityCorrectionSolverClient.intensityCorrectSetupList(sparkContext, setupListForRun);
 
 				// clean-up intermediate stacks for prior runs if requested
 				if (cleanUpIntermediateStacks && (runIndex > 0)) {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -265,12 +265,9 @@ public class DistributedIntensityCorrectionBlockSolverClient
 		final int nRuns = setup.alternatingRuns.nRuns;
 		final boolean cleanUpIntermediateStacks = ! setup.alternatingRuns.keepIntermediateStacks;
 
-		final String matchSuffix = pipelineParameters.getMatchCopyToCollectionSuffix();
 		for (final StackWithZValues stackWithZValues : stackList) {
 			setupList.add(setup.buildPipelineClone(multiProject.getBaseDataUrl(),
-												   stackWithZValues,
-												   multiProject.deriveMatchCollectionNamesFromProject,
-												   matchSuffix));
+												   stackWithZValues));
 		}
 
 		final DistributedIntensityCorrectionBlockSolverClient intensityCorrectionSolverClient = new DistributedIntensityCorrectionBlockSolverClient();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -13,6 +13,7 @@ import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.newsolver.BlockCollection;
 import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.DistributedIntensityCorrectionSolver;
+import org.janelia.render.client.newsolver.AlternatingSolveUtils;
 import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
 import org.janelia.render.client.newsolver.setup.IntensityCorrectionSetup;
 import org.janelia.render.client.newsolver.setup.RenderSetup;
@@ -84,7 +85,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 		final List<DistributedSolveParameters> solveParameters = setupList.stream()
 				.map(setup -> setup.distributedSolve)
 				.collect(Collectors.toList());
-		final int parallelism = DistributedSolveUtils.deriveParallelismValues(sparkContext, solveParameters);
+		final int parallelism = SparkDistributedSolveUtils.deriveParallelismValues(sparkContext, solveParameters);
 
 		final List<DistributedIntensityCorrectionSolver> solverList = new ArrayList<>();
 		final List<Tuple2<Integer, BlockData<ArrayList<AffineModel1D>, ?>>> inputBlocksWithSetupIndexes = new ArrayList<>();
@@ -295,7 +296,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 				// clean-up intermediate stacks for prior runs if requested
 				if (cleanUpIntermediateStacks && (runIndex > 0)) {
 					setupListForRun.forEach(
-							s -> DistributedSolveUtils.cleanUpIntermediateStack(s.renderWeb,
+							s -> AlternatingSolveUtils.cleanUpIntermediateStack(s.renderWeb,
 																				s.intensityAdjust.stack));
 				}
 			}
@@ -321,7 +322,7 @@ public class DistributedIntensityCorrectionBlockSolverClient
 
 				final IntensityCorrectionSetup runSetup = updatedSetup.clone();
 				runSetup.intensityAdjust.stack = runSourceStack;
-				runSetup.targetStack.stack = DistributedSolveUtils.getStackNameForRun(originalTargetStack,
+				runSetup.targetStack.stack = AlternatingSolveUtils.getStackNameForRun(originalTargetStack,
 																					  runNumber,
 																					  nRuns);
 				updateParameters(runSetup, runNumber);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/SparkDistributedSolveUtils.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/SparkDistributedSolveUtils.java
@@ -70,7 +70,7 @@ public class SparkDistributedSolveUtils {
 
 			solveParametersList.forEach(param -> {
 				param.threadsGlobal = threadsGlobal;
-				param.threadsWorker = executorCores;
+				param.threadsWorker = threadsWorker;
 			});
 
 			try {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/SparkDistributedSolveUtils.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/SparkDistributedSolveUtils.java
@@ -1,20 +1,17 @@
 package org.janelia.render.client.spark.newsolver;
 
+import java.util.List;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
-import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
-
 /**
- * Common shared utilities for distributed alignment or intensity correction runs.
+ * Common shared utilities for distributed alignment or intensity correction runs on spark clusters.
  */
-public class DistributedSolveUtils {
+public class SparkDistributedSolveUtils {
 
 	/**
 	 * If requested in the solve parameters, derive the parallelism value to use for the run
@@ -76,25 +73,5 @@ public class DistributedSolveUtils {
 		return parallelism;
 	}
 
-    /**
-     * Tries to remove the specified stack and simply logs an error if that fails.
-     */
-	public static void cleanUpIntermediateStack(final RenderWebServiceParameters renderWeb,
-                                                final String stack) {
-		final RenderDataClient dataClient = renderWeb.getDataClient();
-		try {
-			dataClient.deleteStack(stack, null);
-			LOG.info("cleanUpIntermediateStack: deleted stack {}", stack);
-		} catch (final IOException e) {
-			LOG.error("cleanUpIntermediateStack: error deleting stack {}", stack, e);
-		}
-	}
-
-	public static String getStackNameForRun(final String name,
-                                            final int runNumber,
-                                            final int nTotalRuns) {
-        return runNumber == nTotalRuns ? name : name + "_run" + runNumber;
-    }
-
-	private static final Logger LOG = LoggerFactory.getLogger(DistributedSolveUtils.class);
+	private static final Logger LOG = LoggerFactory.getLogger(SparkDistributedSolveUtils.class);
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -13,6 +13,7 @@ import org.janelia.alignment.spec.stack.PipelineStackIdNamingGroups;
 import org.janelia.alignment.spec.stack.StackIdNamingGroup;
 import org.janelia.alignment.util.FileUtil;
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
+import org.janelia.render.client.newsolver.setup.IntensityCorrectionSetup;
 import org.janelia.render.client.parameter.MFOVMontageMatchPatchParameters;
 import org.janelia.render.client.parameter.MatchCopyParameters;
 import org.janelia.render.client.parameter.MipmapParameters;
@@ -42,11 +43,13 @@ public class AlignmentPipelineParameters
     private final TileClusterParameters tileCluster;
     private final MatchCopyParameters matchCopy;
     private final AffineBlockSolverSetup affineBlockSolverSetup;
+    private final IntensityCorrectionSetup intensityCorrectionSetup;
     private final ZSpacingParameters zSpacing;
 
     @SuppressWarnings("unused")
     public AlignmentPipelineParameters() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -69,6 +72,7 @@ public class AlignmentPipelineParameters
                                        final TileClusterParameters tileCluster,
                                        final MatchCopyParameters matchCopy,
                                        final AffineBlockSolverSetup affineBlockSolverSetup,
+                                       final IntensityCorrectionSetup intensityCorrectionSetup,
                                        final ZSpacingParameters zSpacing) {
         this.multiProject = multiProject;
         this.pipelineStackGroups = pipelineStackGroups;
@@ -80,6 +84,7 @@ public class AlignmentPipelineParameters
         this.tileCluster = tileCluster;
         this.matchCopy = matchCopy;
         this.affineBlockSolverSetup = affineBlockSolverSetup;
+        this.intensityCorrectionSetup = intensityCorrectionSetup;
         this.zSpacing = zSpacing;
     }
 
@@ -130,6 +135,10 @@ public class AlignmentPipelineParameters
 
     public AffineBlockSolverSetup getAffineBlockSolverSetup() {
         return affineBlockSolverSetup;
+    }
+
+    public IntensityCorrectionSetup getIntensityCorrectionSetup() {
+        return intensityCorrectionSetup;
     }
 
     public ZSpacingParameters getZSpacing() {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStep.java
@@ -42,4 +42,8 @@ public interface AlignmentPipelineStep {
                          final AlignmentPipelineParameters pipelineParameters)
             throws IllegalArgumentException, IOException;
 
+    /**
+     * @return the default identifier for this step.
+     */
+    AlignmentPipelineStepId getDefaultStepId();
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
@@ -9,6 +9,7 @@ import org.janelia.render.client.spark.match.MultiStagePointMatchClient;
 import org.janelia.render.client.spark.multisem.MFOVMontageMatchPatchClient;
 import org.janelia.render.client.spark.multisem.UnconnectedCrossMFOVClient;
 import org.janelia.render.client.spark.newsolver.DistributedAffineBlockSolverClient;
+import org.janelia.render.client.spark.newsolver.DistributedIntensityCorrectionBlockSolverClient;
 import org.janelia.render.client.spark.zspacing.ZPositionCorrectionClient;
 
 /**
@@ -25,7 +26,8 @@ public enum AlignmentPipelineStepId {
     FIND_UNCONNECTED_TILES_AND_EDGES(ClusterCountClient::new),
     FILTER_MATCHES(CopyMatchClient::new),
     ALIGN_TILES(DistributedAffineBlockSolverClient::new),
-    CORRECT_Z_POSITIONS(ZPositionCorrectionClient::new);
+    CORRECT_Z_POSITIONS(ZPositionCorrectionClient::new),
+    CORRECT_INTENSITY(DistributedIntensityCorrectionBlockSolverClient::new);
 
     private final Supplier<AlignmentPipelineStep> stepClientSupplier;
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/zspacing/ZPositionCorrectionClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/zspacing/ZPositionCorrectionClient.java
@@ -21,6 +21,7 @@ import org.janelia.render.client.parameter.ZSpacingParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.janelia.render.client.zspacing.CrossCorrelationData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,6 +122,11 @@ public class ZPositionCorrectionClient
         clientParameters.multiProject = pipelineParameters.getMultiProject(pipelineParameters.getAlignedNamingGroup());
         clientParameters.zSpacing = pipelineParameters.getZSpacing();
         deriveAndSolveCrossCorrelationData(sparkContext, clientParameters);
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.CORRECT_Z_POSITIONS;
     }
 
     private void deriveAndSolveCrossCorrelationData(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParametersTest.java
@@ -35,7 +35,11 @@ public class AlignmentPipelineParametersTest {
         final List<AlignmentPipelineStep> stepClients = pipelineParameters.buildStepClients();
         
         Assert.assertNotNull("stepClients is null", stepClients);
-        Assert.assertEquals("incorrect number of stepClients", 6, stepClients.size());
+        Assert.assertEquals("incorrect number of stepClients", 7, stepClients.size());
+
+        final AlignmentPipelineStep stepClient = stepClients.get(0);
+        Assert.assertEquals("first stepClient has incorrect defaultStepId",
+                            AlignmentPipelineStepId.GENERATE_MIPMAPS, stepClient.getDefaultStepId());
     }
 
     private AlignmentPipelineParameters loadTestParameters() throws IOException {

--- a/render-ws-spark-client/src/test/resources/pipeline/msem_alignment_pipeline.json
+++ b/render-ws-spark-client/src/test/resources/pipeline/msem_alignment_pipeline.json
@@ -25,7 +25,8 @@
     "PATCH_MFOV_MONTAGE_MATCHES",
     "FIND_UNCONNECTED_MFOVS",
     "FILTER_MATCHES",
-    "ALIGN_TILES"
+    "ALIGN_TILES",
+    "CORRECT_INTENSITY"
   ],
   "mipmap" : {
     "rootDirectory" : "/nrs/hess/data/hess_wafer_53/mipmaps",
@@ -350,15 +351,16 @@
       "maxIterationsGlobal": 1000,
       "maxPlateauWidthGlobal": 200,
       "threadsWorker": 2,
-      "threadsGlobal": 44
+      "threadsGlobal": 2,
+      "deriveThreadsUsingSparkConfig" : true
     },
     "targetStack": {
       "stackSuffix": "_align",
       "completeStack": true
     },
     "blockPartition": {
-      "sizeX": 7000,
-      "sizeY": 6000
+      "sizeX": 9000,
+      "sizeY": 9000
     },
     "blockOptimizer": {
       "lambdasRigid": [ 1.0, 1.0, 0.9, 0.3, 0.01 ],
@@ -371,6 +373,37 @@
     "alternatingRuns": {
       "nRuns": 4,
       "keepIntermediateStacks": false
+    }
+  },
+  "intensityCorrectionSetup": {
+    "distributedSolve" : {
+      "maxAllowedErrorGlobal" : 10.0,
+      "maxIterationsGlobal" : 10000,
+      "maxPlateauWidthGlobal" : 500,
+      "threadsWorker" : 2,
+      "threadsGlobal" : 2,
+      "deriveThreadsUsingSparkConfig" : true
+    },
+    "intensityAdjust" : {
+      "lambda1" : 0.01,
+      "lambda2" : 0.01,
+      "maxPixelCacheGb" : 1,
+      "renderScale" : 0.1,
+      "zDistance" : {
+        "simpleZDistance" : [
+          1
+        ]
+      },
+      "numCoefficients" : 8,
+      "equilibrationWeight" : 0.0
+    },
+    "targetStack": {
+      "stackSuffix": "_ic",
+      "completeStack": true
+    },
+    "blockPartition": {
+      "sizeX": 9000,
+      "sizeY": 9000
     }
   }
 }


### PR DESCRIPTION
This is my first attempt at a spark client for intensity correction. Since this is my first attempt at spark ever, I copied a lot of stuff and I'm sure that there are a bunch of bugs in there.
I'm happy to go over this together at some point to learn from your experience @trautmane. 

One thing that I take from this experience is that we didn't do a good job of abstracting concepts. I tried to extract common functionality but failed for various reasons most of the time:
* `AffineBlockSolverSetup` and `IntensityCorrectionSetup` don't share a common superclass or interface.
* The "model" for intensity correction does not implement `Model`, which makes it hard to generalize.
* There are a lot of `public static` methods. While this is not bad per se, I think here it means that encapsulation is not tight.