### PR TITLE
Feature: local destreaking

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -2,24 +2,20 @@ package org.janelia.alignment.destreak;
 
 import ij.ImagePlus;
 import ij.process.ImageProcessor;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.janelia.alignment.filter.Filter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
-import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
+import org.janelia.alignment.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -28,9 +28,7 @@ import net.imglib2.type.numeric.real.FloatType;
  * @author Stephan Preibisch
  * @author Eric Trautman
  */
-public class ConfigurableMaskStreakCorrector
-        extends StreakCorrector
-        implements Filter {
+public class ConfigurableMaskStreakCorrector extends StreakCorrector {
 
     private int fftWidth;
     private int fftHeight;

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -16,8 +16,6 @@ import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import org.janelia.alignment.filter.Filter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -1,0 +1,171 @@
+package org.janelia.alignment.destreak;
+
+import ij.ImagePlus;
+import ij.plugin.filter.GaussianBlur;
+import ij.process.ImageProcessor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.img.imageplus.ImagePlusImg;
+import net.imglib2.img.imageplus.ImagePlusImgs;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.janelia.alignment.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}.
+ * This applies the mask of the {@link ConfigurableMaskStreakExtractor} to parts of the input image.
+ *
+ * @author Michael Innerberger
+ */
+public class LocalConfigurableMaskStreakCorrector
+        extends ConfigurableMaskStreakCorrector
+        implements Filter {
+
+	private static int DOWN_SAMPLE_FACTOR = 2;
+	private static final int GAUSSIAN_BLUR_RADIUS = 100;
+	private static final float INITIAL_THRESHOLD = 20.0f;
+	private static final float FINAL_THRESHOLD = 0.1f;
+
+
+    public LocalConfigurableMaskStreakCorrector() {
+        this(1);
+    }
+
+    public LocalConfigurableMaskStreakCorrector(final int numThreads) {
+        super(numThreads);
+    }
+
+    public LocalConfigurableMaskStreakCorrector(final int numThreads,
+												final int fftWidth,
+												final int fftHeight,
+												final int extraX,
+												final int extraY,
+												final int[][] regionsToClear) {
+        super(numThreads, fftWidth, fftHeight, extraX, extraY, regionsToClear);
+    }
+
+    public LocalConfigurableMaskStreakCorrector(final ConfigurableMaskStreakCorrector corrector) {
+        super(corrector);
+    }
+
+    @Override
+    public void process(final ImageProcessor ip, final double scale) {
+		// save original image for later subtraction
+		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
+		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
+
+		// de-streak image
+		super.process(ip, scale);
+
+		final ImagePlus fixedIP = new ImagePlus("fixed", ip);
+		final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedIP);
+
+
+		// resize to speed up processing
+//		final int targetWidth = DOWN_SAMPLE_FACTOR * ip.getWidth();
+//		final int targetHeight = DOWN_SAMPLE_FACTOR * ip.getHeight();
+//		final ImagePlus maskExtended = Scaler.resize(fixedIP, targetWidth, targetHeight, 1, "bilinear");
+//
+//		// median filtering for actual background computation
+//		final double downscaledRadius = GAUSSIAN_BLUR_RADIUS * DOWN_SAMPLE_FACTOR;
+//		final ImagePlus extendedBackground = extendBorder(maskExtended, downscaledRadius);
+//
+//		final GaussianBlur gaussianBlur = new GaussianBlur();
+//		gaussianBlur.blurGaussian(extendedBackground.getProcessor(), downscaledRadius);
+//		final ImagePlus filteredBackground = crop(extendedBackground, downscaledRadius);
+
+//		final ImagePlus fixedImagePlus = new ImagePlus("fixed", ip);
+//		gaussianBlur.blurGaussian(fixedImagePlus.getProcessor(), GAUSSIAN_BLUR_RADIUS);
+
+		// subtract fixed from original to get streaks and threshold
+		// has to be FloatType since there may be negative values
+		final RandomAccessibleInterval<FloatType> weight =
+				Converters.convertRAI(original,
+									  fixed,
+									  (i1,i2,o) -> o.set(Math.abs(i1.get() - i2.get())),
+									  new FloatType());
+
+		weigthedSum(ip, originalIP.getProcessor(), weight);
+	}
+
+	private static void weigthedSum(final ImageProcessor target,
+									final ImageProcessor original,
+									final RandomAccessibleInterval<FloatType> weight) {
+
+		final ImagePlus weigthIP = ImageJFunctions.wrapFloat(weight, "weight");
+		final ImagePlus extendedWeight = extendBorder(weigthIP, GAUSSIAN_BLUR_RADIUS);
+
+		final GaussianBlur gaussianBlur = new GaussianBlur();
+		threshold(extendedWeight.getProcessor(), INITIAL_THRESHOLD);
+//		threshold(extendedWeight.getProcessor(), 0);
+		gaussianBlur.blurGaussian(extendedWeight.getProcessor(), GAUSSIAN_BLUR_RADIUS);
+		threshold(extendedWeight.getProcessor(), FINAL_THRESHOLD);
+		gaussianBlur.blurGaussian(extendedWeight.getProcessor(), GAUSSIAN_BLUR_RADIUS);
+		final ImagePlus smoothedWeight = crop(extendedWeight, GAUSSIAN_BLUR_RADIUS);
+		final ImageProcessor w = smoothedWeight.getProcessor();
+
+//		final ImageProcessor w = weigthIP.getProcessor();
+//		gaussianBlur.blurGaussian(w, GAUSSIAN_BLUR_RADIUS);
+
+		// reset min and max before converting to byte processor so that streaks are more easily viewed
+		w.resetMinAndMax();
+		final float maxValue = (float) w.getMax();
+		System.out.println("max value = " + maxValue);
+		for (int i = 0; i < w.getPixelCount(); i++) {
+			w.setf(i, w.getf(i) / maxValue);
+		}
+
+		for (int i = 0; i < w.getPixelCount(); i++) {
+//			if (weightImageProcessor.get(i) > 0) {
+//				System.out.println("image processor = " + weightImageProcessor.get(i) + ", float processor = " + w.getf(i));
+//			}
+//			final int value = (int) (target.get(i) * w.getf(i) + original.get(i) * (1 - w.getf(i)));
+			final int value = (int) (255 * w.getf(i));
+			target.set(i, value);
+		}
+	}
+
+	private static void threshold(final ImageProcessor ip, final float threshold) {
+		for (int i = 0; i < ip.getPixelCount(); i++) {
+			final int value = ip.getf(i) > threshold ? 1 : 0;
+			ip.setf(i, value);
+		}
+	}
+
+	private static ImagePlus extendBorder(final ImagePlus input, final double padding) {
+		final Img<FloatType> in = ImageJFunctions.wrap(input);
+		final long extendSize = (long) Math.ceil(padding);
+		final IntervalView<FloatType> view = Views.expandMirrorSingle(in, extendSize, extendSize);
+
+		// make copy, otherwise the changes of the median filter are not visible
+		// this leads to a very hard to find bug, so don't delete this copy!
+		final ImagePlusImg<FloatType, FloatArray> test = ImagePlusImgs.floats(input.getWidth() + 2 * extendSize, input.getHeight() + 2 * extendSize);
+		LoopBuilder.setImages(view, test).forEachPixel((v, t) -> t.set(v.get()));
+
+		final ImagePlus out = test.getImagePlus();
+		out.getProcessor().setMinAndMax(0.0, 255.0);
+		return out;
+	}
+
+	private static ImagePlus crop(final ImagePlus input, final double padding) {
+		final long cropSize = (long) Math.ceil(padding);
+		final long[] min = new long[] {cropSize, cropSize};
+		final long[] max = new long[] {input.getWidth() - cropSize - 1, input.getHeight() - cropSize - 1};
+		final Img<FloatType> in = ImageJFunctions.wrap(input);
+
+		final RandomAccessibleInterval<FloatType> roi = Views.interval(in, min, max);
+		final ImagePlus out = ImageJFunctions.wrap(roi, "cropped");
+		out.getProcessor().setMinAndMax(0.0, 255.0);
+		return out;
+	}
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalConfigurableMaskStreakCorrector.class);
+}

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -29,9 +29,7 @@ import java.util.Map;
  *
  * @author Michael Innerberger
  */
-public class LocalConfigurableMaskStreakCorrector
-        extends ConfigurableMaskStreakCorrector
-        implements Filter {
+public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreakCorrector {
 
 	private int gaussianBlurRadius;
 	private float initialThreshold;

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -38,6 +38,7 @@ public class LocalConfigurableMaskStreakCorrector
 	private float finalThreshold;
 
 
+	// TODO: find a way to make this work for all streak correctors
     public LocalConfigurableMaskStreakCorrector(
 			final ConfigurableMaskStreakCorrector corrector,
 			final int gaussianBlurRadius,

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -19,6 +19,10 @@ import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}.
  * This applies the mask of the {@link ConfigurableMaskStreakExtractor} to parts of the input image.
@@ -29,9 +33,9 @@ public class LocalConfigurableMaskStreakCorrector
         extends ConfigurableMaskStreakCorrector
         implements Filter {
 
-	private final int gaussianBlurRadius;
-	private final float initialThreshold;
-	private final float finalThreshold;
+	private int gaussianBlurRadius;
+	private float initialThreshold;
+	private float finalThreshold;
 
 
     public LocalConfigurableMaskStreakCorrector(
@@ -43,6 +47,33 @@ public class LocalConfigurableMaskStreakCorrector
 		this.gaussianBlurRadius = gaussianBlurRadius;
 		this.initialThreshold = initialThreshold;
 		this.finalThreshold = finalThreshold;
+	}
+
+	@Override
+	public void init(final Map<String, String> params) {
+		final List<String> values = new LinkedList<>(List.of(Filter.getCommaSeparatedStringParameter(DATA_STRING_NAME, params)));
+
+		final int nParams = values.size();
+		final boolean canHoldAllParameters = (nParams >= 3);
+		if (! canHoldAllParameters) {
+			throw new IllegalArgumentException(DATA_STRING_NAME +
+													   " must have pattern <corrector arguments>,<gaussianBlurRadius>,<initialThreshold>,<finalThreshold>");
+		}
+
+		this.finalThreshold = Float.parseFloat(values.remove(nParams - 1));
+		this.initialThreshold = Float.parseFloat(values.remove(nParams - 2));
+		this.gaussianBlurRadius = Integer.parseInt(values.remove(nParams - 3));
+
+		final String remainingParams = String.join(",", values);
+		super.init(Map.of(DATA_STRING_NAME, remainingParams));
+	}
+
+	@Override
+	public String toDataString() {
+		return super.toDataString() + ',' +
+				gaussianBlurRadius + ',' +
+				initialThreshold + ',' +
+				finalThreshold;
 	}
 
     @Override

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -16,8 +16,6 @@ import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import org.janelia.alignment.filter.Filter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -25,20 +25,20 @@ import java.util.Map;
 
 /**
  * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}.
- * This applies the mask of the {@link ConfigurableMaskStreakCorrector} to parts of the input image.
+ * This applies the mask of the {@link SmoothMaskStreakCorrector} to parts of the input image.
  *
  * @author Michael Innerberger
  */
-public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreakCorrector {
+public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 
 	private int gaussianBlurRadius;
 	private float initialThreshold;
 	private float finalThreshold;
 
 
-	// TODO: this duplicates LocalSmoothMaskStreakCorrector; find a way to unify this
-    public LocalConfigurableMaskStreakCorrector(
-			final ConfigurableMaskStreakCorrector corrector,
+	// TODO: this duplicates LocalConfigurableMaskStreakCorrector; find a way to unify this
+    public LocalSmoothMaskStreakCorrector(
+			final SmoothMaskStreakCorrector corrector,
 			final int gaussianBlurRadius,
 			final float initialThreshold,
 			final float finalThreshold) {

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -96,6 +96,7 @@ public class SmoothMaskStreakCorrector
         final RandomAccess<FloatType> ra = mask.randomAccess();
         final double outerSigma = 2 * outerRadius * outerRadius;
         final double innerSigma = 2 * innerRadius * innerRadius;
+        final double bandSigma = 2 * bandWidth * bandWidth;
         final double rad = Math.toRadians(angle);
         final double s = Math.sin(rad);
         final double c = Math.cos(rad);
@@ -109,7 +110,7 @@ public class SmoothMaskStreakCorrector
                 final double newX2 = newX * newX;
                 final double newY2 = newY * newY;
                 final float dog = (float) (Math.exp(-newX2 / outerSigma) - Math.exp(-newX2 / innerSigma));
-                final float band = (float) Math.exp(-newY2 / bandWidth);
+                final float band = (float) Math.exp(-newY2 / bandSigma);
 
                 ra.setPosition(x, 0);
                 ra.setPosition(y, 1);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -96,8 +96,9 @@ public class SmoothMaskStreakCorrector
         final RandomAccess<FloatType> ra = mask.randomAccess();
         final double outerSigma = 2 * outerRadius * outerRadius;
         final double innerSigma = 2 * innerRadius * innerRadius;
-        final double s = Math.sin(angle);
-        final double c = Math.cos(angle);
+        final double rad = Math.toRadians(angle);
+        final double s = Math.sin(rad);
+        final double c = Math.cos(rad);
 
         // smooth with a difference of gaussian (dog) profile in the radial direction (given by angle)
         // multiplied by a small gaussian band in the orthogonal direction

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -11,8 +11,6 @@ import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
-import org.apache.commons.lang.math.DoubleRange;
-import org.apache.commons.lang.math.IntRange;
 import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +20,18 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 /**
- * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}
- * (derived from original code to correct Z07422_17_VNC_1 volume).
+ * Streak corrector with a smooth parameterized mask that can also be used as {@link Filter}.
+ * The mask is a difference of gaussian (dog) profile in the radial direction (given by angle)
+ * multiplied by a small gaussian band in the orthogonal direction.
+ * The tunable parameters are:
+ * <ul>
+ * <li>innerRadius: inner radius of the dog profile in px; smaller values may improve de-streaking, values that are too small tinker with the overall intensity of the image</li>
+ * <li>outerRadius: outer radius of the dog profile in px; larger values may improve de-streaking, values that are too high ? </li>
+ * <li>bandWidth: width of the gaussian band in px; smaller values may improve de-streaking, values that are too high blur the image in the direction orthogonal to the angle</li>
+ * <li>angle: angle of the band in deg; this should be orthogonal to the streaks (e.g., choose an angle of 0.0 for vertical streaks and 90.0 vor horizontal ones)</li>
+ * </ul>
  *
- * @author Stephan Preibisch
- * @author Eric Trautman
+ * @author Michael Innerberger
  */
 public class SmoothMaskStreakCorrector
         extends StreakCorrector

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -36,6 +36,14 @@ public abstract class StreakCorrector {
         this.numThreads = numThreads;
     }
 
+    protected static void ensureDimensions(final Dimensions dim, final int width, final int height) {
+        if (dim.dimension(0) != width || dim.dimension(1) != height) {
+            throw new IllegalArgumentException(
+                    "mask is hard-coded for an FFT size of " + width + " x " + height +
+                    " but requested FFT size is " + dim.dimension(0) + " x " + dim.dimension(1));
+        }
+    }
+
     public int getNumThreads() {
         return numThreads;
     }

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -1,5 +1,6 @@
 package org.janelia.alignment.destreak;
 
+import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +29,7 @@ import net.imglib2.view.Views;
  * @author Stephan Preibisch
  */
 @SuppressWarnings("CommentedOutCode")
-public abstract class StreakCorrector {
+public abstract class StreakCorrector implements Filter {
 
     private final int numThreads;
 

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -101,7 +101,6 @@ public class ConfigurableStreakCorrectorTest {
                                           6161,
                                           8190,
                                           30,
-                                          5000,
                                           15,
                                           0.0);
 

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -156,8 +156,8 @@ done
         final String srcPath = "/Users/trautmane/Desktop/cellmap_cosem/jrc_hum-airway-14953vc/raw-images/" +
                                HUM_AIRWAY_FILE_NAMES[0]; // change file names index to test different images
 
-//        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR, 100, 20.0f, 0.1f);
-		displayStreakCorrectionResult(srcPath, SMOOTH_MASK_STREAK_CORRECTOR);
+        final StreakCorrector corrector = new LocalSmoothMaskStreakCorrector(SMOOTH_MASK_STREAK_CORRECTOR, 100, 8.0f, 0.1f);
+        displayStreakCorrectionResult(srcPath, corrector);
 //        displayStreakCorrectionDetails(srcPath, HUM_AIRWAY_CORRECTOR);
     }
 

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -161,10 +161,9 @@ done
 		displayStreakCorrection(srcPath, SMOOTH_MASK_STREAK_CORRECTOR, false);
     }
 
-    public static <T extends StreakCorrector & Filter>
-    void displayStreakCorrection(final String srcPath,
-                                 final T corrector,
-                                 final boolean displayCorrectionData) {
+    public static void displayStreakCorrection(final String srcPath,
+                                               final StreakCorrector corrector,
+                                               final boolean displayCorrectionData) {
 
         final ImagePlus imp = new ImagePlus(srcPath);
 

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -100,9 +100,9 @@ public class ConfigurableStreakCorrectorTest {
             new SmoothMaskStreakCorrector(8,
                                           6161,
                                           8190,
-                                          50,
-                                          3000,
-                                          50,
+                                          30,
+                                          5000,
+                                          15,
                                           0.0);
 
     public static final String[] HUM_AIRWAY_FILE_NAMES = {
@@ -158,13 +158,14 @@ done
         final String srcPath = "/Users/trautmane/Desktop/cellmap_cosem/jrc_hum-airway-14953vc/raw-images/" +
                                HUM_AIRWAY_FILE_NAMES[0]; // change file names index to test different images
 
-        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR, 100, 20.0f, 0.1f);
-        displayStreakCorrection(srcPath, corrector, false);
+//        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR, 100, 20.0f, 0.1f);
+		displayStreakCorrection(srcPath, SMOOTH_MASK_STREAK_CORRECTOR, false);
     }
 
-    public static void displayStreakCorrection(final String srcPath,
-                                               final ConfigurableMaskStreakCorrector corrector,
-                                               final boolean displayCorrectionData) {
+    public static <T extends StreakCorrector & Filter>
+    void displayStreakCorrection(final String srcPath,
+                                 final T corrector,
+                                 final boolean displayCorrectionData) {
 
         final ImagePlus imp = new ImagePlus(srcPath);
 

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -148,9 +148,8 @@ done
         final String srcPath = "/Users/trautmane/Desktop/cellmap_cosem/jrc_hum-airway-14953vc/raw-images/" +
                                HUM_AIRWAY_FILE_NAMES[0]; // change file names index to test different images
 
-        displayStreakCorrection(srcPath,
-                                HUM_AIRWAY_CORRECTOR,
-                                true);
+        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR);
+        displayStreakCorrection(srcPath, corrector, false);
     }
 
     public static void displayStreakCorrection(final String srcPath,

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -5,6 +5,7 @@ import ij.ImagePlus;
 
 import java.util.Map;
 
+import org.janelia.alignment.filter.Filter;
 import org.janelia.alignment.filter.FilterSpec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -94,6 +95,15 @@ public class ConfigurableStreakCorrectorTest {
                                                 0,
                                                 0,
                                                 HUM_AIRWAY_REGIONS_TO_CLEAR);
+
+    public static final SmoothMaskStreakCorrector SMOOTH_MASK_STREAK_CORRECTOR =
+            new SmoothMaskStreakCorrector(8,
+                                          6161,
+                                          8190,
+                                          50,
+                                          3000,
+                                          50,
+                                          0.0);
 
     public static final String[] HUM_AIRWAY_FILE_NAMES = {
             "23-12-04_185805_0-0-0.4664.0.tif",

--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -148,7 +148,7 @@ done
         final String srcPath = "/Users/trautmane/Desktop/cellmap_cosem/jrc_hum-airway-14953vc/raw-images/" +
                                HUM_AIRWAY_FILE_NAMES[0]; // change file names index to test different images
 
-        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR);
+        final ConfigurableMaskStreakCorrector corrector = new LocalConfigurableMaskStreakCorrector(HUM_AIRWAY_CORRECTOR, 100, 20.0f, 0.1f);
         displayStreakCorrection(srcPath, corrector, false);
     }
 


### PR DESCRIPTION
I implemented a first version of local de-streaking. The locality is based on the following algorithm:
1. de-streak with band-pass
2. threshold difference to get only the streaks
3. blur the result and threshold again to get a larger area around the streaks
4. blur the result again to get a smooth transition
5. use the result as a local weight between the original and the de-streaked image

The locality works reasonably well, the overall result looks not that convincing, though. This may be based on the non-linear intensity transformation that the de-streaking introduces (there are lighter and darker regions simultaneously).

Side note: My manual tests in FIJI looked a little better, which could be due to the different (i.e., not as invasive) band-pass that I applied there.

![Screenshot from 2024-02-22 18-17-08](https://github.com/saalfeldlab/render/assets/20970305/4c51d567-5821-448e-b3ef-a233c2a0db99)