### PR TITLE
Refactor intensity matching

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/RansacRegressionReduceFilter.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/intensity/RansacRegressionReduceFilter.java
@@ -19,9 +19,6 @@
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
  * #L%
  */
-/**
- *
- */
 package org.janelia.render.client.intensityadjust.intensity;
 
 import java.util.ArrayList;
@@ -33,8 +30,9 @@ import mpicbg.models.AffineModel1D;
 import mpicbg.models.IllDefinedDataPointsException;
 import mpicbg.models.Model;
 import mpicbg.models.NotEnoughDataPointsException;
-import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
+import org.janelia.render.client.newsolver.solvers.intensity.Point1D;
+import org.janelia.render.client.newsolver.solvers.intensity.PointMatch1D;
 
 /**
  * @author Stephan Saalfeld saalfelds@janelia.hhmi.org
@@ -95,25 +93,25 @@ public class RansacRegressionReduceFilter implements PointMatchFilter
 
 		final double[] minMax = minMax(inliers);
 		final double weight = 2.0 / model.getMinNumMatches();
-		final List<Point> points = evenlySpacedPoints(minMax, model.getMinNumMatches());
+		final List<Point1D> points = evenlySpacedPoints(minMax, model.getMinNumMatches());
 		inliers.clear();
 
-		for (final Point point : points) {
+		for (final Point1D point : points) {
 			point.apply(model);
-			inliers.add(new PointMatch(point, new Point(point.getW().clone()), weight));
+			inliers.add(new PointMatch1D(point, new Point1D(point.getW()[0]), weight));
 		}
 	}
 
-	protected List<Point> evenlySpacedPoints(final double[] interval, final int n) {
+	protected List<Point1D> evenlySpacedPoints(final double[] interval, final int n) {
 		if (n == 1)
-			return List.of(new Point(new double[]{ (interval[0] + interval[1]) / 2 }));
+			return List.of(new Point1D((interval[0] + interval[1]) / 2));
 
 		final double min = interval[0];
 		final double delta = (interval[1] - interval[0]) / (n-1);
-		final List<Point> points = new ArrayList<>();
+		final List<Point1D> points = new ArrayList<>();
 
 		for (int k = 0; k < n; k++) {
-			points.add(new Point(new double[]{ min + k*delta }));
+			points.add(new Point1D(min + k*delta));
 		}
 
 		return points;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -235,20 +235,19 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 		/* optimize */
 		final List<IntensityTile> tiles = new ArrayList<>(coefficientTiles.values());
-		final List<IntensityTile> fixedTiles = new ArrayList<>();
 
 		// anchor the equilibration tile if it is used, otherwise anchor a random tile (the first one)
+		final IntensityTile fixedTile;
 		if (blockData.solveTypeParameters().equilibrationWeight() > 0.0) {
 			tiles.add(equilibrationTile);
-			fixedTiles.add(equilibrationTile);
+			fixedTile = equilibrationTile;
 		} else {
-			final IntensityTile firstTile = tiles.get(0);
-			fixedTiles.add(firstTile);
+			fixedTile = tiles.get(0);
 		}
 
 		LOG.info("solveForGlobalCoefficients: optimizing {} tiles with {} threads", tiles.size(), numThreads);
 		final IntensityTileOptimizer optimizer = new IntensityTileOptimizer(0.01, iterations, iterations, 0.75, numThreads);
-		optimizer.optimize(tiles, fixedTiles);
+		optimizer.optimize(tiles, fixedTile);
 
 		// TODO: this is not the right error measure, what is idToBlockErrorMap supposed to be exactly?
 		coefficientTiles.forEach((tileId, tile) -> {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -1,15 +1,11 @@
 package org.janelia.render.client.newsolver.solvers.intensity;
 
-import mpicbg.models.Affine1D;
 import mpicbg.models.AffineModel1D;
-import mpicbg.models.ErrorStatistic;
 import mpicbg.models.IdentityModel;
 import mpicbg.models.InterpolatedAffineModel1D;
 import mpicbg.models.NoninvertibleModelException;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
-import mpicbg.models.TileConfiguration;
-import mpicbg.models.TileUtil;
 import mpicbg.models.TranslationModel1D;
 import net.imglib2.util.ValuePair;
 
@@ -76,14 +72,14 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 		final List<TileSpec> wrappedTiles = AdjustBlock.sortTileSpecs(blockData.rtsc());
 
-		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = computeCoefficients(wrappedTiles);
+		final Map<String, IntensityTile> coefficientTiles = computeCoefficients(wrappedTiles);
 
 		coefficientTiles.forEach((tileId, tiles) -> {
 			final ArrayList<AffineModel1D> models = new ArrayList<>();
-			tiles.forEach(tile -> {
-				final AffineModel1D model = ((InterpolatedAffineModel1D<?, ?>) tile.getModel()).createAffineModel1D();
-				models.add(model);
-			});
+			for (int i = 0; i < tiles.nSubTiles(); i++) {
+				final InterpolatedAffineModel1D<?, ?> interpolatedModel = (InterpolatedAffineModel1D<?, ?>) tiles.getSubTile(i).getModel();
+				models.add(interpolatedModel.createAffineModel1D());
+			}
 			blockData.getResults().recordModel(tileId, models);
 		});
 
@@ -105,7 +101,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		blockData.getResults().init(rtsc);
 	}
 
-	private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> computeCoefficients(final List<TileSpec> tiles)
+	private Map<String, IntensityTile> computeCoefficients(final List<TileSpec> tiles)
 			throws ExecutionException, InterruptedException {
 
 		LOG.info("computeCoefficients: entry");
@@ -115,7 +111,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 				? ImageProcessorCache.DISABLED_CACHE
 				: new ImageProcessorCache(parameters.maxNumberOfCachedPixels(), true, false);
 
-		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = splitIntoCoefficientTiles(tiles, imageProcessorCache);
+		final Map<String, IntensityTile> coefficientTiles = splitIntoCoefficientTiles(tiles, imageProcessorCache);
 
 		if (tiles.size() > 1) {
 			solveForGlobalCoefficients(coefficientTiles, ITERATIONS);
@@ -126,7 +122,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return coefficientTiles;
 	}
 
-	private HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> splitIntoCoefficientTiles(
+	private HashMap<String, IntensityTile> splitIntoCoefficientTiles(
 			final List<TileSpec> tiles,
 			final ImageProcessorCache imageProcessorCache
 	) throws InterruptedException, ExecutionException {
@@ -139,8 +135,7 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		LOG.info("splitIntoCoefficientTiles: entry, collecting pairs for {} patches with zDistance {}", tiles.size(), parameters.zDistance());
 
 		// generate coefficient tiles for all patches
-		final int nGridPoints = parameters.numCoefficients() * parameters.numCoefficients();
-		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = generateCoefficientsTiles(tiles, nGridPoints);
+		final HashMap<String, IntensityTile> coefficientTiles = generateCoefficientsTiles(tiles);
 
 		final List<ValuePair<TileSpec, TileSpec>> patchPairs = findOverlappingPatches(tiles, parameters.zDistance());
 
@@ -187,24 +182,18 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		return new IntensityMatcher(filter, parameters, meshResolution, imageProcessorCache);
 	}
 
-	private  HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> generateCoefficientsTiles(
-			final Collection<TileSpec> patches,
-			final int nGridPoints
-	) {
+	private  HashMap<String, IntensityTile> generateCoefficientsTiles(final Collection<TileSpec> patches) {
+
 		final InterpolatedAffineModel1D<InterpolatedAffineModel1D<AffineModel1D, TranslationModel1D>, IdentityModel> modelTemplate =
 				new InterpolatedAffineModel1D<>(
 						new InterpolatedAffineModel1D<>(
 								new AffineModel1D(), new TranslationModel1D(), parameters.lambdaTranslation()),
 						new IdentityModel(), parameters.lambdaIdentity());
 
-		final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles = new HashMap<>();
+		final HashMap<String, IntensityTile> coefficientTiles = new HashMap<>();
 		for (final TileSpec p : patches) {
-			final ArrayList<Tile<? extends Affine1D<?>>> coefficientModels = new ArrayList<>();
-			for (int i = 0; i < nGridPoints; ++i) {
-				final InterpolatedAffineModel1D<?,?> model = modelTemplate.copy();
-				coefficientModels.add(new Tile<>(model));
-			}
-			coefficientTiles.put(p.getTileId(), coefficientModels);
+			final IntensityTile tile = new IntensityTile(modelTemplate::copy, parameters.numCoefficients(), 1);
+			coefficientTiles.put(p.getTileId(), tile);
 		}
 		return coefficientTiles;
 	}
@@ -237,34 +226,34 @@ public class AffineIntensityCorrectionBlockWorker<M>
 
 	@SuppressWarnings("SameParameterValue")
 	private void solveForGlobalCoefficients(
-			final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
+			final Map<String, IntensityTile> coefficientTiles,
 			final int iterations
 	) {
-		final Tile<? extends Affine1D<?>> equilibrationTile = new Tile<>(new IdentityModel());
+		final IntensityTile equilibrationTile = new IntensityTile(IdentityModel::new, 1, 1);
 
 		connectTilesWithinPatches(coefficientTiles, equilibrationTile);
 
 		/* optimize */
-		final TileConfiguration tc = new TileConfiguration();
-		coefficientTiles.values().forEach(tc::addTiles);
+		final List<IntensityTile> tiles = new ArrayList<>(coefficientTiles.values());
+		final List<IntensityTile> fixedTiles = new ArrayList<>();
 
-		// anchor the equilibration tile
-		tc.addTile(equilibrationTile);
-		tc.fixTile(equilibrationTile);
-
-		LOG.info("solveForGlobalCoefficients: optimizing {} tiles with {} threads", tc.getTiles().size(), numThreads);
-		try {
-			TileUtil.optimizeConcurrently(new ErrorStatistic(iterations + 1), 0.01f, iterations, iterations, 0.75f, tc, tc.getTiles(), tc.getFixedTiles(), numThreads);
-		} catch (final Exception e) {
-			throw new RuntimeException(e);
+		// anchor the equilibration tile if it is used, otherwise anchor a random tile (the first one)
+		if (blockData.solveTypeParameters().equilibrationWeight() > 0.0) {
+			tiles.add(equilibrationTile);
+			fixedTiles.add(equilibrationTile);
+		} else {
+			final IntensityTile firstTile = tiles.get(0);
+			fixedTiles.add(firstTile);
 		}
 
+		LOG.info("solveForGlobalCoefficients: optimizing {} tiles with {} threads", tiles.size(), numThreads);
+		final IntensityTileOptimizer optimizer = new IntensityTileOptimizer(0.01, iterations, iterations, 0.75, numThreads);
+		optimizer.optimize(tiles, fixedTiles);
+
 		// TODO: this is not the right error measure, what is idToBlockErrorMap supposed to be exactly?
-		coefficientTiles.forEach((tileId, tiles) -> {
-			final Double error = tiles.stream().mapToDouble(t -> {
-				t.updateCost();
-				return t.getDistance();
-			}).average().orElse(Double.MAX_VALUE);
+		coefficientTiles.forEach((tileId, tile) -> {
+			tile.updateDistance();
+			final double error = tile.getDistance();
 			final Map<String, Double> errorMap = new HashMap<>();
 			errorMap.put(tileId, error);
 			blockData.getResults().recordAllErrors(tileId, errorMap);
@@ -274,46 +263,37 @@ public class AffineIntensityCorrectionBlockWorker<M>
 	}
 
 	private void connectTilesWithinPatches(
-			final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles,
-			final Tile<? extends Affine1D<?>> equilibrationTile
+			final Map<String, IntensityTile> coefficientTiles,
+			final IntensityTile equilibrationTile
 	) {
 		final Collection<TileSpec> allTiles = blockData.rtsc().getTileSpecs();
 		final double equilibrationWeight = blockData.solveTypeParameters().equilibrationWeight();
 
 		final ResultContainer<ArrayList<AffineModel1D>> results = blockData.getResults();
 		for (final TileSpec p : allTiles) {
-			final List<? extends Tile<?>> coefficientTile = coefficientTiles.get(p.getTileId());
+			final IntensityTile coefficientTile = coefficientTiles.get(p.getTileId());
 			for (int i = 1; i < parameters.numCoefficients(); ++i) {
 				for (int j = 0; j < parameters.numCoefficients(); ++j) {
-					final int left = getLinearIndex(i-1, j, parameters.numCoefficients());
-					final int right = getLinearIndex(i, j, parameters.numCoefficients());
-					final int top = getLinearIndex(j, i, parameters.numCoefficients());
-					final int bot = getLinearIndex(j, i-1, parameters.numCoefficients());
+					final Tile<?> left = coefficientTile.getSubTile(i-1, j);
+					final Tile<?> right = coefficientTile.getSubTile(i, j);
+					final Tile<?> top = coefficientTile.getSubTile(j, i);
+					final Tile<?> bot = coefficientTile.getSubTile(j, i-1);
 
-					identityConnect(coefficientTile.get(right), coefficientTile.get(left));
-					identityConnect(coefficientTile.get(top), coefficientTile.get(bot));
+					identityConnect(right, left);
+					identityConnect(top, bot);
 				}
 			}
 			if (equilibrationWeight > 0.0) {
 				final List<Double> averages = results.getAveragesFor(p.getTileId());
-				for (int i = 0; i < parameters.numCoefficients(); i++) {
-					for (int j = 0; j < parameters.numCoefficients(); j++) {
-						final int idx = getLinearIndex(i, j, parameters.numCoefficients());
-						equilibrateIntensity(coefficientTile.get(idx),
-											 equilibrationTile,
-											 averages.get(idx),
-											 equilibrationWeight);
-					}
+				coefficientTile.connectTo(equilibrationTile);
+				for (int i = 0; i < coefficientTile.nSubTiles(); i++) {
+					equilibrateIntensity(coefficientTile.getSubTile(i),
+										 equilibrationTile.getSubTile(0),
+										 averages.get(i),
+										 equilibrationWeight);
 				}
 			}
 		}
-	}
-
-	/**
-	 * Get index of the (x,y) pixel in an n x n grid represented by a linear array
-	 */
-	private int getLinearIndex(final int x, final int y, final int n) {
-		return y * n + x;
 	}
 
 	private static void equilibrateIntensity(final Tile<?> coefficientTile,

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -6,7 +6,6 @@ import mpicbg.models.ErrorStatistic;
 import mpicbg.models.IdentityModel;
 import mpicbg.models.InterpolatedAffineModel1D;
 import mpicbg.models.NoninvertibleModelException;
-import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import mpicbg.models.TileConfiguration;
@@ -321,16 +320,14 @@ public class AffineIntensityCorrectionBlockWorker<M>
 											 final Tile<?> equilibrationTile,
 											 final Double average,
 											 final double weight) {
-		final PointMatch eqMatch = new PointMatch(new Point(new double[] { average }),
-												  new Point(new double[] { 0.5 }),
-												  weight);
+		final PointMatch eqMatch = new PointMatch1D(new Point1D(average), new Point1D(0.5), weight);
 		coefficientTile.connect(equilibrationTile, List.of(eqMatch));
 	}
 
 	static protected void identityConnect(final Tile<?> t1, final Tile<?> t2) {
 		final ArrayList<PointMatch> matches = new ArrayList<>();
-		matches.add(new PointMatch(new Point(new double[] { 0 }), new Point(new double[] { 0 })));
-		matches.add(new PointMatch(new Point(new double[] { 1 }), new Point(new double[] { 1 })));
+		matches.add(new PointMatch1D(new Point1D(0), new Point1D(0)));
+		matches.add(new PointMatch1D(new Point1D(1), new Point1D(1)));
 		t1.connect(t2, matches);
 	}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -3,7 +3,6 @@ package org.janelia.render.client.newsolver.solvers.intensity;
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
 import mpicbg.models.Affine1D;
-import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import net.imglib2.util.Pair;
@@ -93,7 +92,7 @@ class IntensityMatcher {
 			if (matchCanContribute) {
 				final double p = pixels1.getf(i);
 				final double q = pixels2.getf(i);
-				final PointMatch pq = new PointMatch(new Point(new double[]{p}), new Point(new double[]{q}), weight1 * weight2);
+				final PointMatch pq = new PointMatch1D(new Point1D(p), new Point1D(q), weight1 * weight2);
 
 				/* first sub-tile label is 1 */
 				final List<PointMatch> matches = get(matrix, label1 - 1, label2 - 1, nCoefficientTiles);
@@ -176,9 +175,9 @@ class IntensityMatcher {
 		for (final Map.Entry<Pair<Integer, Integer>, Double> entry : pairToWeights.entrySet()) {
 			final Pair<Integer, Integer> pair = entry.getKey();
 			final double weight = entry.getValue();
-			final Point p1 = new Point(new double[]{ (double) pair.getA() / nBins });
-			final Point p2 = new Point(new double[]{ (double) pair.getB() / nBins });
-			compressedCandidates.add(new PointMatch(p1, p2, weight));
+			final Point1D p1 = new Point1D((double) pair.getA() / nBins);
+			final Point1D p2 = new Point1D((double) pair.getB() / nBins);
+			compressedCandidates.add(new PointMatch1D(p1, p2, weight));
 		}
 
 		return compressedCandidates;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -6,7 +6,9 @@ import mpicbg.models.Affine1D;
 import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
+import net.imglib2.util.Pair;
 import net.imglib2.util.StopWatch;
+import net.imglib2.util.ValuePair;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.intensityadjust.intensity.PointMatchFilter;
@@ -19,6 +21,7 @@ import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 /*
@@ -31,6 +34,8 @@ import java.util.List;
  * @author Michael Innerberger
  */
 class IntensityMatcher {
+	private static final int N_BINS = 256;
+
 	final private PointMatchFilter filter;
 	final private double sameLayerScale;
 	final private double crossLayerScale;
@@ -99,8 +104,13 @@ class IntensityMatcher {
 		/* filter matches */
 		final List<PointMatch> inliers = new ArrayList<>();
 		for (final List<PointMatch> candidates : matrix) {
+			if (candidates.isEmpty())
+				continue;
+
+			final List<PointMatch> compressedCandidates = compressByBinning(candidates, N_BINS);
+
 			inliers.clear();
-			filter.filter(candidates, inliers);
+			filter.filter(compressedCandidates, inliers);
 			candidates.clear();
 			candidates.addAll(inliers);
 		}
@@ -143,6 +153,35 @@ class IntensityMatcher {
 
 	private static int numberOfPixels(final int length, final double scale) {
 		return (int) Math.round(length * scale);
+	}
+
+	// Since there is a good chance that some intensity matches are redundant, we can try to compress them by binning
+	private static List<PointMatch> compressByBinning(final List<PointMatch> candidates, final int nBins) {
+		final Map<Pair<Integer, Integer>, Double> pairToWeights = new HashMap<>(nBins * nBins);
+		for (final PointMatch candidate : candidates) {
+			// Use the fact that the intensity matches are integers in the range [0, 255]
+			final int x = (int) Math.round(candidate.getP1().getL()[0] * nBins);
+			final int y = (int) Math.round(candidate.getP2().getL()[0] * nBins);
+			final Pair<Integer, Integer> pair = new ValuePair<>(x, y);
+			final double previousWeight = pairToWeights.getOrDefault(pair, 0.0);
+			pairToWeights.put(pair, previousWeight + candidate.getWeight());
+		}
+
+		if (pairToWeights.size() == candidates.size()) {
+			// Compression was not successful
+			return candidates;
+		}
+
+		final List<PointMatch> compressedCandidates = new ArrayList<>(pairToWeights.size());
+		for (final Map.Entry<Pair<Integer, Integer>, Double> entry : pairToWeights.entrySet()) {
+			final Pair<Integer, Integer> pair = entry.getKey();
+			final double weight = entry.getValue();
+			final Point p1 = new Point(new double[]{ (double) pair.getA() / nBins });
+			final Point p2 = new Point(new double[]{ (double) pair.getB() / nBins });
+			compressedCandidates.add(new PointMatch(p1, p2, weight));
+		}
+
+		return compressedCandidates;
 	}
 
 	List<Double> computeAverages(final TileSpec tile) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -2,7 +2,6 @@ package org.janelia.render.client.newsolver.solvers.intensity;
 
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
-import mpicbg.models.Affine1D;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import net.imglib2.util.Pair;
@@ -55,7 +54,7 @@ class IntensityMatcher {
 		this.imageProcessorCache = imageProcessorCache;
 	}
 
-	public void match(final TileSpec p1, final TileSpec p2, final HashMap<String, ArrayList<Tile<? extends Affine1D<?>>>> coefficientTiles) {
+	public void match(final TileSpec p1, final TileSpec p2, final HashMap<String, IntensityTile> intensityTiles) {
 
 		final StopWatch stopWatch = StopWatch.createAndStart();
 
@@ -115,22 +114,26 @@ class IntensityMatcher {
 		}
 
 		/* connect tiles across patches */
-		final List<Tile<? extends Affine1D<?>>> p1CoefficientTiles = coefficientTiles.get(p1.getTileId());
-		final List<Tile<? extends Affine1D<?>>> p2CoefficientTiles = coefficientTiles.get(p2.getTileId());
+		final IntensityTile p1IntensityTile = intensityTiles.get(p1.getTileId());
+		final IntensityTile p2IntensityTile = intensityTiles.get(p2.getTileId());
 		int connectionCount = 0;
 
 		for (int i = 0; i < nCoefficientTiles; ++i) {
-			final Tile<?> t1 = p1CoefficientTiles.get(i);
+			final Tile<?> t1 = p1IntensityTile.getSubTile(i);
 
 			for (int j = 0; j < nCoefficientTiles; ++j) {
 				final List<PointMatch> matches = get(matrix, i, j, nCoefficientTiles);
 				if (matches.isEmpty())
 					continue;
 
-				final Tile<?> t2 = p2CoefficientTiles.get(j);
+				final Tile<?> t2 = p2IntensityTile.getSubTile(j);
 				t1.connect(t2, matches);
 				connectionCount++;
 			}
+		}
+
+		if (connectionCount > 0) {
+			p1IntensityTile.connectTo(p2IntensityTile);
 		}
 
 		stopWatch.stop();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTile.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTile.java
@@ -68,6 +68,10 @@ class IntensityTile {
 		return this.subTiles.size();
 	}
 
+	public int nFittingCycles() {
+		return nFittingCycles;
+	}
+
 	public double getDistance() {
 		return distance;
 	}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTile.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTile.java
@@ -1,0 +1,126 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import mpicbg.models.Affine1D;
+import mpicbg.models.IllDefinedDataPointsException;
+import mpicbg.models.Model;
+import mpicbg.models.NotEnoughDataPointsException;
+import mpicbg.models.Tile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+
+/**
+ * A tile that contains a grid of sub-tiles, each of which has a model that can be fitted and applied. This acts as a
+ * convenience class for handling the fitting and applying of the models of the sub-tiles necessary for intensity
+ * correction. The encapsulated sub-tiles also potentially speed up the optimization process by reducing the overhead
+ * of parallelizing the optimization of the sub-tiles.
+ * <p>
+ * This class doesn't derive from {@link Tile} because most of the methods there are tagged final, so they cannot be
+ * overridden. This class should only be used in the context of intensity correction.
+ */
+class IntensityTile {
+
+	final private int nSubTilesPerDimension;
+	final private int nFittingCycles;
+	final private List<Tile<? extends Affine1D<?>>> subTiles;
+
+	private double distance = 0;
+	private final Set<IntensityTile> connectedTiles = new HashSet<>();
+
+	/**
+	 * Creates a new intensity tile with the specified number of sub-tiles per dimension and the number of fitting
+	 * cycles to perform within one fit of the intensity tile.
+	 * @param modelSupplier supplies instances of the model to use for the sub-tiles
+	 * @param nSubTilesPerDimension the number of sub-tiles per side of the tile
+	 * @param nFittingCycles the number of fitting cycles
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public IntensityTile(
+			final Supplier<? extends Affine1D<?>> modelSupplier,
+			final int nSubTilesPerDimension,
+			final int nFittingCycles
+	) {
+		this.nSubTilesPerDimension = nSubTilesPerDimension;
+		this.nFittingCycles = nFittingCycles;
+		final int N = nSubTilesPerDimension * nSubTilesPerDimension;
+		this.subTiles = new ArrayList<>(N);
+
+		for (int i = 0; i < N; i++) {
+			final Affine1D<?> model = modelSupplier.get();
+			this.subTiles.add(new Tile<>((Model) model));
+		}
+	}
+
+	public Tile<? extends Affine1D<?>> getSubTile(final int i) {
+		return this.subTiles.get(i);
+	}
+
+	public Tile<? extends Affine1D<?>> getSubTile(final int i, final int j) {
+		return this.subTiles.get(i * this.nSubTilesPerDimension + j);
+	}
+
+	public int nSubTiles() {
+		return this.subTiles.size();
+	}
+
+	public double getDistance() {
+		return distance;
+	}
+
+	/**
+	 * Updates the distance of this tile. The distance is the maximum distance of all sub-tiles.
+	 */
+	public void updateDistance() {
+		distance = 0;
+		for (final Tile<?> subTile : this.subTiles) {
+			subTile.updateCost();
+			distance = Math.max(distance, subTile.getDistance());
+		}
+	}
+
+	public Set<IntensityTile> getConnectedTiles() {
+		return connectedTiles;
+	}
+
+	/**
+	 * Connects this tile to another tile. In contrast to the connect method of the Tile class, this method also
+	 * connects the other tile to this tile.
+	 * @param otherTile the tile to connect to (bidirectional connection)
+	 */
+	public void connectTo(final IntensityTile otherTile) {
+		connectedTiles.add(otherTile);
+		otherTile.connectedTiles.add(this);
+	}
+
+	/**
+	 * Fits the model of all sub-tiles as often as specified by the nFittingCycles parameter. After fitting the model,
+	 * the model is immediately applied to the sub-tile.
+	 * @param damp the damping factor to apply to the model
+	 * @throws NotEnoughDataPointsException if there are not enough data points to fit the model
+	 * @throws IllDefinedDataPointsException if the data points are such that the model cannot be fitted
+	 */
+	public void fitAndApply(final double damp) throws NotEnoughDataPointsException, IllDefinedDataPointsException {
+		final List<Tile<? extends Affine1D<?>>> shuffledTiles = new ArrayList<>(this.subTiles);
+		for (int i = 0; i < nFittingCycles; i++) {
+			Collections.shuffle(shuffledTiles);
+			for (final Tile<? extends Affine1D<?>> subTile : shuffledTiles) {
+				subTile.fitModel();
+				subTile.apply(damp);
+			}
+		}
+	}
+
+	/**
+	 * Applies the model of all sub-tiles.
+	 */
+	public void apply() {
+		for (final Tile<? extends Affine1D<?>> subTile : this.subTiles) {
+			subTile.apply();
+		}
+	}
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTileOptimizer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTileOptimizer.java
@@ -55,9 +55,15 @@ class IntensityTileOptimizer {
 		this.nThreads = nThreads;
 	}
 
+	/**
+	 * Optimize the given tiles concurrently. Since an intensity tile is a collection of sub-tiles, "fixed" in this
+	 * context means that one of the sub-tiles is fixed, while the other sub-tiles are optimized.
+	 * @param tiles the intensity tiles to optimize
+	 * @param fixedTile the intensity tile where one sub-tile is fixed
+	 */
 	public void optimize(
 			final List<IntensityTile> tiles,
-			final List<IntensityTile> fixedTiles
+			final IntensityTile fixedTile
 		) {
 
 		final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads);
@@ -66,7 +72,7 @@ class IntensityTileOptimizer {
 			final ErrorStatistic observer = new ErrorStatistic(maxIterations + 1);
 
 			final List<IntensityTile> freeTiles = new ArrayList<>(tiles);
-			freeTiles.removeAll(fixedTiles);
+			freeTiles.remove(fixedTile);
 			Collections.shuffle(freeTiles);
 
 			final long t1 = System.currentTimeMillis();
@@ -87,6 +93,7 @@ class IntensityTileOptimizer {
 				final Deque<IntensityTile> pending = new ConcurrentLinkedDeque<>(freeTiles);
 				final List<Future<Void>> tasks = new ArrayList<>(nThreads);
 
+				// Fit and apply all free tiles concurrently
 				for (int j = 0; j < nThreads; j++) {
 					final boolean cleanUp = (j == 0);
 					tasks.add(executor.submit(() -> fitAndApplyWorker(pending, executingTiles, damp, cleanUp)));
@@ -97,6 +104,19 @@ class IntensityTileOptimizer {
 						task.get();
 					} catch (final InterruptedException | ExecutionException e) {
 						throw new RuntimeException(e);
+					}
+				}
+
+				// Fit and apply the fixed tile separately (don't fit the first sub-tile)
+				for (int j = 0; j < fixedTile.nFittingCycles(); j++) {
+					for (int k = 1; k < fixedTile.nSubTiles(); k++) {
+						final Tile<?> subTile = fixedTile.getSubTile(k);
+						try {
+							subTile.fitModel();
+							subTile.apply(damp);
+						} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
+							LOG.warn("Error while fitting and applying fixed tile: {}", e.getMessage());
+						}
 					}
 				}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTileOptimizer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityTileOptimizer.java
@@ -1,0 +1,224 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import mpicbg.models.ErrorStatistic;
+import mpicbg.models.IllDefinedDataPointsException;
+import mpicbg.models.NotEnoughDataPointsException;
+import mpicbg.models.Tile;
+import mpicbg.models.TileConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.DoubleSummaryStatistics;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+
+/**
+ * Concurrent optimizer for collections of {@link IntensityTile}s. This is basically a slightly modified implementation
+ * of {@link mpicbg.models.TileUtil#optimizeConcurrently(ErrorStatistic, double, int, int, double, TileConfiguration, Set, Set, int, boolean)},
+ * which is necessary because {@link IntensityTile} doesn't derive from {@link Tile}.
+ * Also, some methods of {@link mpicbg.models.TileConfiguration} are re-implemented here for the same reason.
+ * <p>
+ * Since an {@link IntensityTile} hides the sub-tiles it contains, this reduces the parallelization overhead of the
+ * optimizer, which would otherwise have to synchronize access to the (large number of) sub-tiles.
+ */
+class IntensityTileOptimizer {
+
+	private static final Logger LOG = LoggerFactory.getLogger(IntensityTileOptimizer.class);
+
+	private final double maxAllowedError;
+	private final int maxIterations;
+	private final int maxPlateauWidth;
+	private final double damp;
+	private final int nThreads;
+
+	public IntensityTileOptimizer(
+			final double maxAllowedError,
+			final int maxIterations,
+			final int maxPlateauWidth,
+			final double damp,
+			final int nThreads
+	) {
+		this.maxAllowedError = maxAllowedError;
+		this.maxIterations = maxIterations;
+		this.maxPlateauWidth = maxPlateauWidth;
+		this.damp = damp;
+		this.nThreads = nThreads;
+	}
+
+	public void optimize(
+			final List<IntensityTile> tiles,
+			final List<IntensityTile> fixedTiles
+		) {
+
+		final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads);
+		try {
+			final long t0 = System.currentTimeMillis();
+			final ErrorStatistic observer = new ErrorStatistic(maxIterations + 1);
+
+			final List<IntensityTile> freeTiles = new ArrayList<>(tiles);
+			freeTiles.removeAll(fixedTiles);
+			Collections.shuffle(freeTiles);
+
+			final long t1 = System.currentTimeMillis();
+			LOG.debug("Shuffling took {} ms", t1 - t0);
+
+			/* initialize the configuration with the current model of each tile */
+			applyAll(tiles, executor);
+
+			final long t2 = System.currentTimeMillis();
+			LOG.debug("First apply took {} ms", t2 - t1);
+
+			int i = 0;
+			boolean proceed = i < maxIterations;
+			final Set<IntensityTile> executingTiles = ConcurrentHashMap.newKeySet();
+
+			while (proceed) {
+				Collections.shuffle(freeTiles);
+				final Deque<IntensityTile> pending = new ConcurrentLinkedDeque<>(freeTiles);
+				final List<Future<Void>> tasks = new ArrayList<>(nThreads);
+
+				for (int j = 0; j < nThreads; j++) {
+					final boolean cleanUp = (j == 0);
+					tasks.add(executor.submit(() -> fitAndApplyWorker(pending, executingTiles, damp, cleanUp)));
+				}
+
+				for (final Future<Void> task : tasks) {
+					try {
+						task.get();
+					} catch (final InterruptedException | ExecutionException e) {
+						throw new RuntimeException(e);
+					}
+				}
+
+				final double error = computeErrors(tiles, executor);
+				observer.add(error);
+
+				LOG.debug("{}: {} {}", i, error, observer.max);
+
+				if (i > maxPlateauWidth) {
+					proceed = error > maxAllowedError;
+
+					int d = maxPlateauWidth;
+					while (!proceed && d >= 1) {
+						try {
+							proceed = Math.abs(observer.getWideSlope(d)) > 0.0001;
+						} catch (final Exception e) {
+							LOG.warn("Error while computing slope: {}", e.getMessage());
+						}
+						d /= 2;
+					}
+				}
+
+				proceed &= ++i < maxIterations;
+			}
+
+			final long t3 = System.currentTimeMillis();
+			LOG.info("Concurrent tile optimization loop took {} ms, total took {} ms", t3 - t2, t3 - t0);
+
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static void applyAll(final List<IntensityTile> tiles, final ThreadPoolExecutor executor) {
+		final int nTiles = tiles.size();
+		final int nThreads = executor.getMaximumPoolSize();
+		final int tilesPerThread = nTiles / nThreads + (nTiles % nThreads == 0 ? 0 : 1);
+		final List<Future<Void>> applyTasks = new ArrayList<>(nThreads);
+
+		for (int j = 0; j < nThreads; j++) {
+			final int start = j * tilesPerThread;
+			final int end = Math.min((j + 1) * tilesPerThread, nTiles);
+			applyTasks.add(executor.submit(() -> applyToRange(tiles, start, end)));
+		}
+
+		for (final Future<Void> task : applyTasks) {
+			try {
+				task.get();
+			} catch (final InterruptedException | ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	private static Void applyToRange(final List<IntensityTile> tiles, final int start, final int end) {
+		for (int i = start; i < end; i++) {
+			final IntensityTile t = tiles.get(i);
+			t.apply();
+		}
+		return null;
+	}
+
+	private static double computeErrors(final List<IntensityTile> tiles, final ThreadPoolExecutor executor) {
+		final int nTiles = tiles.size();
+		final int nThreads = executor.getMaximumPoolSize();
+		final int tilesPerThread = nTiles / nThreads + (nTiles % nThreads == 0 ? 0 : 1);
+		final List<Future<DoubleSummaryStatistics>> applyTasks = new ArrayList<>(nThreads);
+
+		for (int j = 0; j < nThreads; j++) {
+			final int start = j * tilesPerThread;
+			final int end = Math.min((j + 1) * tilesPerThread, nTiles);
+			applyTasks.add(executor.submit(() -> computeErrorsOfRange(tiles, start, end)));
+		}
+
+		final DoubleSummaryStatistics totalStats = new DoubleSummaryStatistics();
+		for (final Future<DoubleSummaryStatistics> task : applyTasks) {
+			try {
+				final DoubleSummaryStatistics taskStats = task.get();
+				totalStats.combine(taskStats);
+			} catch (final InterruptedException | ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		return totalStats.getAverage();
+	}
+
+	private static DoubleSummaryStatistics computeErrorsOfRange(final List<IntensityTile> tiles, final int start, final int end) {
+		final DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+		for (int i = start; i < end; i++) {
+			final IntensityTile t = tiles.get(i);
+			t.updateDistance();
+			stats.accept(t.getDistance());
+		}
+		return stats;
+	}
+
+	private static Void fitAndApplyWorker(
+			final Deque<IntensityTile> pendingTiles,
+			final Set<IntensityTile> executingTiles,
+			final double damp,
+			final boolean cleanUp
+	) throws NotEnoughDataPointsException, IllDefinedDataPointsException {
+
+		final int n = pendingTiles.size();
+		for (int i = 0; (i < n) || cleanUp; i++){
+			// the polled tile can only be null if the deque is empty, i.e., there is no more work
+			final IntensityTile tile = pendingTiles.pollFirst();
+			if (tile == null)
+				return null;
+
+			executingTiles.add(tile);
+			final boolean canBeProcessed = Collections.disjoint(tile.getConnectedTiles(), executingTiles);
+
+			if (canBeProcessed) {
+				tile.fitAndApply(damp);
+				executingTiles.remove(tile);
+			} else {
+				executingTiles.remove(tile);
+				pendingTiles.addLast(tile);
+			}
+		}
+		return null;
+	}
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/Point1D.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/Point1D.java
@@ -1,0 +1,24 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import mpicbg.models.CoordinateTransform;
+import mpicbg.models.Point;
+
+/**
+ * A 1D point. This is used in the intensity matching algorithm and adds an optimized method for applying a
+ * transformation a 1D point. The method doesn't overwrite {@link Point#apply(CoordinateTransform)} since this method
+ * is marked as final in the superclass.
+ */
+public class Point1D extends Point {
+	public Point1D(final double l, final double w) {
+		super(new double[] { l }, new double[] { w });
+	}
+
+	public Point1D(final double l) {
+		this(l, l);
+	}
+
+	public void applyFast(final CoordinateTransform t) {
+		w[0] = l[0];
+		t.applyInPlace(w);
+	}
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/PointMatch1D.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/PointMatch1D.java
@@ -26,6 +26,6 @@ public class PointMatch1D extends PointMatch {
 	public double getDistance(){
 		final Point1D p1 = (Point1D) this.p1;
 		final Point1D p2 = (Point1D) this.p2;
-		return Math.abs(p1.getL()[0] - p2.getL()[0]);
+		return Math.abs(p1.getW()[0] - p2.getW()[0]);
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/PointMatch1D.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/PointMatch1D.java
@@ -1,0 +1,31 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import mpicbg.models.CoordinateTransform;
+import mpicbg.models.PointMatch;
+
+/**
+ * A match of two 1D points. This is used in the intensity matching algorithm and adds an optimized method for computing
+ * the distance of two 1D points.
+ */
+public class PointMatch1D extends PointMatch {
+	public PointMatch1D(final Point1D p1, final Point1D p2) {
+		super(p1, p2);
+	}
+
+	public PointMatch1D(final Point1D p1, final Point1D p2, final double weight) {
+		super(p1, p2, weight);
+	}
+
+	@Override
+	public void apply(final CoordinateTransform t) {
+		final Point1D p1 = (Point1D) this.p1;
+		p1.applyFast(t);
+	}
+
+	@Override
+	public double getDistance(){
+		final Point1D p1 = (Point1D) this.p1;
+		final Point1D p2 = (Point1D) this.p2;
+		return Math.abs(p1.getL()[0] - p2.getL()[0]);
+	}
+}


### PR DESCRIPTION
I played around with the intensity match derivation process and introduced two optimizations:
1. I introduced a binning strategy for the matching process. After matches are found on sub-tiles by rendering, transforming, and partitioning images tiles, I bin the matches into `nBins x nBins` bins (where I tentatively set `nBins = 256`). All matches in one bin result in a single match with a weight that equals the sum of all original matches in that bin. I am aware that this introduces a discretization error, but since the number of bins is sufficiently large, the effect should be small. Reducing the number of bins further improves the runtime, trading off accuracy.
2. I specialized `Point` and `PointMatch` for 1D points. Since there are a lot of static and final methods in the original `Point` class, there's only so much that one can specialize, but all methods that are called in the intensity matching process make full use of the optimizations.

I tested the impact of these changes on a randomly chosen neighboring pair of images from some fibsem stack, using the parameters that were specified in the alignment-prep files for that project.

For this tile pair, the matching process (including RANSAC filtering) took 2.36s with a single core on my local machine. Of this, the rendering accounted for 0.95s, while the RANSAC filtering took 1.38s. The optimizations described above resulted in the following runtime improvements for the RANSAC filtering:
```
base :  1.38s
1.   :  0.98s  (~30% improvement)
1.+2.:  0.18s  (~85% improvement)
```

My chosen example might not be a representative test case. Maybe @trautmane can help me set up a test case for multi-sem so that we can make sure the changes didn't introduce bugs and see how much we gain in this case. @StephanPreibisch 