### PR TITLE
Feature: MFOV layer-prealign

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -76,9 +76,9 @@ public class MultiSemPreAlignClient implements Serializable {
 
 		@Parameter(
 				names = "--maxNumMatches",
-				description = "Max number of matches between mFOV layers (default:100)"
+				description = "Max number of matches between mFOV layers (default:1000)"
 		)
-		public Integer maxNumMatches = 100;
+		public Integer maxNumMatches = 1000;
 
 		@Parameter(
 				names = "--numThreads",
@@ -151,7 +151,7 @@ public class MultiSemPreAlignClient implements Serializable {
 		for (final Map.Entry<String, RigidModel2D> entry : tileIdToModel.entrySet()) {
 			final String tileId = entry.getKey();
 			final TransformSpec transformSpec = SolveTools.getTransformSpec(entry.getValue());
-			rtsc.addTransformSpecToTile(tileId, transformSpec, TransformApplicationMethod.REPLACE_LAST);
+			rtsc.addTransformSpecToTile(tileId, transformSpec, TransformApplicationMethod.PRE_CONCATENATE_LAST);
 		}
 
 		dataClient.saveResolvedTiles(rtsc, parameters.targetStack, null );

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -95,10 +95,6 @@ public class MultiSemPreAlignClient implements Serializable {
 				final MultiSemPreAlignClient client = new MultiSemPreAlignClient(parameters);
 
 				client.process();
-
-				if (parameters.completeTargetStack) {
-					client.completeTargetStack();
-				}
 			}
 		};
 		clientRunner.run();
@@ -118,7 +114,7 @@ public class MultiSemPreAlignClient implements Serializable {
 		dataClient.setupDerivedStack(stackMetaData, parameters.targetStack);
 	}
 
-	private void completeTargetStack() throws Exception {
+	private void completeTargetStack() throws IOException {
 		dataClient.setStackState(parameters.targetStack, StackMetaData.StackState.COMPLETE);
 	}
 
@@ -154,8 +150,12 @@ public class MultiSemPreAlignClient implements Serializable {
 		}
 
 		dataClient.saveResolvedTiles(rtsc, parameters.targetStack, null );
+		if (parameters.completeTargetStack) {
+			completeTargetStack();
+		}
 	}
 
+	// TODO: substitute with SolveTools.getTransformSpec(model.createAffine()) once this is fixed
 	public static LeafTransformSpec getTransformSpec(final RigidModel2D model) {
 		final double[] m = new double[6];
 		model.toArray(m);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -1,0 +1,168 @@
+package org.janelia.render.client;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import mpicbg.models.RigidModel2D;
+import org.janelia.alignment.match.CanvasMatches;
+import org.janelia.alignment.spec.LeafTransformSpec;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection.TransformApplicationMethod;
+import org.janelia.alignment.spec.ResolvedTileSpecsWithMatchPairs;
+import org.janelia.alignment.spec.TransformSpec;
+import org.janelia.alignment.spec.stack.StackMetaData;
+import org.janelia.render.client.newsolver.solvers.affine.MultiSemPreAligner;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.MatchCollectionParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public class MultiSemPreAlignClient implements Serializable {
+
+	public static class Parameters extends CommandLineParameters {
+
+		@ParametersDelegate
+		public RenderWebServiceParameters renderWeb = new RenderWebServiceParameters();
+
+		@ParametersDelegate
+		public MatchCollectionParameters matches = new MatchCollectionParameters();
+
+		@Parameter(
+				names = "--stack",
+				description = "Name of source stack",
+				required = true)
+		public String stack;
+
+		@Parameter(
+				names = "--targetStack",
+				description = "Name of target stack",
+				required = true)
+		public String targetStack;
+
+		@Parameter(
+				names = "--completeTargetStack",
+				description = "Complete the target stack after pre-alignment",
+				arity = 0)
+		public boolean completeTargetStack = false;
+
+		@Parameter(
+				names = "--maxAllowedError",
+				description = "Max allowed error (default:10.0)"
+		)
+		public Double maxAllowedError = 10.0;
+
+		@Parameter(
+				names = "--maxIterations",
+				description = "Max iterations (default:1000)"
+		)
+		public Integer maxIterations = 1000;
+
+		@Parameter(
+				names = "--maxPlateauWidth",
+				description = "Max plateau width (default:250)"
+		)
+		public Integer maxPlateauWidth = 250;
+
+		@Parameter(
+				names = "--maxNumMatches",
+				description = "Max number of matches between mFOV layers (default:100)"
+		)
+		public Integer maxNumMatches = 100;
+
+		@Parameter(
+				names = "--numThreads",
+				description = "Number of threads (default:8)"
+		)
+		public Integer numThreads = 8;
+	}
+
+	public static void main(final String[] args) {
+		final ClientRunner clientRunner = new ClientRunner(args) {
+			@Override
+			public void runClient(final String[] args) throws Exception {
+
+				final Parameters parameters = new Parameters();
+				parameters.parse(args);
+
+				LOG.info("runClient: entry, parameters={}", parameters);
+
+				final MultiSemPreAlignClient client = new MultiSemPreAlignClient(parameters);
+
+				client.process();
+
+				if (parameters.completeTargetStack) {
+					client.completeTargetStack();
+				}
+			}
+		};
+		clientRunner.run();
+	}
+
+
+	private final Parameters parameters;
+	private final RenderDataClient dataClient;
+
+	public MultiSemPreAlignClient(final Parameters parameters) {
+		this.parameters = parameters;
+		this.dataClient = parameters.renderWeb.getDataClient();
+	}
+
+	private void setUpTargetStack() throws IOException {
+		final StackMetaData stackMetaData = dataClient.getStackMetaData(parameters.stack);
+		dataClient.setupDerivedStack(stackMetaData, parameters.targetStack);
+	}
+
+	private void completeTargetStack() throws Exception {
+		dataClient.setStackState(parameters.targetStack, StackMetaData.StackState.COMPLETE);
+	}
+
+	private void process() throws IOException, ExecutionException, InterruptedException {
+		setUpTargetStack();
+
+		final ResolvedTileSpecsWithMatchPairs tileSpecsWithMatchPairs =
+				dataClient.getResolvedTilesWithMatchPairs(parameters.stack,
+														  null,
+														  parameters.matches.matchCollection,
+														  null,
+														  null,
+														  true);
+
+		final ResolvedTileSpecCollection rtsc = tileSpecsWithMatchPairs.getResolvedTileSpecs();
+		final List<CanvasMatches> matches = tileSpecsWithMatchPairs.getMatchPairs();
+
+		final MultiSemPreAligner<RigidModel2D> preAligner = new MultiSemPreAligner<>(
+				new RigidModel2D(),
+				parameters.maxAllowedError,
+				parameters.maxIterations,
+				parameters.maxPlateauWidth,
+				parameters.numThreads,
+				parameters.maxNumMatches
+		);
+
+		final Map<String, RigidModel2D> tileIdToModel = preAligner.preAlign(rtsc, matches);
+
+		for (final Map.Entry<String, RigidModel2D> entry : tileIdToModel.entrySet()) {
+			final String tileId = entry.getKey();
+			final TransformSpec transformSpec = getTransformSpec(entry.getValue());
+			rtsc.addTransformSpecToTile(tileId, transformSpec, TransformApplicationMethod.REPLACE_LAST);
+		}
+
+		dataClient.saveResolvedTiles(rtsc, parameters.targetStack, null );
+	}
+
+	public static LeafTransformSpec getTransformSpec(final RigidModel2D model) {
+		final double[] m = new double[6];
+		model.toArray(m);
+
+		final String data = String.valueOf(m[0]) + ' ' + m[1] + ' ' + m[2] + ' ' + m[3] + ' ' + m[4] + ' ' + m[5];
+		return new LeafTransformSpec(mpicbg.trakem2.transform.AffineModel2D.class.getName(), data);
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(MultiSemPreAlignClient.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -23,6 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * Coarsely aligns a multi-SEM stack by treating each mFOV layer as a single tile and using a rigid model.
+ *
+ * @author Michael Innerberger
+ */
 public class MultiSemPreAlignClient implements Serializable {
 
 	public static class Parameters extends CommandLineParameters {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -58,31 +58,31 @@ public class MultiSemPreAlignClient implements Serializable {
 
 		@Parameter(
 				names = "--maxAllowedError",
-				description = "Max allowed error (default:10.0)"
+				description = "Max allowed error"
 		)
 		public Double maxAllowedError = 10.0;
 
 		@Parameter(
 				names = "--maxIterations",
-				description = "Max iterations (default:1000)"
+				description = "Max iterations"
 		)
 		public Integer maxIterations = 1000;
 
 		@Parameter(
 				names = "--maxPlateauWidth",
-				description = "Max plateau width (default:250)"
+				description = "Max plateau width"
 		)
 		public Integer maxPlateauWidth = 250;
 
 		@Parameter(
 				names = "--maxNumMatches",
-				description = "Max number of matches between mFOV layers (default:1000)"
+				description = "Max number of matches between mFOV layers"
 		)
 		public Integer maxNumMatches = 1000;
 
 		@Parameter(
 				names = "--numThreads",
-				description = "Number of threads (default:8)"
+				description = "Number of threads"
 		)
 		public Integer numThreads = 8;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/MultiSemPreAlignClient.java
@@ -4,7 +4,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import mpicbg.models.RigidModel2D;
 import org.janelia.alignment.match.CanvasMatches;
-import org.janelia.alignment.spec.LeafTransformSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection.TransformApplicationMethod;
 import org.janelia.alignment.spec.ResolvedTileSpecsWithMatchPairs;
@@ -14,6 +13,7 @@ import org.janelia.render.client.newsolver.solvers.affine.MultiSemPreAligner;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MatchCollectionParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.solver.SolveTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,7 +150,7 @@ public class MultiSemPreAlignClient implements Serializable {
 
 		for (final Map.Entry<String, RigidModel2D> entry : tileIdToModel.entrySet()) {
 			final String tileId = entry.getKey();
-			final TransformSpec transformSpec = getTransformSpec(entry.getValue());
+			final TransformSpec transformSpec = SolveTools.getTransformSpec(entry.getValue());
 			rtsc.addTransformSpecToTile(tileId, transformSpec, TransformApplicationMethod.REPLACE_LAST);
 		}
 
@@ -158,15 +158,6 @@ public class MultiSemPreAlignClient implements Serializable {
 		if (parameters.completeTargetStack) {
 			completeTargetStack();
 		}
-	}
-
-	// TODO: substitute with SolveTools.getTransformSpec(model.createAffine()) once this is fixed
-	public static LeafTransformSpec getTransformSpec(final RigidModel2D model) {
-		final double[] m = new double[6];
-		model.toArray(m);
-
-		final String data = String.valueOf(m[0]) + ' ' + m[1] + ' ' + m[2] + ' ' + m[3] + ' ' + m[4] + ' ' + m[5];
-		return new LeafTransformSpec(mpicbg.trakem2.transform.AffineModel2D.class.getName(), data);
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(MultiSemPreAlignClient.class);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/Trakem2SolverPreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/Trakem2SolverPreAlignClient.java
@@ -25,6 +25,7 @@ import org.janelia.alignment.spec.stack.StackStats;
 import org.janelia.alignment.util.ScriptUtil;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.solver.SolveTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -548,7 +549,7 @@ public class Trakem2SolverPreAlignClient{
 
                     if (tile != null) {
                         resolvedTiles.addTransformSpecToTile(tileId,
-                                                             getTransformSpec(tile.getModel()),
+                                                             SolveTools.getTransformSpec(tile.getModel()),
                                                              REPLACE_LAST);
                     }
 
@@ -565,13 +566,6 @@ public class Trakem2SolverPreAlignClient{
         }
 
         LOG.info("saveTargetStackTiles: exit");
-    }
-
-    private LeafTransformSpec getTransformSpec(final TranslationModel2D forModel) {
-        final double[] m = new double[6];
-        forModel.toArray(m);
-        final String data = String.valueOf(m[0]) + ' ' + m[1] + ' ' + m[2] + ' ' + m[3] + ' ' + m[4] + ' ' + m[5];
-        return new LeafTransformSpec(mpicbg.trakem2.transform.AffineModel2D.class.getName(), data);
     }
 
     private TileSpec getTileSpec(final String sectionId,

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
@@ -1,0 +1,173 @@
+package org.janelia.render.client.newsolver.solvers.affine;
+
+import mpicbg.models.Affine2D;
+import mpicbg.models.ErrorStatistic;
+import mpicbg.models.Model;
+import mpicbg.models.PointMatch;
+import mpicbg.models.Tile;
+import mpicbg.models.TileConfiguration;
+import mpicbg.models.TileUtil;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import org.janelia.alignment.match.CanvasMatchResult;
+import org.janelia.alignment.match.CanvasMatches;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.render.client.solver.SolveTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.DoubleSummaryStatistics;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Coarsely aligns a multi-SEM stack by treating each mFOV layer as a single tile.
+ *
+ * @param <M> the model type
+ *
+ * @author Michael Innerberger
+ */
+public class MultiSemPreAligner<M extends Model<M> & Affine2D<M>> implements Serializable {
+
+	// Note: this assumes a specific tileId format:
+	// <cut>_<mFov>_<sFov>_<day>_<time>.<z>.0
+	private static final Pattern TILE_ID_SEPARATOR = Pattern.compile("[_.]");
+
+	private final M model;
+	private final double maxAllowedError;
+	private final int maxIterations;
+	private final int maxPlateauWidth;
+	private final int numThreads;
+	private final int maxNumMatches;
+
+
+	public MultiSemPreAligner(
+			final M model,
+			final double maxAllowedError,
+			final int maxIterations,
+			final int maxPlateauWidth,
+			final int numThreads,
+			final int maxNumMatches
+	) {
+		this.model = model;
+		this.maxAllowedError = maxAllowedError;
+		this.maxIterations = maxIterations;
+		this.maxPlateauWidth = maxPlateauWidth;
+		this.numThreads = numThreads;
+		this.maxNumMatches = maxNumMatches;
+	}
+
+	public Map<String, M> preAlign(
+			final ResolvedTileSpecCollection rtsc,
+			final List<CanvasMatches> canvasMatches
+	) throws IOException, ExecutionException, InterruptedException {
+
+		// initialize and connect models for each mFOV layer
+		final Map<String, String> tileIdToMFovLayer = rtsc.getTileSpecs().stream()
+				.map(TileSpec::getTileId)
+				.collect(Collectors.toMap(
+						tileId -> tileId,
+						MultiSemPreAligner::extractMFovLayerId
+				));
+		final Map<String, Tile<M>> mFovLayerToTile = initializeAndConnectTiles(tileIdToMFovLayer, canvasMatches);
+
+		// optimize the models
+		final TileConfiguration tileConfig = new TileConfiguration();
+		tileConfig.addTiles(mFovLayerToTile.values());
+
+		final DoubleSummaryStatistics errorsBefore = SolveTools.computeErrors(tileConfig.getTiles());
+		LOG.info("mFOV layer-wise pre-align: errors after connecting, before optimization: {}", errorsBefore);
+
+		TileUtil.optimizeConcurrently(
+				new ErrorStatistic(maxPlateauWidth + 1),
+				maxAllowedError,
+				maxIterations,
+				maxPlateauWidth,
+				1.0f,
+				tileConfig,
+				tileConfig.getTiles(),
+				tileConfig.getFixedTiles(),
+				numThreads);
+
+		final DoubleSummaryStatistics errorsAfter = SolveTools.computeErrors(tileConfig.getTiles());
+		LOG.info("mFOV layer-wise pre-align: errors after optimization: {}", errorsAfter);
+
+		// distribute models to individual tiles
+		final Map<String, M> tileIdToModel = new HashMap<>();
+		for (final Map.Entry<String, String> tileIdAndMFovLayer : tileIdToMFovLayer.entrySet()) {
+			final String tileId = tileIdAndMFovLayer.getKey();
+			final String mFovLayer = tileIdAndMFovLayer.getValue();
+			final Tile<M> tile = mFovLayerToTile.get(mFovLayer);
+			tileIdToModel.put(tileId, tile.getModel());
+		}
+
+		return tileIdToModel;
+	}
+
+	private Map<String, Tile<M>> initializeAndConnectTiles(
+			final Map<String, String> tileIdToMFovLayer,
+			final List<CanvasMatches> canvasMatches
+	) {
+		// initialize models for each mFOV layer
+		final Map<String, Tile<M>> mFovLayerToTile = new HashMap<>();
+		for (final String mFovLayer : tileIdToMFovLayer.values()) {
+			mFovLayerToTile.put(mFovLayer, new Tile<>(model.copy()));
+		}
+
+		// accumulate matches for each pair of mFOV layers
+		final Map<Pair<Tile<M>, Tile<M>>, List<PointMatch>> pairsToMatches = new HashMap<>();
+		for (final CanvasMatches canvasMatch : canvasMatches) {
+			final String mFovLayerP = tileIdToMFovLayer.get(canvasMatch.getpId());
+			final String mFovLayerQ = tileIdToMFovLayer.get(canvasMatch.getqId());
+			if (mFovLayerP.equals(mFovLayerQ)) {
+				// only connect tiles from different layers and different mFOVs
+				continue;
+			}
+
+			final Tile<M> p = mFovLayerToTile.get(mFovLayerP);
+			final Tile<M> q = mFovLayerToTile.get(mFovLayerQ);
+			final List<PointMatch> layerMatches = pairsToMatches.computeIfAbsent(new ValuePair<>(p, q), k -> new ArrayList<>());
+
+			final List<PointMatch> tileMatches = CanvasMatchResult.convertMatchesToPointMatchList(canvasMatch.getMatches());
+			layerMatches.addAll(tileMatches);
+		}
+
+		// reduce the number of matches to a maximal number (choose randomly)
+		for (final Map.Entry<Pair<Tile<M>, Tile<M>>, List<PointMatch>> entry : pairsToMatches.entrySet()) {
+			final Tile<M> p = entry.getKey().getA();
+			final Tile<M> q = entry.getKey().getB();
+			final List<PointMatch> pointMatches = entry.getValue();
+			final List<PointMatch> reducedMatches = getRandomElements(pointMatches, maxNumMatches);
+			p.connect(q, reducedMatches);
+		}
+
+		return mFovLayerToTile;
+	}
+
+	private <T> List<T> getRandomElements(final List<T> list, final int maxEntries) {
+		if (list.size() <= maxEntries) {
+			return list;
+		} else {
+			Collections.shuffle(list);
+			return list.subList(0, maxEntries);
+		}
+	}
+
+	private static String extractMFovLayerId(final String tileId) {
+		final String[] components = TILE_ID_SEPARATOR.split(tileId);
+		final String mFov = components[1];
+		final String layer = components[5];
+		return mFov + "_" + layer;
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(MultiSemPreAligner.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
@@ -131,7 +131,7 @@ public class MultiSemPreAligner<M extends Model<M> & Affine2D<M>> implements Ser
 			final String mFovLayerQ = tileIdToMFovLayer.get(canvasMatch.getqId());
 			final boolean tileIsMissing = mFovLayerToTile.get(mFovLayerP) == null || mFovLayerToTile.get(mFovLayerQ) == null;
 			if (tileIsMissing || mFovLayerP.equals(mFovLayerQ)) {
-				// only connect tiles from different layers and different mFOVs
+				// only connect tiles from different mFOVs
 				continue;
 			}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/affine/MultiSemPreAligner.java
@@ -128,7 +128,8 @@ public class MultiSemPreAligner<M extends Model<M> & Affine2D<M>> implements Ser
 		for (final CanvasMatches canvasMatch : canvasMatches) {
 			final String mFovLayerP = tileIdToMFovLayer.get(canvasMatch.getpId());
 			final String mFovLayerQ = tileIdToMFovLayer.get(canvasMatch.getqId());
-			if (mFovLayerP.equals(mFovLayerQ)) {
+			final boolean tileIsMissing = mFovLayerToTile.get(mFovLayerP) == null || mFovLayerToTile.get(mFovLayerQ) == null;
+			if (tileIsMissing || mFovLayerP.equals(mFovLayerQ)) {
 				// only connect tiles from different layers and different mFOVs
 				continue;
 			}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solve/PartialSolve.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solve/PartialSolve.java
@@ -27,6 +27,7 @@ import org.janelia.alignment.util.ZFilter;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.solver.SolveTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,9 +128,9 @@ public abstract class PartialSolve< B extends Model< B > & Affine2D< B > >
 	
 					if ( model != null )
 					{
-						resolvedTiles.addTransformSpecToTile( tileId,
-								getTransformSpec( model ),
-								applyMethod );
+						resolvedTiles.addTransformSpecToTile(tileId,
+															 SolveTools.getTransformSpec(model),
+															 applyMethod );
 					}
 				}
 			}
@@ -141,14 +142,6 @@ public abstract class PartialSolve< B extends Model< B > & Affine2D< B > >
 		}
 
 		LOG.info( "saveTargetStackTiles: exit" );
-	}
-
-	private LeafTransformSpec getTransformSpec( final AffineModel2D forModel )
-	{
-		final double[] m = new double[ 6 ];
-		forModel.toArray( m );
-		final String data = String.valueOf( m[ 0 ] ) + ' ' + m[ 1 ] + ' ' + m[ 2 ] + ' ' + m[ 3 ] + ' ' + m[ 4 ] + ' ' + m[ 5 ];
-		return new LeafTransformSpec( mpicbg.trakem2.transform.AffineModel2D.class.getName(), data );
 	}
 
 	public ImagePlus render( final HashMap<String, AffineModel2D> idToModels,

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solver/SolveTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solver/SolveTools.java
@@ -991,34 +991,24 @@ public class SolveTools
 		return new LeafTransformSpec( mpicbg.trakem2.transform.AffineModel2D.class.getName(), data );
 	}
 
-	// TODO: Bug, this method is not working
+	/**
+	 * Note: this method relies on the internal structure of AffineTransform2D
+	 * as such, it is fragile and may break if the internal structure of AffineTransform2D changes, see, e.g.,
+	 * <a href="https://github.com/imglib/imglib2-realtransform/commit/28986382280012a338cfed879956fbf6ac1f0f2e">this commit</a>
+	 * <p>
+	 * OLD:               NEW:
+	 * data[0] = a.m00;   data[0] = a.m00;
+	 * data[1] = a.m01;   data[1] = a.m01;
+	 * data[3] = a.m02;   data[2] = a.m02;
+	 * data[4] = a.m10;   data[3] = a.m10;
+	 * data[6] = a.m11;   data[4] = a.m11;
+	 * data[7] = a.m12;   data[5] = a.m12;
+	 */
 	public static LeafTransformSpec getTransformSpec( final AffineTransform2D forModel )
 	{
 		final double[] m = new double[ 6 ];
 		forModel.toArray( m );
 
-		// TODO: fix when bug in imglib2-realtransform is released
-		// https://github.com/imglib/imglib2-realtransform/commit/28986382280012a338cfed879956fbf6ac1f0f2e
-
-		/*
-		OLD:
-		data[ 0 ] = a.m00;
-		data[ 1 ] = a.m01;
-		data[ 3 ] = a.m02;
-		data[ 4 ] = a.m10;
-		data[ 6 ] = a.m11;
-		data[ 7 ] = a.m12;
-
-		NEW:
-		data[ 0 ] = a.m00;
-		data[ 1 ] = a.m01;
-		data[ 2 ] = a.m02;
-		data[ 3 ] = a.m10;
-		data[ 4 ] = a.m11;
-		data[ 5 ] = a.m12;
-		*/
-
-		//final String data = String.valueOf( m[ 0 ] ) + ' ' + m[ 4 ] + ' ' + m[ 1 ] + ' ' + m[ 6 ] + ' ' + m[ 3 ] + ' ' + m[ 7 ];
 		final String data = String.valueOf( m[ 0 ] ) + ' ' + m[ 3 ] + ' ' + m[ 1 ] + ' ' + m[ 4 ] + ' ' + m[ 2 ] + ' ' + m[ 5 ];
 		System.out.println( data );
 		return new LeafTransformSpec( mpicbg.trakem2.transform.AffineModel2D.class.getName(), data );

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solver/SolveTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solver/SolveTools.java
@@ -973,22 +973,24 @@ public class SolveTools
 		LOG.info( "saveTargetStackTiles: exit" );
 	}
 
-	public static LeafTransformSpec getTransformSpec( final AffineModel2D forModel )
-	{
-		final double[] m = new double[ 6 ];
-		forModel.toArray( m );
+	/**
+	 * Note: this method relies on the internal structure of Affine2D
+	 * as such, it is fragile and may break if the internal structure of Affine2D changes.
+	 * <p>
+	 * Current layout:
+	 * data[0] = m00;
+	 * data[1] = m10;
+	 * data[2] = m01;
+	 * data[3] = m11;
+	 * data[4] = m02;
+	 * data[5] = m12;
+	 */
+	public static LeafTransformSpec getTransformSpec(final Affine2D<?> forModel) {
+		final double[] m = new double[6];
+		forModel.toArray(m);
 
-		/*
-		data[ 0 ] = m00;
-		data[ 1 ] = m10;
-		data[ 2 ] = m01;
-		data[ 3 ] = m11;
-		data[ 4 ] = m02;
-		data[ 5 ] = m12;
-		*/
-		
-		final String data = String.valueOf( m[ 0 ] ) + ' ' + m[ 1 ] + ' ' + m[ 2 ] + ' ' + m[ 3 ] + ' ' + m[ 4 ] + ' ' + m[ 5 ];
-		return new LeafTransformSpec( mpicbg.trakem2.transform.AffineModel2D.class.getName(), data );
+		final String data = String.valueOf(m[0]) + ' ' + m[1] + ' ' + m[2] + ' ' + m[3] + ' ' + m[4] + ' ' + m[5];
+		return new LeafTransformSpec(mpicbg.trakem2.transform.AffineModel2D.class.getName(), data);
 	}
 
 	/**

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
@@ -34,6 +34,4 @@ public class MultiSemPreAlignClientTest {
 
         MultiSemPreAlignClient.main(effectiveArgs);
     }
-
-
 }

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
@@ -28,7 +28,7 @@ public class MultiSemPreAlignClientTest {
                 "--maxAllowedError", "10.0",
                 "--maxIterations", "1000",
                 "--maxPlateauWidth", "250",
-                "--maxNumMatches", "100",
+                "--maxNumMatches", "1000",
                 "--numThreads", "8"
         };
 

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/MultiSemPreAlignClientTest.java
@@ -1,0 +1,39 @@
+package org.janelia.render.client;
+
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.junit.Test;
+
+/**
+ * Tests the {@link MultiSemPreAlignClient} class.
+ *
+ * @author Michael Innerberger
+ */
+public class MultiSemPreAlignClientTest {
+
+    @Test
+    public void testParameterParsing() throws Exception {
+        CommandLineParameters.parseHelp(new MultiSemPreAlignClient.Parameters());
+    }
+
+    public static void main(final String[] args) {
+        final String[] effectiveArgs = {
+                "--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+                "--owner", "hess_wafer_53",
+                "--project", "cut_000_to_009",
+                "--stack", "c009_s310_v01_mfov_08",
+                "--targetStack", "c009_s310_v01_mfov_08_mfov_prealign",
+                "--matchOwner", "hess_wafer_53",
+                "--matchCollection", "c009_s310_v01_match",
+                "--completeTargetStack",
+                "--maxAllowedError", "10.0",
+                "--maxIterations", "1000",
+                "--maxPlateauWidth", "250",
+                "--maxNumMatches", "100",
+                "--numThreads", "8"
+        };
+
+        MultiSemPreAlignClient.main(effectiveArgs);
+    }
+
+
+}


### PR DESCRIPTION
I tentatively added a pre-alignment routine that treats a single layer of a single MFOV as a tile and aligns these using a rigid model.

I tested this on a small stack (see `MultiSemPreAlignClientTest`). So far, it seems like pulling and processing all the data is fine (and does reduce the error by some factor), but pushing the data to the render database again doesn't seem to work. In particular, the put request that should set the stack state to complete doesn't return. Do you have any clues as to why this might be, @trautmane?

Once these issues are resolved, I would test this on a larger stack and also check if this reduces the time for the subsequent alignment. Finally, I'll make this into a spark client that can process multiple stacks at once.

~Side note: To put the transforms computed by this method into the `TileSpecs`, I wanted to use [`SolveTools.getTransformSpec`](https://github.com/saalfeldlab/render/blob/78f5591df004a1b888bc3af2a5553ce2bf13a2dc/render-ws-java-client/src/main/java/org/janelia/render/client/solver/SolveTools.java#L995), but the TODOs there seem to indicate that this method doesn't work right now. The [last commit that changed this method](https://github.com/saalfeldlab/render/commit/7b4f3aedccebc2f370fe72670dd2d0135bacba55) says that the issue is fixed, though. Can you please comment on that, @StephanPreibisch?~ Resolved by [0df486](https://github.com/saalfeldlab/render/pull/184/commits/0df4862a5a469269fe9acfe18f162893a797c85a).