### PR TITLE
Reordering tiles

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
@@ -1,0 +1,103 @@
+package org.janelia.render.client;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.stack.StackMetaData;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * This client reorders the tiles in a multi-sem stack in a way that the rendering order
+ * causes overlapping tiles to be rendered in the correct order. (I.e., the tile where
+ * the overlapping region is imaged first is on top.)
+ *
+ * @author Michael Innerberger
+ */
+public class TileReorderingClient {
+	public static class Parameters extends CommandLineParameters {
+
+		@ParametersDelegate
+		public RenderWebServiceParameters renderWeb = new RenderWebServiceParameters();
+
+		@Parameter(
+				names = "--stack",
+				description = "Name of source stack",
+				required = true)
+		public String stack;
+
+		@Parameter(
+				names = "--targetStack",
+				description = "Name of target stack",
+				required = true)
+		public String targetStack;
+	}
+
+	public static void main(final String[] args) {
+		final String[] xargs = {
+				"--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+				"--owner", "hess_wafer_53b",
+				"--project", "cut_070_to_079",
+				"--stack", "c070_s032_v01_align_ic",
+				"--targetStack", "c070_s032_v01_mi_reordering_test"
+		};
+		final ClientRunner clientRunner = new ClientRunner(xargs) {
+			@Override
+			public void runClient(final String[] args) throws Exception {
+
+				final Parameters parameters = new Parameters();
+				parameters.parse(args);
+
+				LOG.info("runClient: entry, parameters={}", parameters);
+
+				final TileReorderingClient client = new TileReorderingClient(parameters);
+
+				client.setUpTargetStack();
+				client.transferTileSpecs();
+				client.completeTargetStack();
+			}
+		};
+		clientRunner.run();
+	}
+
+	private final Parameters parameters;
+	private final RenderDataClient dataClient;
+
+	private TileReorderingClient(final Parameters parameters) {
+		this.parameters = parameters;
+		this.dataClient = parameters.renderWeb.getDataClient();
+	}
+
+	private void setUpTargetStack() throws Exception {
+		final StackMetaData sourceStackMetaData = dataClient.getStackMetaData(parameters.stack);
+		dataClient.setupDerivedStack(sourceStackMetaData, parameters.targetStack);
+		LOG.info("setUpTargetStack: setup stack {}", parameters.targetStack);
+	}
+
+	private void completeTargetStack() throws Exception {
+		dataClient.setStackState(parameters.targetStack, StackMetaData.StackState.COMPLETE);
+		LOG.info("completeTargetStack: setup stack {}", parameters.targetStack);
+	}
+
+	private void transferTileSpecs() throws Exception {
+		final List<Double> zValues = dataClient.getStackZValues(parameters.stack);
+		for (final Double z : zValues) {
+			transferLayer(z);
+		}
+	}
+
+	private void transferLayer(final Double z) throws Exception {
+		final ResolvedTileSpecCollection sourceCollection = dataClient.getResolvedTiles(parameters.stack, z);
+		LOG.info("transferLayer: transferring layer {} with {} tiles", z, sourceCollection.getTileCount());
+
+		if (sourceCollection.getTileCount() > 0) {
+			dataClient.saveResolvedTiles(sourceCollection, parameters.targetStack, z);
+		}
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(TileReorderingClient.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
@@ -65,20 +65,12 @@ public class TileReorderingClient {
 
 		@Parameter(
 				names = "--renderingOrder",
-				description = "Rendering order",
-				required = false)
+				description = "Rendering order")
 		public RenderingOrder renderingOrder = RenderingOrder.HORIZONTAL_SCAN;
 	}
 
 	public static void main(final String[] args) {
-		final String[] xargs = {
-				"--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
-				"--owner", "hess_wafer_53b",
-				"--project", "cut_070_to_079",
-				"--stack", "c070_s032_v01_align_ic",
-				"--targetStack", "c070_s032_v01_mi_reordering_test_scan_order"
-		};
-		final ClientRunner clientRunner = new ClientRunner(xargs) {
+		final ClientRunner clientRunner = new ClientRunner(args) {
 			@Override
 			public void runClient(final String[] args) throws Exception {
 
@@ -156,8 +148,8 @@ public class TileReorderingClient {
 
 		public String serialNumberFor(final String tileId) {
 			final String[] tileIdComponents = TILE_ID_SEPARATOR.split(tileId);
-			final int mFov = Integer.parseInt(tileIdComponents[1]);
-			final int sFov = Integer.parseInt(tileIdComponents[2]);
+			final int mFov = Integer.parseInt(tileIdComponents[MFOV_INDEX]);
+			final int sFov = Integer.parseInt(tileIdComponents[SFOV_INDEX]);
 			return String.format("%04d", mAndSFovToSerialNumber.applyAsInt(mFov, sFov));
 		}
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
@@ -10,7 +10,10 @@ import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.IntBinaryOperator;
 import java.util.regex.Pattern;
 
@@ -82,7 +85,7 @@ public class TileReorderingClient {
 				final TileReorderingClient client = new TileReorderingClient(parameters);
 
 				client.setUpTargetStack();
-				client.transferTileSpecs();
+				client.reorderTileSpecs();
 				client.completeTargetStack();
 			}
 		};
@@ -109,14 +112,14 @@ public class TileReorderingClient {
 		LOG.info("completeTargetStack: setup stack {}", parameters.targetStack);
 	}
 
-	private void transferTileSpecs() throws Exception {
+	private void reorderTileSpecs() throws Exception {
 		final List<Double> zValues = dataClient.getStackZValues(parameters.stack);
 		for (final Double z : zValues) {
-			transferLayer(z);
+			reorderLayer(z);
 		}
 	}
 
-	private void transferLayer(final Double z) throws Exception {
+	private void reorderLayer(final Double z) throws Exception {
 		final ResolvedTileSpecCollection sourceCollection = dataClient.getResolvedTiles(parameters.stack, z);
 		LOG.info("transferLayer: transferring layer {} with {} tiles", z, sourceCollection.getTileCount());
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
@@ -17,9 +17,14 @@ import java.util.stream.Collectors;
 
 /**
  * This client reorders the tiles in a multi-sem stack in a way that the rendering order
- * causes overlapping tiles to be rendered in the correct order. (I.e., the tile where
+ * causes overlapping tiles to be rendered in different orders. (I.e., the tile where
  * the overlapping region is imaged first is on top.)
- *
+ * <br/>
+ * Reordering is done by changing tile IDs.  This is sufficient to change the rendering
+ * order for a "final export", but changing tile IDs decouples tiles from their
+ * match data.  This means that reordered tiles cannot subsequently be used in
+ * tasks/pipelines that rely upon match data.
+ * 
  * @author Michael Innerberger
  */
 public class TileReorderingClient {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/TileReorderingClient.java
@@ -10,10 +10,8 @@ import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 /**
  * This client reorders the tiles in a multi-sem stack in a way that the rendering order
@@ -23,6 +21,28 @@ import java.util.stream.Collectors;
  * @author Michael Innerberger
  */
 public class TileReorderingClient {
+
+	private static final int MFOVS_PER_STACK = 19;
+	private static final int SFOVS_PER_MFOV = 91;
+	private static final Pattern TILE_ID_SEPARATOR = Pattern.compile("_");
+
+	// The new order of the tiles in the multi-sem stack:
+	// Number the tiles in an SFOV from 1 to 91, starting in the top left corner and going
+	// row by row. Then, record these numbers in the original order of the tiles (i.e.,
+	// starting in the middle of the SFOV and spiraling outwards counterclockwise).
+	private static final int[] newNumber = {
+			46, 47, 36, 35, 45, 56, 57, 48, 37, 27,
+			26, 25, 34, 44, 55, 65, 66, 67, 58, 49,
+			38, 28, 19, 18, 17, 16, 24, 33, 43, 54,
+			64, 73, 74, 75, 76, 68, 59, 50, 39, 29,
+			20, 12, 11, 10,  9,  8, 15, 23, 32, 42,
+			53, 63, 72, 80, 81, 82, 83, 84, 77, 69,
+			60, 51, 40, 30, 21, 13,  6,  5,  4,  3,
+			2,  1,  7, 14, 22, 31, 41, 52, 62, 71,
+			79, 86, 87, 88, 89, 90, 91, 85, 78, 70, 61
+	};
+
+
 	public static class Parameters extends CommandLineParameters {
 
 		@ParametersDelegate
@@ -71,21 +91,6 @@ public class TileReorderingClient {
 	private final Parameters parameters;
 	private final RenderDataClient dataClient;
 
-	// The new order of the tiles in the multi-sem stack:
-	// Number the tiles in an SFOV from 1 to 91, starting in the top left corner and going
-	// row by row. Then, record these numbers in the original order of the tiles (i.e.,
-	// starting in the middle of the SFOV and spiraling outwards counterclockwise).
-	private final int[] newNumber = {
-			46, 47, 36, 35, 45, 56, 57, 48, 37, 27,
-			26, 25, 34, 44, 55, 65, 66, 67, 58, 49,
-			38, 28, 19, 18, 17, 16, 24, 33, 43, 54,
-			64, 73, 74, 75, 76, 68, 59, 50, 39, 29,
-			20, 12, 11, 10,  9,  8, 15, 23, 32, 42,
-			53, 63, 72, 80, 81, 82, 83, 84, 77, 69,
-			60, 51, 40, 30, 21, 13,  6,  5,  4,  3,
-			 2,  1,  7, 14, 22, 31, 41, 52, 62, 71,
-			79, 86, 87, 88, 89, 90, 91, 85, 78, 70, 61
-	};
 
 	private TileReorderingClient(final Parameters parameters) {
 		this.parameters = parameters;
@@ -116,7 +121,7 @@ public class TileReorderingClient {
 
 		for (final String tileId : sourceCollection.getTileIds()) {
 			final TileSpec tileSpec = sourceCollection.getTileSpec(tileId);
-			tileSpec.setTileId(updateSfovNumber(tileId));
+			tileSpec.setTileId(prependRenderOrder(tileId));
 		}
 
 		if (sourceCollection.getTileCount() > 0) {
@@ -124,11 +129,12 @@ public class TileReorderingClient {
 		}
 	}
 
-	private String updateSfovNumber(final String tileId) {
-		final String[] tileIdComponents = tileId.split("_");
-		final int oldNumber = Integer.parseInt(tileIdComponents[2]);
-		tileIdComponents[2] = String.format("%03d", newNumber[oldNumber - 1]);
-		return String.join("_", tileIdComponents);
+	private static String prependRenderOrder(final String tileId) {
+		final String[] tileIdComponents = TILE_ID_SEPARATOR.split(tileId);
+		final int sFov = Integer.parseInt(tileIdComponents[2]);
+		final int mFov = Integer.parseInt(tileIdComponents[1]);
+		final String renderOrder = String.format("%04d", (MFOVS_PER_STACK - mFov) * SFOVS_PER_MFOV + newNumber[sFov - 1]);
+		return renderOrder + "_" + tileId;
 	}
 
 	private static final Logger LOG = LoggerFactory.getLogger(TileReorderingClient.class);

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/TileReorderingClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/TileReorderingClientTest.java
@@ -1,0 +1,30 @@
+package org.janelia.render.client;
+
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.junit.Test;
+
+/**
+ * Tests the {@link TileReorderingClient} class.
+ *
+ * @author Michael Innerberger
+ */
+public class TileReorderingClientTest {
+
+    @Test
+    public void testParameterParsing() throws Exception {
+        CommandLineParameters.parseHelp(new TileReorderingClient.Parameters());
+    }
+
+    public static void main(final String[] args) {
+
+        final String[] effectiveArgs = args.length > 0 ? args : new String[] {
+                "--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+                "--owner", "hess_wafer_53d",
+                "--project", "slab_120_to_129",
+                "--stack", "s127_m232_align_mi_ic_test1",
+                "--targetStack", "s127_m232_align_mi_reordering_test_horizontal_scan"
+        };
+
+        TileReorderingClient.main(effectiveArgs);
+    }
+}


### PR DESCRIPTION
I investigated the rendering order for tiles in multi-SEM and implemented a quick hack to re-order tiles to get the desired rendering order: for each tile in a z-layer, a new serial number is created (that reflects the desired rendering order) and prepended to the tile ID.

There are currently three orders implemented:
1. the original order (i.e., don't change anything)
2. render the mFOVs last to first and the sFOVs in a left to right, top to bottom fashion
3. the reverse of 2.

It looks like strategy 2 yields the best results as most tiles have the unfavorable regions on the right and the bottom of the image. However, some tiles have one of the regions on the left side instead of the right side, or it is completely missing. In theory, one should be able to determine the location (and therefore the correct order) by investigating the y-coordinates of the tiles. However, I didn't find any definitive criterion (based on bounding boxes before or after transformation) that could solve this. Therefore, I suggest to stay with strategy 2 as the default for now.