### PR TITLE
Add pre-alignment method for multi-SEM

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMAlignmentParameters.java
@@ -29,7 +29,7 @@ import mpicbg.models.Model;
 public class FIBSEMAlignmentParameters< M extends Model< M > & Affine2D< M >, S extends Model< S > & Affine2D< S > > extends BlockDataSolveParameters< M, AffineModel2D, FIBSEMAlignmentParameters< M, S > >
 {
 	private static final long serialVersionUID = 4247180309556813829L;
-	public enum PreAlign { NONE, TRANSLATION, RIGID }
+	public enum PreAlign { NONE, TRANSLATION, RIGID, MULTI_SEM }
 
 	final private Function< Integer, S > stitchingModelSupplier;
 	final private Function< Integer, Integer > minStitchingInliersSupplier; // if it is less, it is not stitched first


### PR DESCRIPTION
After some experiments, it turns out that using a simple `tileConfig.preAlign()` greatly reduces the runtime of alignment for multi-SEM alignment. This is a quick hack to get this into production as fast as possible, but we should definitely clean up after the pipeline is complete.

For now, specify `--preAlign MULTI_SEM` to enable this.