### PR TITLE
Exponential fit

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/filter/CompositeFilter.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/CompositeFilter.java
@@ -1,0 +1,58 @@
+package org.janelia.alignment.filter;
+
+import ij.process.ImageProcessor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds a collection of {@link Filter}s to be applied in sequence.
+ *
+ * @author Michael Innerberger
+ */
+public class CompositeFilter implements Filter {
+
+    private List<Filter> filters;
+
+    // empty constructor required to create instances from specifications
+    @SuppressWarnings("unused")
+    public CompositeFilter() {
+        this((List<Filter>) null);
+    }
+
+    public CompositeFilter(final Filter... filters) {
+        this(List.of(filters));
+    }
+
+    public CompositeFilter(final List<Filter> filters) {
+        this.filters = filters;
+    }
+
+    @Override
+    public void init(final Map<String, String> params) {
+        filters = new ArrayList<>(params.size());
+        for (final String serializedFilter : params.values()) {
+            final FilterSpec filterSpec = FilterSpec.fromJson(serializedFilter);
+            filters.add(filterSpec.buildInstance());
+        }
+    }
+
+    @Override
+    public Map<String, String> toParametersMap() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < filters.size(); i++) {
+            final FilterSpec filterSpec = FilterSpec.forFilter(filters.get(i));
+            map.put(String.valueOf(i), filterSpec.toJson());
+        }
+        return map;
+    }
+
+    @Override
+    public void process(final ImageProcessor ip, final double scale) {
+        for (final Filter filter : filters) {
+            filter.process(ip, scale);
+        }
+    }
+}

--- a/render-app/src/main/java/org/janelia/alignment/filter/CompositeFilter.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/CompositeFilter.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Holds a collection of {@link Filter}s to be applied in sequence.
+ * Holds a list of {@link Filter}s to be applied in sequence (first to last).
  *
  * @author Michael Innerberger
  */
@@ -33,7 +33,8 @@ public class CompositeFilter implements Filter {
     @Override
     public void init(final Map<String, String> params) {
         filters = new ArrayList<>(params.size());
-        for (final String serializedFilter : params.values()) {
+        for (int i = 0; i < params.size(); i++) {
+            final String serializedFilter = params.get(filterKey(i));
             final FilterSpec filterSpec = FilterSpec.fromJson(serializedFilter);
             filters.add(filterSpec.buildInstance());
         }
@@ -44,9 +45,13 @@ public class CompositeFilter implements Filter {
         final Map<String, String> map = new LinkedHashMap<>();
         for (int i = 0; i < filters.size(); i++) {
             final FilterSpec filterSpec = FilterSpec.forFilter(filters.get(i));
-            map.put(String.valueOf(i), filterSpec.toJson());
+            map.put(filterKey(i), filterSpec.toJson());
         }
         return map;
+    }
+
+    private static String filterKey(final int i) {
+        return "filter" + i;
     }
 
     @Override

--- a/render-app/src/main/java/org/janelia/alignment/filter/ExponentialIntensityFilter.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/ExponentialIntensityFilter.java
@@ -1,6 +1,5 @@
 package org.janelia.alignment.filter;
 
-import ij.plugin.ContrastEnhancer;
 import ij.process.ImageProcessor;
 
 import java.util.LinkedHashMap;

--- a/render-app/src/main/java/org/janelia/alignment/filter/ExponentialIntensityFilter.java
+++ b/render-app/src/main/java/org/janelia/alignment/filter/ExponentialIntensityFilter.java
@@ -1,0 +1,65 @@
+package org.janelia.alignment.filter;
+
+import ij.plugin.ContrastEnhancer;
+import ij.process.ImageProcessor;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Applies a multiplicative correction (1 + exp(-a * (y - b))) to the y-direction of the given image data.
+ * <p>
+ * This filter is used to correct an exponential intensity drop towards the upper edge of the images in
+ * MultiSEM stacks.
+ *
+ * @author Michael Innerberger
+ */
+public class ExponentialIntensityFilter implements Filter {
+
+    private double a;
+    private double b;
+
+    // empty constructor required to create instances from specifications
+    @SuppressWarnings("unused")
+    public ExponentialIntensityFilter() {
+        this(0.0, 0.0);
+    }
+
+    public ExponentialIntensityFilter(final double a, final double b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public void init(final Map<String, String> params) {
+        this.a = Filter.getDoubleParameter("a", params);
+        this.b = Filter.getDoubleParameter("b", params);
+    }
+
+    @Override
+    public Map<String, String> toParametersMap() {
+        final Map<String, String> map = new LinkedHashMap<>();
+        map.put("a", String.valueOf(a));
+        map.put("b", String.valueOf(b));
+        return map;
+    }
+
+    @Override
+    public void process(final ImageProcessor ip, final double scale) {
+        // find midpoints of pixels in highest-resolution coordinate system
+        final int height = ip.getHeight();
+        final double[] y = new double[height];
+        for (int i = 0; i < height; i++) {
+            y[i] = (i + 0.5) / scale;
+        }
+
+        // apply correction
+        for (int j = 0; j < height; j++) {
+            final float correction = (float) (1.0 + Math.exp(-a * (y[j] - b)));
+            for (int i = 0; i < ip.getWidth(); i++) {
+                ip.setf(i, j, ip.getf(i, j) * correction);
+            }
+        }
+    }
+
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
@@ -8,6 +8,7 @@ import net.imglib2.algorithm.localization.FunctionFitter;
 import net.imglib2.algorithm.localization.LevenbergMarquardtSolver;
 import org.janelia.alignment.filter.ExponentialIntensityFilter;
 import org.janelia.alignment.filter.Filter;
+import org.janelia.alignment.filter.FilterSpec;
 import org.janelia.alignment.loader.ImageLoader;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
@@ -184,6 +185,7 @@ public class ExponentialFitClient {
 	private Map<String, double[]> convertToMultiplicativeFactors(final Map<String, double[]> coefficients, final boolean averageOverLayer) {
 		final Map<String, double[]> filterCoefficients = new HashMap<>();
 		final double[] average = new double[2];
+		final double threshold = 100.0;
 
 		for (final Map.Entry<String, double[]> entry : coefficients.entrySet()) {
 			final String tileId = entry.getKey();
@@ -191,7 +193,7 @@ public class ExponentialFitClient {
 
 			// first coefficient is the baseline intensity, which is discarded
 			if (averageOverLayer) {
-				if (coeff[0] > 100 || coeff[1] > 100 || coeff[2] > 100) {
+				if (coeff[0] > threshold || coeff[1] > threshold || coeff[2] > threshold) {
 					LOG.debug("convertToMultiplicativeFactors: skipping outlier tile {}", tileId);
 					continue;
 				}
@@ -218,7 +220,8 @@ public class ExponentialFitClient {
 			final double[] coeff = entry.getValue();
 
 			final Filter filter = new ExponentialIntensityFilter(coeff[0], coeff[1]);
-			tileSpec.addFilter(filter);
+			final FilterSpec filterSpec = new FilterSpec(filter.getClass().getName(), filter.toParametersMap());
+			tileSpec.setFilterSpec(filterSpec);
 		}
 	}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
@@ -127,8 +127,7 @@ public class ExponentialFitClient {
 		}
 		final File coefficientsFile = new File(params.coefficientsFile);
 		if (coefficientsFile.exists()) {
-			LOG.error("process: coefficients file {} already exists", params.coefficientsFile);
-			System.exit(1);
+			throw new IllegalArgumentException("process: coefficients file '" + params.coefficientsFile + "' already exists");
 		}
 		return new PrintWriter(coefficientsFile);
 	}
@@ -191,11 +190,8 @@ public class ExponentialFitClient {
 			final double[] coeff = entry.getValue();
 
 			// first coefficient is the baseline intensity, which is discarded
-			if (average != null) {
-				filterCoefficients.put(tileId, average);
-			} else {
-				filterCoefficients.put(tileId, new double[] {coeff[1], coeff[2]});
-			}
+			final double[] filterCoefficient = (average != null) ? average : new double[] {coeff[1], coeff[2]};
+			filterCoefficients.put(tileId, filterCoefficient);
 		}
 
 		return filterCoefficients;
@@ -206,7 +202,7 @@ public class ExponentialFitClient {
 			return null;
 		}
 
-		LOG.info("computeAverage: enter");
+		LOG.info("computeAverageCoefficients: enter");
 		final double[] average = new double[2];
 		int count = 0;
 		for (final Map.Entry<String, double[]> entry : coefficients.entrySet()) {
@@ -214,7 +210,7 @@ public class ExponentialFitClient {
 			final double[] coeff = entry.getValue();
 			
 			if (coeff[1] > 10.0 || Math.abs(coeff[2]) > 50.0) {
-				LOG.debug("convertToMultiplicativeFactors: skipping outlier tile {}", tileId);
+				LOG.debug("computeAverageCoefficients: skipping outlier tile {}", tileId);
 				continue;
 			}
 			

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
@@ -1,0 +1,147 @@
+package org.janelia.render.client.multisem;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import ij.process.ImageProcessor;
+import net.imglib2.algorithm.localization.FitFunction;
+import net.imglib2.algorithm.localization.FunctionFitter;
+import net.imglib2.algorithm.localization.LevenbergMarquardtSolver;
+import org.janelia.alignment.loader.ImageLoader;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.util.ImageProcessorCache;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Fits an exponential model in y to the image data of the given stack. This should correct an exponential
+ * intensity drop towards the upper edge of the images.
+ * <p>
+ * The model is of the form y = a / (1 + exp(-b * (x - c))), where a, b, and c are the parameters to be estimated;
+ * this is a 3-parameter sigmoidal model. The parameter a describes the baseline intensity and is discarded in the
+ * final model, so that the correction can be done by multiplying with (1 + exp(-b * (x - c))) in the y-direction.
+ *
+ * @author Michael Innerberger
+ */
+public class ExponentialFitClient {
+
+	private static final ImageProcessorCache IMAGE_LOADER = ImageProcessorCache.DISABLED_CACHE;
+
+	public static class Parameters extends CommandLineParameters {
+		@ParametersDelegate
+		private final RenderWebServiceParameters renderWeb = new RenderWebServiceParameters();
+		@Parameter(names = "--stack", description = "Name of source stack", required = true)
+		public String stack;
+		@Parameter(names = "--targetStack", description = "Name of target stack", required = true)
+		public String targetStack;
+		@Parameter(names = "--coefficientsFile", description = "File name for storing the estimated coefficients in the csv format; If not given, coefficients are not stored")
+		private String coefficientsFile = null;
+		@Parameter(names = "--averageOverLayer", description = "If true, average all estimated models and apply the average to the tiles", arity = 0)
+		public boolean averageOverLayer = true;
+		@Parameter(names = "--completeTargetStack", description = "Complete the target stack after fitting", arity = 0)
+		public boolean completeTargetStack = false;
+	}
+
+
+	private final Parameters params;
+
+	public static void main(final String[] args) {
+		final ClientRunner clientRunner = new ClientRunner(args) {
+			@Override
+			public void runClient(final String[] args) throws IOException {
+
+				final Parameters parameters = new Parameters();
+				parameters.parse(args);
+				LOG.info("runClient: entry, parameters={}", parameters);
+
+				final ExponentialFitClient client = new ExponentialFitClient(parameters);
+				client.process();
+			}
+		};
+		clientRunner.run();
+	}
+
+	public ExponentialFitClient(final Parameters parameters) {
+		this.params = parameters;
+	}
+
+	public void process() throws IOException {
+		LOG.info("process: entry");
+		final RenderDataClient renderClient = params.renderWeb.getDataClient();
+		final ResolvedTileSpecCollection tileSpecs = renderClient.getResolvedTiles(params.stack, 2.0);
+		final ImageLoader.LoaderType loaderType = ImageLoader.LoaderType.IMAGEJ_DEFAULT;
+
+		final TileSpec firstTileSpec = tileSpecs.getTileSpecs().stream().findFirst().orElseThrow();
+		final int height = firstTileSpec.getHeight();
+		final double[][] pixels = new double[height][];
+		for (int y = 0; y < height; y++) {
+			pixels[y] = new double[] { y };
+		}
+
+		final TileSpec tileSpec = tileSpecs.getTileSpecs().stream().findFirst().orElseThrow();
+		final ImageProcessor image = IMAGE_LOADER.get(tileSpec.getTileImageUrl(), 0, false, false, loaderType, null);
+		final double[] average = new double[image.getHeight()];
+		for (int y = 0; y < image.getHeight(); y++) {
+			double sum = 0;
+			for (int x = 0; x < image.getWidth(); x++) {
+				sum += image.getf(x, y);
+			}
+			average[y] = sum / image.getHeight();
+			pixels[y] = new double[] { y };
+		}
+		System.out.println("average = " + Arrays.toString(average));
+
+		final FunctionFitter fitter = new LevenbergMarquardtSolver();
+		final FitFunction model = new SigmoidalModel();
+		final double[] parameters = new double[]{average[0], 1, 0};
+
+		try {
+			fitter.fit(pixels, average, parameters, model);
+		} catch (final Exception e) {
+			LOG.error("process: error fitting model", e);
+		}
+
+		System.out.println("fitted parameters = " + Arrays.toString(parameters));
+	}
+
+	/**
+	 * Sigmoidal model of the form y = a / (1 + exp(-b * (x - c))).
+	 */
+	private static class SigmoidalModel implements FitFunction {
+
+		@Override
+		public double val(final double[] x, final double[] a) {
+			return a[0] / (1 + Math.exp(-a[1] * (x[0] - a[2])));
+		}
+
+		@Override
+		public double grad(final double[] x, final double[] a, final int i) {
+			final double z = Math.exp(-a[1] * (x[0] - a[2]));
+			final double z1 = 1 + z;
+			switch (i) {
+				case 0:
+					return 1 / z1;
+				case 1:
+					return a[0] * (x[0] - a[2]) * z / (z1 * z1);
+				case 2:
+					return - a[0] * a[1] * z / (z1 * z1);
+				default:
+					throw new IllegalArgumentException("Invalid parameter index: " + i);
+			}
+		}
+
+		@Override
+		public double hessian(final double[] x, final double[] a, final int i, final int j) {
+			throw new UnsupportedOperationException("Hessian not implemented for sigmoidal model");
+		}
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExponentialFitClient.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ExponentialFitClient.java
@@ -7,7 +7,6 @@ import net.imglib2.algorithm.localization.FitFunction;
 import net.imglib2.algorithm.localization.FunctionFitter;
 import net.imglib2.algorithm.localization.LevenbergMarquardtSolver;
 import org.janelia.alignment.filter.ExponentialIntensityFilter;
-import org.janelia.alignment.filter.Filter;
 import org.janelia.alignment.filter.FilterSpec;
 import org.janelia.alignment.loader.ImageLoader;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
@@ -230,8 +229,7 @@ public class ExponentialFitClient {
 			final TileSpec tileSpec = tileSpecs.getTileSpec(tileId);
 			final double[] coeff = entry.getValue();
 
-			final Filter filter = new ExponentialIntensityFilter(coeff[0], coeff[1]);
-			final FilterSpec filterSpec = new FilterSpec(filter.getClass().getName(), filter.toParametersMap());
+			final FilterSpec filterSpec = FilterSpec.forFilter(new ExponentialIntensityFilter(coeff[0], coeff[1]));
 			tileSpec.setFilterSpec(filterSpec);
 		}
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/FlatFieldCorrectionClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/FlatFieldCorrectionClient.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client;
+package org.janelia.render.client.multisem;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
@@ -14,9 +14,10 @@ import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackMetaData;
 import org.janelia.alignment.util.ImageProcessorCache;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +31,7 @@ import java.util.List;
  *
  * @author Michael Innerberger
  */
-public class MultiSemFlatFieldCorrectionClient {
-
+public class FlatFieldCorrectionClient {
 
 	// make cache large enough to hold all flat field estimates for one layer
 	private final Parameters params;
@@ -50,7 +50,7 @@ public class MultiSemFlatFieldCorrectionClient {
 		private String targetStackSuffix = "_corrected";
 		@Parameter(names = "--inputRoot", description = "Root folder for input data; if given, the structure under this root is replicated in the output folder")
 		private String inputRoot = null;
-		@Parameter(names = "--flatFieldConstantFromZ", description = "Maximum z-layer of flat field estimates to consider. All subsequent z-layers get corrected with the maxium, since the estimates can be bad for the last few z-layers. If not given, all z-layers are considered")
+		@Parameter(names = "--flatFieldConstantFromZ", description = "Maximum z-layer of flat field estimates to consider. All subsequent z-layers get corrected with the maximum, since the estimates can be bad for the last few z-layers. If not given, all z-layers are considered")
 		private Integer flatFieldConstantFromZ = Integer.MAX_VALUE;
 		@Parameter(names = "--cacheSizeGb", description = "Size of the image processor cache in GB (should be enough to hold one layer of flat field estimates)")
 		private double cacheSizeGb = 1.5;
@@ -65,14 +65,14 @@ public class MultiSemFlatFieldCorrectionClient {
 				parameters.parse(args);
 				LOG.info("runClient: entry, parameters={}", parameters);
 
-				final MultiSemFlatFieldCorrectionClient client = new MultiSemFlatFieldCorrectionClient(parameters);
+				final FlatFieldCorrectionClient client = new FlatFieldCorrectionClient(parameters);
 				client.correctTiles();
 			}
 		};
 		clientRunner.run();
 	}
 
-	public MultiSemFlatFieldCorrectionClient(final Parameters parameters) {
+	public FlatFieldCorrectionClient(final Parameters parameters) {
 		this.params = parameters;
 		final double cacheSizeInBytes = 1_000_000_000 * parameters.cacheSizeGb;
 		this.cache = new ImageProcessorCache((long) cacheSizeInBytes, false, false);
@@ -195,5 +195,5 @@ public class MultiSemFlatFieldCorrectionClient {
 		IJ.save(imp, tileSpec.getImagePath());
 	}
 
-	private static final Logger LOG = LoggerFactory.getLogger(MultiSemFlatFieldCorrectionClient.class);
+	private static final Logger LOG = LoggerFactory.getLogger(FlatFieldCorrectionClient.class);
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/PreAlignClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/PreAlignClient.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client;
+package org.janelia.render.client.multisem;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
@@ -9,6 +9,8 @@ import org.janelia.alignment.spec.ResolvedTileSpecCollection.TransformApplicatio
 import org.janelia.alignment.spec.ResolvedTileSpecsWithMatchPairs;
 import org.janelia.alignment.spec.TransformSpec;
 import org.janelia.alignment.spec.stack.StackMetaData;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.solvers.affine.MultiSemPreAligner;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.MatchCollectionParameters;
@@ -28,7 +30,7 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Michael Innerberger
  */
-public class MultiSemPreAlignClient implements Serializable {
+public class PreAlignClient implements Serializable {
 
 	public static class Parameters extends CommandLineParameters {
 
@@ -97,7 +99,7 @@ public class MultiSemPreAlignClient implements Serializable {
 
 				LOG.info("runClient: entry, parameters={}", parameters);
 
-				final MultiSemPreAlignClient client = new MultiSemPreAlignClient(parameters);
+				final PreAlignClient client = new PreAlignClient(parameters);
 
 				client.process();
 			}
@@ -109,7 +111,7 @@ public class MultiSemPreAlignClient implements Serializable {
 	private final Parameters parameters;
 	private final RenderDataClient dataClient;
 
-	public MultiSemPreAlignClient(final Parameters parameters) {
+	public PreAlignClient(final Parameters parameters) {
 		this.parameters = parameters;
 		this.dataClient = parameters.renderWeb.getDataClient();
 	}
@@ -160,5 +162,5 @@ public class MultiSemPreAlignClient implements Serializable {
 		}
 	}
 
-	private static final Logger LOG = LoggerFactory.getLogger(MultiSemPreAlignClient.class);
+	private static final Logger LOG = LoggerFactory.getLogger(PreAlignClient.class);
 }

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/ExponentialFitClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/ExponentialFitClientTest.java
@@ -22,6 +22,7 @@ public class ExponentialFitClientTest {
                 "--project", "slab_070_to_079",
                 "--stack", "s070_m104_align",
                 "--targetStack", "s070_m104_align_exp_test01",
+                "--coefficientsFile", "./coefficients.csv",
                 "--completeTargetStack",
         };
 

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/ExponentialFitClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/ExponentialFitClientTest.java
@@ -1,0 +1,30 @@
+package org.janelia.render.client.multisem;
+
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.junit.Test;
+
+/**
+ * Tests the {@link ExponentialFitClient} class.
+ *
+ * @author Michael Innerberger
+ */
+public class ExponentialFitClientTest {
+
+    @Test
+    public void testParameterParsing() throws Exception {
+        CommandLineParameters.parseHelp(new ExponentialFitClient.Parameters());
+    }
+
+    public static void main(final String[] args) {
+        final String[] effectiveArgs = {
+                "--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+                "--owner", "hess_wafer_53d",
+                "--project", "slab_070_to_079",
+                "--stack", "s070_m104_align",
+                "--targetStack", "s070_m104_align_exp_test01",
+                "--completeTargetStack",
+        };
+
+        ExponentialFitClient.main(effectiveArgs);
+    }
+}

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/FlatFieldCorrectionClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/FlatFieldCorrectionClientTest.java
@@ -1,18 +1,18 @@
-package org.janelia.render.client;
+package org.janelia.render.client.multisem;
 
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.junit.Test;
 
 /**
- * Tests the {@link MultiSemFlatFieldCorrectionClient} class.
+ * Tests the {@link FlatFieldCorrectionClient} class.
  *
  * @author Michael Innerberger
  */
-public class MultiSemFlatFieldCorrectionClientTest {
+public class FlatFieldCorrectionClientTest {
 
     @Test
     public void testParameterParsing() throws Exception {
-        CommandLineParameters.parseHelp(new MultiSemFlatFieldCorrectionClient.Parameters());
+        CommandLineParameters.parseHelp(new FlatFieldCorrectionClient.Parameters());
     }
 
     public static void main(String[] args) {
@@ -28,7 +28,7 @@ public class MultiSemFlatFieldCorrectionClientTest {
                 "--flatFieldFormat", "flat_field_z%03d_sfov%03d_n2000.tif",
         };
 
-        MultiSemFlatFieldCorrectionClient.main(args);
+        FlatFieldCorrectionClient.main(args);
     }
 
 }

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/PreAlignClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/PreAlignClientTest.java
@@ -1,18 +1,18 @@
-package org.janelia.render.client;
+package org.janelia.render.client.multisem;
 
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.junit.Test;
 
 /**
- * Tests the {@link MultiSemPreAlignClient} class.
+ * Tests the {@link PreAlignClient} class.
  *
  * @author Michael Innerberger
  */
-public class MultiSemPreAlignClientTest {
+public class PreAlignClientTest {
 
     @Test
     public void testParameterParsing() throws Exception {
-        CommandLineParameters.parseHelp(new MultiSemPreAlignClient.Parameters());
+        CommandLineParameters.parseHelp(new PreAlignClient.Parameters());
     }
 
     public static void main(final String[] args) {
@@ -32,6 +32,6 @@ public class MultiSemPreAlignClientTest {
                 "--numThreads", "8"
         };
 
-        MultiSemPreAlignClient.main(effectiveArgs);
+        PreAlignClient.main(effectiveArgs);
     }
 }


### PR DESCRIPTION
I added an exponential fit that could potentially cure the dark area at the top of most tiles. To this end, I introduced a client that estimates the correction and adds a filter spec to the tile specs, as well as a filter.

There is [one (layer of one) stack](http://renderer.int.janelia.org:8080/render-ws/view/point-match-explorer.html?renderDataHost=renderer.int.janelia.org%3A8080&dynamicRenderHost=renderer.int.janelia.org%3A8080&catmaidHost=renderer-catmaid.int.janelia.org%3A8000&ndvizHost=renderer.int.janelia.org%3A8080&renderStackOwner=hess_wafer_53d&renderStackProject=slab_070_to_079&renderStack=s070_m104_align_exp_test02&startZ=2&endZ=2) that already has this correction included. However, since the filter code is not deployed yet, I could check the quality of the correction only locally so far.