### PR TITLE
Fix: streak correction

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -139,7 +139,9 @@ public class ConfigurableMaskStreakCorrector extends StreakCorrector {
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-		final Img<FloatType> img = copyToFloatImg(ip, "input");
+        final ImagePlus floatIP = new ImagePlus("input", ip.convertToFloat());
+        final Img<FloatType> img = ImageJFunctions.wrapFloat(floatIP);
+        checkWrappingSucceeded(img, ip, FloatType.class);
 
         final double avg = StreakCorrector.avgIntensity(img);
         LOG.debug("process: average intensity is {}", avg);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -139,7 +139,7 @@ public class ConfigurableMaskStreakCorrector extends StreakCorrector {
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-		final Img<FloatType> img = coptyToFloatImg(ip, "input");
+		final Img<FloatType> img = copyToFloatImg(ip, "input");
 
         final double avg = StreakCorrector.avgIntensity(img);
         LOG.debug("process: average intensity is {}", avg);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakCorrector.java
@@ -139,12 +139,7 @@ public class ConfigurableMaskStreakCorrector extends StreakCorrector {
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-        final ImagePlus imp = new ImagePlus("input", ip.convertToFloat());
-        final Img<FloatType> img = ImageJFunctions.wrapFloat(imp);
-        if (img == null) {
-            throw new IllegalArgumentException("failed to wrap " + ip.getClass().getName() +
-                                               " as Img<UnsignedByteType>");
-        }
+		final Img<FloatType> img = coptyToFloatImg(ip, "input");
 
         final double avg = StreakCorrector.avgIntensity(img);
         LOG.debug("process: average intensity is {}", avg);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -7,7 +7,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
-import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
 
 /**
@@ -33,14 +32,12 @@ public class ConfigurableMaskStreakExtractor
                         final double scale) {
 
         // save original image for later subtraction
-        final ImagePlus originalImagePlus = new ImagePlus("original", ip.duplicate());
-        final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalImagePlus);
+        final Img<FloatType> original = copyToFloatImg(ip, "original");
 
         // de-streak image
         super.process(ip, scale);
 
-        final ImagePlus fixedImagePlus = new ImagePlus("fixed", ip);
-        final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedImagePlus);
+        final Img<FloatType> fixed = copyToFloatImg(ip, "fixed");
 
         // subtract fixed from original to get streaks - has to be FloatType since there may be negative values
         final RandomAccessibleInterval<FloatType> streaks =

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -32,14 +32,18 @@ public class ConfigurableMaskStreakExtractor
                         final double scale) {
 
         // save original image for later subtraction
-        final Img<FloatType> original = copyToFloatImg(ip, "original");
+        final ImagePlus originalIP = new ImagePlus("original", ip.convertToFloat());
+        final Img<FloatType> original = ImageJFunctions.wrapFloat(originalIP);
+        checkWrappingSucceeded(original, ip, FloatType.class);
 
-        // de-streak image
+		// de-streak image
         super.process(ip, scale);
 
-        final Img<FloatType> fixed = copyToFloatImg(ip, "fixed");
+        final ImagePlus fixedIP = new ImagePlus("fixed", ip.convertToFloat());
+        final Img<FloatType> fixed = ImageJFunctions.wrapFloat(fixedIP);
+        checkWrappingSucceeded(fixed, ip, FloatType.class);
 
-        // subtract fixed from original to get streaks - has to be FloatType since there may be negative values
+		// subtract fixed from original to get streaks - has to be FloatType since there may be negative values
         final RandomAccessibleInterval<FloatType> streaks =
                 Converters.convertRAI(original,
                                       fixed,

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -36,14 +36,14 @@ public class ConfigurableMaskStreakExtractor
         final Img<FloatType> original = ImageJFunctions.wrapFloat(originalIP);
         checkWrappingSucceeded(original, ip, FloatType.class);
 
-		// de-streak image
+        // de-streak image
         super.process(ip, scale);
 
         final ImagePlus fixedIP = new ImagePlus("fixed", ip.convertToFloat());
         final Img<FloatType> fixed = ImageJFunctions.wrapFloat(fixedIP);
         checkWrappingSucceeded(fixed, ip, FloatType.class);
 
-		// subtract fixed from original to get streaks - has to be FloatType since there may be negative values
+        // subtract fixed from original to get streaks - has to be FloatType since there may be negative values
         final RandomAccessibleInterval<FloatType> streaks =
                 Converters.convertRAI(original,
                                       fixed,

--- a/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/ConfigurableMaskStreakExtractor.java
@@ -33,7 +33,7 @@ public class ConfigurableMaskStreakExtractor
                         final double scale) {
 
         // save original image for later subtraction
-        final ImagePlus originalImagePlus = new ImagePlus("original", ip.convertToByteProcessor());
+        final ImagePlus originalImagePlus = new ImagePlus("original", ip.duplicate());
         final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalImagePlus);
 
         // de-streak image

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -90,12 +90,20 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
 		// save original image for later subtraction
 		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
+		if (original == null) {
+			throw new IllegalArgumentException("failed to wrap " + originalIP.getClass().getName() +
+													   " as Img<UnsignedByteType>");
+		}
 
 		// de-streak image
 		super.process(ip, scale);
 
 		final ImagePlus fixedIP = new ImagePlus("fixed", ip);
 		final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedIP);
+		if (fixed == null) {
+			throw new IllegalArgumentException("failed to wrap " + fixedIP.getClass().getName() +
+													   " as Img<UnsignedByteType>");
+		}
 
 		// subtract fixed from original to get streaks, which is where the correction should be applied
 		final RandomAccessibleInterval<FloatType> weight =

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -29,10 +29,18 @@ import java.util.Map;
  */
 public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreakCorrector {
 
-	private int gaussianBlurRadius;
-	private float initialThreshold;
-	private float finalThreshold;
+	private int gaussianBlurRadius = 0;
+	private double initialThreshold = 0.0;
+	private double finalThreshold = 0.0;
 
+
+	public LocalConfigurableMaskStreakCorrector() {
+		this(1);
+	}
+
+	public LocalConfigurableMaskStreakCorrector(final int numThreads) {
+		super(numThreads);
+	}
 
 	// TODO: this duplicates LocalSmoothMaskStreakCorrector; find a way to unify this
     public LocalConfigurableMaskStreakCorrector(
@@ -57,8 +65,8 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
 													   " must have pattern <corrector arguments>,<gaussianBlurRadius>,<initialThreshold>,<finalThreshold>");
 		}
 
-		this.finalThreshold = Float.parseFloat(values.remove(nParams - 1));
-		this.initialThreshold = Float.parseFloat(values.remove(nParams - 2));
+		this.finalThreshold = Double.parseDouble(values.remove(nParams - 1));
+		this.initialThreshold = Double.parseDouble(values.remove(nParams - 2));
 		this.gaussianBlurRadius = Integer.parseInt(values.remove(nParams - 3));
 
 		final String remainingParams = String.join(",", values);
@@ -92,16 +100,16 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
 									  (i1,i2,o) -> o.set(Math.abs(i1.get() - i2.get())),
 									  new FloatType());
 
-		weigthedSum(ip, originalIP.getProcessor(), weight);
+		weightedSum(ip, originalIP.getProcessor(), weight);
 	}
 
-	private void weigthedSum(final ImageProcessor target,
-									final ImageProcessor original,
-									final RandomAccessibleInterval<FloatType> weight) {
+	private void weightedSum(final ImageProcessor target,
+							 final ImageProcessor original,
+							 final RandomAccessibleInterval<FloatType> weight) {
 
-		final ImagePlus weigthIP = ImageJFunctions.wrapFloat(weight, "weight");
+		final ImagePlus weightIP = ImageJFunctions.wrapFloat(weight, "weight");
 		final GaussianBlur gaussianBlur = new GaussianBlur();
-		final ImagePlus extendedWeight = extendBorder(weigthIP, gaussianBlurRadius);
+		final ImagePlus extendedWeight = extendBorder(weightIP, gaussianBlurRadius);
 
 		// figure out where exactly the streaks are
 		threshold(extendedWeight.getProcessor(), initialThreshold);
@@ -124,7 +132,7 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
 		}
 	}
 
-	private static void threshold(final ImageProcessor ip, final float threshold) {
+	private static void threshold(final ImageProcessor ip, final double threshold) {
 		for (int i = 0; i < ip.getPixelCount(); i++) {
 			final int value = ip.getf(i) > threshold ? 1 : 0;
 			ip.setf(i, value);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -76,7 +76,7 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
     @Override
     public void process(final ImageProcessor ip, final double scale) {
 		// save original image for later subtraction
-		final ImagePlus originalIP = new ImagePlus("original", ip.convertToByteProcessor());
+		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
 
 		// de-streak image

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -88,22 +88,16 @@ public class LocalConfigurableMaskStreakCorrector extends ConfigurableMaskStreak
     @Override
     public void process(final ImageProcessor ip, final double scale) {
 		// save original image for later subtraction
-		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
+		final ImagePlus originalIP = new ImagePlus("original", ip.convertToByteProcessor());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
-		if (original == null) {
-			throw new IllegalArgumentException("failed to wrap " + originalIP.getClass().getName() +
-													   " as Img<UnsignedByteType>");
-		}
+		checkWrappingSucceeded(original, ip, UnsignedByteType.class);
 
 		// de-streak image
 		super.process(ip, scale);
 
 		final ImagePlus fixedIP = new ImagePlus("fixed", ip);
 		final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedIP);
-		if (fixed == null) {
-			throw new IllegalArgumentException("failed to wrap " + fixedIP.getClass().getName() +
-													   " as Img<UnsignedByteType>");
-		}
+		checkWrappingSucceeded(fixed, ip, UnsignedByteType.class);
 
 		// subtract fixed from original to get streaks, which is where the correction should be applied
 		final RandomAccessibleInterval<FloatType> weight =

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalConfigurableMaskStreakCorrector.java
@@ -24,6 +24,10 @@ import java.util.Map;
 /**
  * Streak corrector with a configurable/parameterized mask that can also be used as {@link Filter}.
  * This applies the mask of the {@link ConfigurableMaskStreakCorrector} to parts of the input image.
+ * The maks is created by thresholding the difference between the original and corrected image:
+ * 1. The difference (=the streak pattern) is thresholded at initialThreshold (in [0, 255])
+ * 2. The thresholded difference is smoothed with a Gaussian blur of radius gaussianBlurRadius
+ * 3. The smoothed difference is thresholded at finalThreshold (in [0, 1])
  *
  * @author Michael Innerberger
  */

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -30,8 +30,8 @@ import java.util.Map;
 public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 
 	private int gaussianBlurRadius = 0;
-	private float initialThreshold = 0.0f; // TODO: why is this a float instead of a double?
-	private float finalThreshold = 0.0f; // TODO: why is this a float instead of a double?
+	private double initialThreshold = 0.0;
+	private double finalThreshold = 0.0;
 
 	public LocalSmoothMaskStreakCorrector() {
 		this(1);
@@ -64,8 +64,8 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 													   " must have pattern <corrector arguments>,<gaussianBlurRadius>,<initialThreshold>,<finalThreshold>");
 		}
 
-		this.finalThreshold = Float.parseFloat(values.remove(nParams - 1));
-		this.initialThreshold = Float.parseFloat(values.remove(nParams - 2));
+		this.finalThreshold = Double.parseDouble(values.remove(nParams - 1));
+		this.initialThreshold = Double.parseDouble(values.remove(nParams - 2));
 		this.gaussianBlurRadius = Integer.parseInt(values.remove(nParams - 3));
 
 		final String remainingParams = String.join(",", values);
@@ -99,16 +99,16 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 									  (i1,i2,o) -> o.set(Math.abs(i1.get() - i2.get())),
 									  new FloatType());
 
-		weigthedSum(ip, originalIP.getProcessor(), weight);
+		weightedSum(ip, originalIP.getProcessor(), weight);
 	}
 
-	private void weigthedSum(final ImageProcessor target,
-									final ImageProcessor original,
-									final RandomAccessibleInterval<FloatType> weight) {
+	private void weightedSum(final ImageProcessor target,
+							 final ImageProcessor original,
+							 final RandomAccessibleInterval<FloatType> weight) {
 
-		final ImagePlus weigthIP = ImageJFunctions.wrapFloat(weight, "weight");
+		final ImagePlus weightIP = ImageJFunctions.wrapFloat(weight, "weight");
 		final GaussianBlur gaussianBlur = new GaussianBlur();
-		final ImagePlus extendedWeight = extendBorder(weigthIP, gaussianBlurRadius);
+		final ImagePlus extendedWeight = extendBorder(weightIP, gaussianBlurRadius);
 
 		// figure out where exactly the streaks are
 		threshold(extendedWeight.getProcessor(), initialThreshold);
@@ -131,7 +131,7 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 		}
 	}
 
-	private static void threshold(final ImageProcessor ip, final float threshold) {
+	private static void threshold(final ImageProcessor ip, final double threshold) {
 		for (int i = 0; i < ip.getPixelCount(); i++) {
 			final int value = ip.getf(i) > threshold ? 1 : 0;
 			ip.setf(i, value);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -85,12 +85,20 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
 		// save original image for later subtraction
 		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
+		if (original == null) {
+			throw new IllegalArgumentException("failed to wrap " + originalIP.getClass().getName() +
+													   " as Img<UnsignedByteType>");
+		}
 
 		// de-streak image
 		super.process(ip, scale);
 
 		final ImagePlus fixedIP = new ImagePlus("fixed", ip);
 		final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedIP);
+		if (fixed == null) {
+			throw new IllegalArgumentException("failed to wrap " + fixedIP.getClass().getName() +
+													   " as Img<UnsignedByteType>");
+		}
 
 		// subtract fixed from original to get streaks, which is where the correction should be applied
 		final RandomAccessibleInterval<FloatType> weight =

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -83,22 +83,16 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
     @Override
     public void process(final ImageProcessor ip, final double scale) {
 		// save original image for later subtraction
-		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
+		final ImagePlus originalIP = new ImagePlus("original", ip.convertToByteProcessor());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
-		if (original == null) {
-			throw new IllegalArgumentException("failed to wrap " + originalIP.getClass().getName() +
-													   " as Img<UnsignedByteType>");
-		}
+		checkWrappingSucceeded(original, ip, UnsignedByteType.class);
 
 		// de-streak image
 		super.process(ip, scale);
 
 		final ImagePlus fixedIP = new ImagePlus("fixed", ip);
 		final Img<UnsignedByteType> fixed = ImageJFunctions.wrapByte(fixedIP);
-		if (fixed == null) {
-			throw new IllegalArgumentException("failed to wrap " + fixedIP.getClass().getName() +
-													   " as Img<UnsignedByteType>");
-		}
+		checkWrappingSucceeded(fixed, ip, UnsignedByteType.class);
 
 		// subtract fixed from original to get streaks, which is where the correction should be applied
 		final RandomAccessibleInterval<FloatType> weight =

--- a/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/LocalSmoothMaskStreakCorrector.java
@@ -83,7 +83,7 @@ public class LocalSmoothMaskStreakCorrector extends SmoothMaskStreakCorrector {
     @Override
     public void process(final ImageProcessor ip, final double scale) {
 		// save original image for later subtraction
-		final ImagePlus originalIP = new ImagePlus("original", ip.convertToByteProcessor());
+		final ImagePlus originalIP = new ImagePlus("original", ip.duplicate());
 		final Img<UnsignedByteType> original = ImageJFunctions.wrapByte(originalIP);
 
 		// de-streak image

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -173,9 +173,11 @@ public class SmoothMaskStreakCorrector
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-        final Img<FloatType> img = copyToFloatImg(ip, "input");
+        final ImagePlus floatIP = new ImagePlus("input", ip.convertToFloat());
+        final Img<FloatType> img = ImageJFunctions.wrapFloat(floatIP);
+        checkWrappingSucceeded(img, ip, FloatType.class);
 
-        // remove streaking
+		// remove streaking
         final Img<FloatType> imgCorr = fftBandpassCorrection(img, false);
 
         // convert to 8-bit grayscale

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -173,11 +173,7 @@ public class SmoothMaskStreakCorrector
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-        final ImagePlus imp = new ImagePlus("input", ip.convertToFloat());
-        final Img<FloatType> img = ImageJFunctions.wrapFloat(imp);
-        if (img == null) {
-            throw new IllegalArgumentException("failed to wrap " + ip.getClass().getName() + " as Img<UnsignedByteType>");
-        }
+        final Img<FloatType> img = coptyToFloatImg(ip, "input");
 
         // remove streaking
         final Img<FloatType> imgCorr = fftBandpassCorrection(img, false);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -173,7 +173,7 @@ public class SmoothMaskStreakCorrector
             throw new UnsupportedOperationException("this filter only supports full scale images");
         }
 
-        final Img<FloatType> img = coptyToFloatImg(ip, "input");
+        final Img<FloatType> img = copyToFloatImg(ip, "input");
 
         // remove streaking
         final Img<FloatType> imgCorr = fftBandpassCorrection(img, false);

--- a/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/SmoothMaskStreakCorrector.java
@@ -177,7 +177,7 @@ public class SmoothMaskStreakCorrector
         final Img<FloatType> img = ImageJFunctions.wrapFloat(floatIP);
         checkWrappingSucceeded(img, ip, FloatType.class);
 
-		// remove streaking
+        // remove streaking
         final Img<FloatType> imgCorr = fftBandpassCorrection(img, false);
 
         // convert to 8-bit grayscale

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -1,5 +1,7 @@
 package org.janelia.alignment.destreak;
 
+import ij.ImagePlus;
+import ij.process.ImageProcessor;
 import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,15 @@ public abstract class StreakCorrector implements Filter {
                     "mask is hard-coded for an FFT size of " + width + " x " + height +
                     " but requested FFT size is " + dim.dimension(0) + " x " + dim.dimension(1));
         }
+    }
+
+    protected static Img<FloatType> coptyToFloatImg(final ImageProcessor ip, final String name) {
+        final ImagePlus imp = new ImagePlus(name, ip.convertToFloat());
+        final Img<FloatType> img = ImageJFunctions.wrapFloat(imp);
+        if (img == null) {
+            throw new IllegalArgumentException("failed to wrap " + ip.getClass().getName() + " as Img<FloatType>");
+        }
+        return img;
     }
 
     public int getNumThreads() {

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -1,8 +1,7 @@
 package org.janelia.alignment.destreak;
 
-import ij.ImagePlus;
 import ij.process.ImageProcessor;
-import net.imglib2.img.imageplus.FloatImagePlus;
+import net.imglib2.type.Type;
 import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,13 +47,11 @@ public abstract class StreakCorrector implements Filter {
         }
     }
 
-    protected static FloatImagePlus<FloatType> copyToFloatImg(final ImageProcessor ip, final String name) {
-        final ImagePlus imp = new ImagePlus(name, ip.convertToFloat());
-        final Img<FloatType> img = ImageJFunctions.wrapFloat(imp);
+    protected static void checkWrappingSucceeded(final Img<?> img, final ImageProcessor ip, final Class<? extends Type<?>> typeClass) {
         if (img == null) {
-            throw new IllegalArgumentException("failed to wrap " + ip.getClass().getName() + " as Img<FloatType>");
+            final String ipClass = ip.getClass().getName();
+            throw new IllegalArgumentException("failed to wrap " + ipClass + " as Img<" + typeClass + ">");
         }
-        return (FloatImagePlus<FloatType>) img;
     }
 
     public int getNumThreads() {

--- a/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
+++ b/render-app/src/main/java/org/janelia/alignment/destreak/StreakCorrector.java
@@ -2,6 +2,7 @@ package org.janelia.alignment.destreak;
 
 import ij.ImagePlus;
 import ij.process.ImageProcessor;
+import net.imglib2.img.imageplus.FloatImagePlus;
 import org.janelia.alignment.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,13 +48,13 @@ public abstract class StreakCorrector implements Filter {
         }
     }
 
-    protected static Img<FloatType> coptyToFloatImg(final ImageProcessor ip, final String name) {
+    protected static FloatImagePlus<FloatType> copyToFloatImg(final ImageProcessor ip, final String name) {
         final ImagePlus imp = new ImagePlus(name, ip.convertToFloat());
         final Img<FloatType> img = ImageJFunctions.wrapFloat(imp);
         if (img == null) {
             throw new IllegalArgumentException("failed to wrap " + ip.getClass().getName() + " as Img<FloatType>");
         }
-        return img;
+        return (FloatImagePlus<FloatType>) img;
     }
 
     public int getNumThreads() {


### PR DESCRIPTION
I tried to make the streak correction code a bit more robust:
* All computations in non-local `StreakCorrector`s are done in `FloatType`
* All computations in local ones are done in `UnsignedByteType`
* All wrappings have a check that blows up with a sensible error message if the wrapping didn't work  