### PR TITLE
Change order of sanity check and downsample removal

### DIFF
--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
@@ -332,6 +332,13 @@ public class N5Client {
 
         } else if (parameters.appendToExisting) {
 
+            final Long minZToRender = setupAppendExportN5(parameters,
+                                                          fullScaleDatasetName,
+                                                          stackMetaData,
+                                                          dimensions,
+                                                          blockSize,
+                                                          getDataType());
+
             if (fullScaleDatasetName.endsWith("s0")) {
                 final File parentDir = datasetDir.getParentFile();
                 final File[] downsampledDirs = parentDir.listFiles(DOWNSAMPLED_DIR_FILTER);
@@ -348,13 +355,6 @@ public class N5Client {
                     }
                 }
             }
-
-            final Long minZToRender = setupAppendExportN5(parameters,
-                                                          fullScaleDatasetName,
-                                                          stackMetaData,
-                                                          dimensions,
-                                                          blockSize,
-                                                          getDataType());
 
             renderStack(sparkContext,
                         blockSize,


### PR DESCRIPTION
This is to fix an issue with the append mode of the N5 client: if one of the sanity checks in `setupAppendExportN5` fails, the whole process is aborted. However, the downsampled data was already removed at this point, rendering the existing N5 invalid.

By changing the order, the sanity checks should abort before touching the N5.

There is one thing I'm not sure about: `setupAppendExportN5` updates some metadata of the N5. Is it ok to do this before removing the data, or is the metadata used in the removal process?