### PR TITLE
Refactor grid functionality

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/spec/Bounds.java
+++ b/render-app/src/main/java/org/janelia/alignment/spec/Bounds.java
@@ -100,11 +100,21 @@ public class Bounds implements Serializable {
         return minY.intValue();
     }
 
+    /**
+     * Note: this is the same as {@link #getDeltaX()} rounded up to the nearest integer and is distinct from the natural
+     * interpretation of the term "width" of an image, which is the number of pixels in the x direction.
+     * @return the width of the bounding box, rounded up to the nearest integer.
+     */
     @JsonIgnore
     public int getWidth() {
         return (int) Math.ceil(getDeltaX());
     }
 
+    /**
+     * Note: this is the same as {@link #getDeltaY()} rounded up to the nearest integer and is distinct from the natural
+     * interpretation of the term "height" of an image, which is the number of pixels in the y direction.
+     * @return the height of the bounding box, rounded up to the nearest integer.
+     */
     @JsonIgnore
     public int getHeight() {
         return (int) Math.ceil(getDeltaY());

--- a/render-app/src/main/java/org/janelia/alignment/util/Grid.java
+++ b/render-app/src/main/java/org/janelia/alignment/util/Grid.java
@@ -16,6 +16,7 @@
  */
 package org.janelia.alignment.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +37,7 @@ public class Grid {
 
 	/**
 	 * Crops the dimensions of a {@link DataBlock} at a given offset to fit
-	 * into and {@link Interval} of given dimensions.  Fills long and int
+	 * into an {@link Interval} of given dimensions.  Fills long and int
 	 * version of cropped block size.  Also calculates the grid raster position
 	 * assuming that the offset divisible by block size without remainder.
 	 */
@@ -63,25 +64,20 @@ public class Grid {
 	 * specified on an independent output grid.  It is assumed that
 	 * gridBlockSize is an integer multiple of outBlockSize.
 	 */
-	public static List<long[][]> create(
+	public static List<Block> create(
 			final long[] dimensions,
 			final int[] gridBlockSize,
 			final int[] outBlockSize) {
 
 		final int n = dimensions.length;
-		final ArrayList<long[][]> gridBlocks = new ArrayList<>();
+		final List<Block> gridBlocks = new ArrayList<>();
 
 		final long[] offset = new long[n];
 		final long[] gridPosition = new long[n];
 		final long[] longCroppedGridBlockSize = new long[n];
 		for (int d = 0; d < n;) {
 			cropBlockDimensions(dimensions, offset, outBlockSize, gridBlockSize, longCroppedGridBlockSize, gridPosition);
-				gridBlocks.add(
-						new long[][]{
-							offset.clone(),
-							longCroppedGridBlockSize.clone(),
-							gridPosition.clone()
-						});
+			gridBlocks.add(new Block(offset, longCroppedGridBlockSize, gridPosition));
 
 			for (d = 0; d < n; ++d) {
 				offset[d] += gridBlockSize[d];
@@ -99,7 +95,7 @@ public class Grid {
 	 * the world coordinate offset, the size of the grid block, and the
 	 * grid-coordinate offset.
 	 */
-	public static List<long[][]> create(
+	public static List<Block> create(
 			final long[] dimensions,
 			final int[] blockSize) {
 
@@ -165,5 +161,18 @@ public class Grid {
 		final long[] ceilScaled = new long[doubles.length];
 		Arrays.setAll(ceilScaled, i -> (long)Math.ceil(doubles[i] * scale));
 		return ceilScaled;
+	}
+
+
+	public static class Block implements Serializable {
+		public final long[] dimensions;
+		public final long[] offset;
+		public final long[] gridPosition;
+
+		public Block(final long[] dimensions, final long[] offset, final long[] gridPosition) {
+			this.dimensions = dimensions.clone();
+			this.offset = offset.clone();
+			this.gridPosition = gridPosition.clone();
+		}
 	}
 }

--- a/render-app/src/main/java/org/janelia/alignment/util/Grid.java
+++ b/render-app/src/main/java/org/janelia/alignment/util/Grid.java
@@ -164,7 +164,7 @@ public class Grid {
 	}
 
 
-	public static class Block implements Serializable {
+	public static class Block implements Serializable, Interval {
 		public final long[] dimensions;
 		public final long[] offset;
 		public final long[] gridPosition;
@@ -173,6 +173,32 @@ public class Grid {
 			this.dimensions = dimensions.clone();
 			this.offset = offset.clone();
 			this.gridPosition = gridPosition.clone();
+
+			if (dimensions.length != offset.length || dimensions.length != gridPosition.length)
+				throw new IllegalArgumentException("Dimensions of block, offset, and grid position must match.");
+		}
+
+		public Block(final Block otherBlock) {
+			this(otherBlock.dimensions, otherBlock.offset, otherBlock.gridPosition);
+		}
+
+		public Block(final Interval interval, final long[] gridPosition) {
+			this(interval.dimensionsAsLongArray(), interval.minAsLongArray(), gridPosition);
+		}
+
+		@Override
+		public long min(final int i) {
+			return offset[i];
+		}
+
+		@Override
+		public long max(final int i) {
+			return offset[i] + dimensions[i] - 1;
+		}
+
+		@Override
+		public int numDimensions() {
+			return dimensions.length;
 		}
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/RecapKensAlignmentTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/RecapKensAlignmentTools.java
@@ -73,7 +73,7 @@ public class RecapKensAlignmentTools {
 						ArrayImgs.unsignedBytes( interval.dimensionsAsLongArray() ),
 						Intervals.minAsLongArray( interval ) );
 
-		final List<long[][]> grid =
+		final List<Grid.Block> grid =
 				Grid.create(
 						interval.dimensionsAsLongArray(),
 						new int[] { 512, 512 } );
@@ -121,8 +121,8 @@ public class RecapKensAlignmentTools {
 							final Interval block =
 									Intervals.translate(
 											Intervals.translate(
-													new FinalInterval( gridBlock[1] ), // blocksize
-													gridBlock[0] ), // block offset
+													new FinalInterval(gridBlock.dimensions),
+													gridBlock.offset),
 											Intervals.minAsLongArray( interval ) ); // offset of global interval
 
 							final RandomAccessibleInterval< UnsignedByteType > target = Views.interval( output, block );

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/RecapKensAlignmentTools.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/RecapKensAlignmentTools.java
@@ -73,10 +73,7 @@ public class RecapKensAlignmentTools {
 						ArrayImgs.unsignedBytes( interval.dimensionsAsLongArray() ),
 						Intervals.minAsLongArray( interval ) );
 
-		final List<Grid.Block> grid =
-				Grid.create(
-						interval.dimensionsAsLongArray(),
-						new int[] { 512, 512 } );
+		final List<Grid.Block> grid = Grid.create(interval.dimensionsAsLongArray(), new int[] {512, 512});
 
 		System.out.println( "num blocks = " + grid.size() );
 
@@ -118,13 +115,7 @@ public class RecapKensAlignmentTools {
 		ex.submit(() ->
 			grid.parallelStream().forEach(
 					gridBlock -> {
-							final Interval block =
-									Intervals.translate(
-											Intervals.translate(
-													new FinalInterval(gridBlock.dimensions),
-													gridBlock.offset),
-											Intervals.minAsLongArray( interval ) ); // offset of global interval
-
+							final Interval block = Intervals.translate(gridBlock, interval.minAsLongArray()); // offset of global interval
 							final RandomAccessibleInterval< UnsignedByteType > target = Views.interval( output, block );
 
 							// test which images we actually overlap

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ResaveSegmentations.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/ResaveSegmentations.java
@@ -139,7 +139,7 @@ public class ResaveSegmentations {
 		final String targetStack = stackBaseName + targetStackSuffix;
 		final ResolvedTileSpecCollection sourceTiles = dataClient.getResolvedTiles(stackBaseName + sourceStackSuffix, null);
 		final ResolvedTileSpecCollection targetTiles = dataClient.getResolvedTiles(targetStack, null);
-		final List<long[][]> grid = createGridOverRelevantTiles(targetAttributes, targetBounds, targetTiles, sourceTiles);
+		final List<Grid.Block> grid = createGridOverRelevantTiles(targetAttributes, targetBounds, targetTiles, sourceTiles);
 		scanTransformedTemplateTile = createRawBoundingBox(targetTiles.getTileSpecs().stream().findAny().orElseThrow());
 
 		// Get mapping "layer in exported stack" -> "stack name + layer" for the stack under consideration
@@ -148,7 +148,7 @@ public class ResaveSegmentations {
 		// Fuse data block by block
 		final ExecutorService executor = (numThreads == 1) ? Executors.newSingleThreadExecutor() : Executors.newFixedThreadPool(numThreads);
 		final CompletionService<Void> completionService = new ExecutorCompletionService<>(executor);
-		for (final long[][] gridBlock : grid) {
+		for (final Grid.Block gridBlock : grid) {
 			completionService.submit(() -> fuseBlock(sourceTiles.getTileIdToSpecMap(), targetTiles.getTileIdToSpecMap(), segmentations, gridBlock, layerOrigins, targetN5, targetDataset));
 		}
 
@@ -165,14 +165,14 @@ public class ResaveSegmentations {
 		}
 	}
 
-	private static List<long[][]> createGridOverRelevantTiles(
+	private static List<Grid.Block> createGridOverRelevantTiles(
 			final DatasetAttributes targetAttributes,
 			final Bounds targetBounds,
 			final ResolvedTileSpecCollection targetTiles,
 			final ResolvedTileSpecCollection sourceTiles
 	) {
 		// Start with a grid over the full dimensions, then only keep blocks that intersect with tiles that will be used in writing
-		final List<long[][]> fullGrid = Grid.create(targetAttributes.getDimensions(), targetAttributes.getBlockSize());
+		final List<Grid.Block> fullGrid = Grid.create(targetAttributes.getDimensions(), targetAttributes.getBlockSize());
 
 		// Offset the grid by the stack offset
 		final long[] stackOffset = new long[]{targetBounds.getMinX().longValue(), targetBounds.getMinY().longValue(), targetBounds.getMinZ().longValue()};
@@ -181,7 +181,7 @@ public class ResaveSegmentations {
 		targetTiles.retainTileSpecs(sourceTiles.getTileIds());
 		targetTiles.recalculateBoundingBoxes();
 		final Rectangle remainingStackBounds = targetTiles.toBounds().toRectangle();
-		final List<long[][]> relevantGridBlocks = fullGrid.stream()
+		final List<Grid.Block> relevantGridBlocks = fullGrid.stream()
 				.map(gridBlock -> offsetBlock(gridBlock, stackOffset))
 				.filter(gridBlock -> intersectsWithStackBounds(gridBlock, remainingStackBounds))
 				.collect(Collectors.toList());
@@ -190,16 +190,15 @@ public class ResaveSegmentations {
 		return relevantGridBlocks;
 	}
 
-	private static long[][] offsetBlock(final long[][] gridBlock, final long[] stackOffset) {
-		gridBlock[0][0] += stackOffset[0];
-		gridBlock[0][1] += stackOffset[1];
+	private static Grid.Block offsetBlock(final Grid.Block gridBlock, final long[] stackOffset) {
+		gridBlock.offset[0] += stackOffset[0];
+		gridBlock.offset[1] += stackOffset[1];
 		return gridBlock;
 	}
 
-	private static boolean intersectsWithStackBounds(final long[][] gridBlock, final Rectangle remainingStackBounds) {
-		final long[] blockOffset = gridBlock[0];
-		final long[] blockSize = gridBlock[1];
-		final Rectangle blockBounds = new Rectangle((int) blockOffset[0], (int) blockOffset[1], (int) blockSize[0], (int) blockSize[1]);
+	private static boolean intersectsWithStackBounds(final Grid.Block gridBlock, final Rectangle remainingStackBounds) {
+		final Rectangle blockBounds = new Rectangle((int) gridBlock.offset[0], (int) gridBlock.offset[1],
+													(int) gridBlock.dimensions[0], (int) gridBlock.dimensions[1]);
 		return remainingStackBounds.intersects(blockBounds);
 	}
 
@@ -207,15 +206,13 @@ public class ResaveSegmentations {
 			final Map<String, TileSpec> sourceTiles,
 			final Map<String, TileSpec> targetTiles,
 			final RandomAccessibleInterval<UnsignedLongType> segmentations,
-			final long[][] gridBlock,
+			final Grid.Block gridBlock,
 			final Map<Integer, LayerOrigin> layerOrigins,
 			final String n5path,
 			final String dataset
 	) {
-		final long[] blockSize = gridBlock[1];
-		final long[] blockOffset = gridBlock[0];
-		final Interval block = Intervals.translate(new FinalInterval(blockSize), blockOffset);
-		final Img<UnsignedLongType> blockData = ArrayImgs.unsignedLongs(blockSize);
+		final Interval block = Intervals.translate(new FinalInterval(gridBlock.dimensions), gridBlock.offset);
+		final Img<UnsignedLongType> blockData = ArrayImgs.unsignedLongs(gridBlock.dimensions);
 
 		final Map<Integer, Integer> zRenderToExport = new HashMap<>();
 		layerOrigins.forEach((exportZ, layerOrigin) -> {
@@ -252,7 +249,7 @@ public class ResaveSegmentations {
 		final long[] cropOffset = new long[]{margin, margin, 0};
 
 		final RandomAccessibleInterval<UnsignedLongType> positionedSegmentation = Views.translate(Views.dropSingletonDimensions(segmentations), cropOffset);
-		final RandomAccessibleInterval<UnsignedLongType> positionedBlock = Views.translate(blockData, blockOffset);
+		final RandomAccessibleInterval<UnsignedLongType> positionedBlock = Views.translate(blockData, gridBlock.offset);
 
 		final Cursor<UnsignedLongType> targetCursor = Views.iterable(positionedBlock).localizingCursor();
 		final RealRandomAccess<UnsignedLongType> sourceRa = Views.interpolate(Views.extendZero(positionedSegmentation), new NearestNeighborInterpolatorFactory<>()).realRandomAccess();
@@ -291,8 +288,7 @@ public class ResaveSegmentations {
 
 		// Write block if it's not empty
 		try (final N5Writer writer = new N5FSWriter(n5path)) {
-			final long[] gridOffset = gridBlock[2];
-			N5Utils.saveNonEmptyBlock(blockData, writer, dataset, gridOffset, new UnsignedLongType(0));
+			N5Utils.saveNonEmptyBlock(blockData, writer, dataset, gridBlock.gridPosition, new UnsignedLongType(0));
 		}
 		return null;
 	}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/ShortN5Client.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/ShortN5Client.java
@@ -9,6 +9,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.janelia.alignment.ShortBoxRenderer;
 import org.janelia.alignment.spec.Bounds;
+import org.janelia.alignment.util.Grid;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.alignment.util.ImageProcessorCacheSpec;
 import org.janelia.render.client.ClientRunner;
@@ -123,9 +124,9 @@ public class ShortN5Client
                                         final ImageProcessorCacheSpec cacheSpec,
                                         final Long minZToRender) {
 
-        final List<long[][]> gridBlocks = buildGridBlocks(tileWidth, tileHeight, dimensions, blockSize, minZToRender);
+        final List<Grid.Block> gridBlocks = buildGridBlocks(tileWidth, tileHeight, dimensions, blockSize, minZToRender);
 
-        final JavaRDD<long[][]> rdd = sc.parallelize(gridBlocks);
+        final JavaRDD<Grid.Block> rdd = sc.parallelize(gridBlocks);
 
         final Broadcast<ImageProcessorCacheSpec> broadcastCacheSpec = sc.broadcast(cacheSpec);
 
@@ -134,11 +135,11 @@ public class ShortN5Client
             final ImageProcessorCache ipCache = broadcastCacheSpec.getValue().getSharableInstance();
 
             /* assume we can fit it in an array */
-            final ArrayImg<UnsignedShortType, ShortArray> block = ArrayImgs.unsignedShorts(gridBlock[1]);
+            final ArrayImg<UnsignedShortType, ShortArray> block = ArrayImgs.unsignedShorts(gridBlock.dimensions);
 
-            final long x = gridBlock[0][0] + min[0];
-            final long y = gridBlock[0][1] + min[1];
-            final long startZ = gridBlock[0][2] + min[2];
+            final long x = gridBlock.offset[0] + min[0];
+            final long y = gridBlock.offset[1] + min[1];
+            final long startZ = gridBlock.offset[2] + min[2];
 
             // enable logging on executors and add gridBlock context to log messages
             LogUtilities.setupExecutorLog4j(x + ":" + y + ":" + startZ);
@@ -149,7 +150,7 @@ public class ShortN5Client
             ShortProcessor nextProcessor = null;
             for (int zIndex = 0; zIndex < block.dimension(2); zIndex++) {
 
-                final long z = gridBlock[0][2] + min[2] + zIndex;
+                final long z = gridBlock.offset[2] + min[2] + zIndex;
 
                 if (thicknessCorrectionData == null) {
                     currentProcessor = boxRenderer.render(x, y, z, ipCache);
@@ -216,7 +217,7 @@ public class ShortN5Client
             }
 
             final N5Writer anotherN5Writer = new N5FSWriter(n5Path); // needed to prevent Spark serialization error
-            N5Utils.saveNonEmptyBlock(block, anotherN5Writer, datasetName, gridBlock[2], new UnsignedShortType(0));
+            N5Utils.saveNonEmptyBlock(block, anotherN5Writer, datasetName, gridBlock.gridPosition, new UnsignedShortType(0));
         });
     }
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/ShortN5Client.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/ShortN5Client.java
@@ -4,6 +4,7 @@ import ij.process.ShortProcessor;
 
 import java.util.List;
 
+import net.imglib2.util.Intervals;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -137,9 +138,10 @@ public class ShortN5Client
             /* assume we can fit it in an array */
             final ArrayImg<UnsignedShortType, ShortArray> block = ArrayImgs.unsignedShorts(gridBlock.dimensions);
 
-            final long x = gridBlock.offset[0] + min[0];
-            final long y = gridBlock.offset[1] + min[1];
-            final long startZ = gridBlock.offset[2] + min[2];
+            final Grid.Block translatedBlock = new Grid.Block(Intervals.translate(block, min), gridBlock.gridPosition);
+            final long x = translatedBlock.min(0);
+            final long y = translatedBlock.min(1);
+            final long startZ = translatedBlock.min(2);
 
             // enable logging on executors and add gridBlock context to log messages
             LogUtilities.setupExecutorLog4j(x + ":" + y + ":" + startZ);
@@ -150,7 +152,7 @@ public class ShortN5Client
             ShortProcessor nextProcessor = null;
             for (int zIndex = 0; zIndex < block.dimension(2); zIndex++) {
 
-                final long z = gridBlock.offset[2] + min[2] + zIndex;
+                final long z = translatedBlock.min(2) + zIndex;
 
                 if (thicknessCorrectionData == null) {
                     currentProcessor = boxRenderer.render(x, y, z, ipCache);


### PR DESCRIPTION
I refactored the Grid class to create a list of `Grid.Block` objects instead of `long[][]` arrays. The latter feels a bit cumbersome and error prone to me (I struggled to remember what the index values meant), so I made it more explicit.

Furthermore, I made `Grid.Block` implement ImgLib2's `Interval`, which makes some uses of the grid blocks more natural, and added clarifying comments to some methods of `Bounds`.