### PR TITLE
newsolver_patch_all_unconnected_with_stage

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVMontageMatchPatchClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVMontageMatchPatchClient.java
@@ -174,17 +174,10 @@ public class MFOVMontageMatchPatchClient {
 
         final int totalNumberOfPositions = positionToPairs.size();
         final Set<MFOVPositionPair> positionsWithoutAnyUnconnectedPairs = new HashSet<>();
-        final Set<String> connectedTileIds = new HashSet<>();
         for (final MFOVPositionPair positionPair : positionToPairs.keySet()) {
             final MFOVPositionPairMatchData positionPairMatchData = positionToPairs.get(positionPair);
             if (! positionPairMatchData.hasUnconnectedPairs()) {
                 positionsWithoutAnyUnconnectedPairs.add(positionPair);
-            }
-            if (patch.onlyPatchCompletelyUnconnectedTiles) {
-                for (final OrderedCanvasIdPair connectedPair : positionPairMatchData.getConnectedPairsForPosition()) {
-                    connectedTileIds.add(connectedPair.getP().getId());
-                    connectedTileIds.add(connectedPair.getQ().getId());
-                }
             }
         }
         for (final MFOVPositionPair positionPair : positionsWithoutAnyUnconnectedPairs) {
@@ -194,7 +187,7 @@ public class MFOVMontageMatchPatchClient {
         LOG.info("deriveAndSaveMatchesForUnconnectedPairsInStack: {} out of {} positions in {} have at least one unconnected pair",
                  positionToPairs.size(), totalNumberOfPositions, stackMFOVWithZValues);
 
-        List<CanvasMatches> derivedMatchesForMFOV = new ArrayList<>();
+        final List<CanvasMatches> derivedMatchesForMFOV = new ArrayList<>();
 
         final List<MFOVPositionPair> sortedPositions =
                 positionToPairs.keySet().stream().sorted().collect(Collectors.toList());
@@ -205,46 +198,6 @@ public class MFOVMontageMatchPatchClient {
                                                                            patch.sameLayerDerivedMatchWeight,
                                                                            patch.crossLayerDerivedMatchWeight,
                                                                            patch.startPositionMatchWeight));
-        }
-
-        if (patch.onlyPatchCompletelyUnconnectedTiles && (! derivedMatchesForMFOV.isEmpty())) {
-
-            final List<String> distinctSortedSectionIds = renderDataClient.getDistinctSortedSectionIds(stack);
-            final List<CanvasMatches> completelyUnconnectedTileMatchesList = new ArrayList<>();
-
-            // Build connected tile set by retrieving match pairs incrementally for each section
-            // to reduce amount of data retrieved from web service in one call.
-            // We need to retrieve all match pairs to ensure that connections
-            // to all tiles outside the MFOV and to all tiles outside the z layer are included.
-            final int originalConnectedTileCount = connectedTileIds.size();
-            for (final String groupId : distinctSortedSectionIds) {
-                for (final CanvasMatches pair : matchClient.getMatchesWithinGroup(groupId, true)) {
-                    connectedTileIds.add(pair.getpId());
-                    connectedTileIds.add(pair.getqId());
-                }
-                for (final CanvasMatches pair : matchClient.getMatchesOutsideGroup(groupId, true)) {
-                    connectedTileIds.add(pair.getpId());
-                    connectedTileIds.add(pair.getqId());
-                }
-            }
-
-            final int additionalConnectedTileCount = connectedTileIds.size() - originalConnectedTileCount;
-            LOG.info("deriveAndSaveMatchesForUnconnectedPairsInStack: added {} more connectedTileIds in {}",
-                     additionalConnectedTileCount, stackMFOVWithZValues);
-
-            for (final CanvasMatches derivedMatches : derivedMatchesForMFOV) {
-                if ((! connectedTileIds.contains(derivedMatches.getpId())) ||
-                    (! connectedTileIds.contains(derivedMatches.getqId()))) {
-                    completelyUnconnectedTileMatchesList.add(derivedMatches);
-                }
-            }
-
-            final int removedCount = derivedMatchesForMFOV.size() - completelyUnconnectedTileMatchesList.size();
-
-            LOG.info("deriveAndSaveMatchesForUnconnectedPairsInStack: removed {} match pairs for partially connected tiles in {}",
-                     removedCount, stackMFOVWithZValues);
-
-            derivedMatchesForMFOV = completelyUnconnectedTileMatchesList;
         }
 
         final int numberOfDerivedMatchPairs = derivedMatchesForMFOV.size();
@@ -401,19 +354,23 @@ public class MFOVMontageMatchPatchClient {
             final MFOVPositionPairMatchData positionPairMatchData = positionToPairs.get(positionPair);
             positionPairMatchData.addUnconnectedPair(unconnectedPair);
 
-            // add same layer pair from another MFOV if any exists
-            final CanvasId p = unconnectedPair.getP();
-            final String indexPairName = MultiSemUtilities.getSFOVIndexPairName(p.getGroupId(),
-                                                                                p.getId(),
-                                                                                unconnectedPair.getQ().getId());
-            final OrderedCanvasIdPair sameLayerPair = sameLayerPairsFromOtherMFOVs.get(indexPairName);
-            if (sameLayerPair == null) {
-                LOG.info("updatePositionPairDataForZ: no same layer pair found for unconnected pair {}",
-                         unconnectedPair);
-            } else {
-                LOG.info("updatePositionPairDataForZ: using same layer pair {} for unconnected pair {}",
-                         sameLayerPair, unconnectedPair);
-                positionPairMatchData.addSameLayerPair(sameLayerPair);
+            // try to add same layer pair data from another MFOV, unless we are patching with stage coordinates
+            if (! patch.patchAllUnconnectedPairsWithStageCoordinates) {
+
+                final CanvasId p = unconnectedPair.getP();
+                final String indexPairName = MultiSemUtilities.getSFOVIndexPairName(p.getGroupId(),
+                                                                                    p.getId(),
+                                                                                    unconnectedPair.getQ().getId());
+                final OrderedCanvasIdPair sameLayerPair = sameLayerPairsFromOtherMFOVs.get(indexPairName);
+                if (sameLayerPair == null) {
+                    LOG.info("updatePositionPairDataForZ: no same layer pair found for unconnected pair {}",
+                             unconnectedPair);
+                } else {
+                    LOG.info("updatePositionPairDataForZ: using same layer pair {} for unconnected pair {}",
+                             sameLayerPair, unconnectedPair);
+                    positionPairMatchData.addSameLayerPair(sameLayerPair);
+                }
+
             }
         }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/UnconnectedCrossMFOVClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/UnconnectedCrossMFOVClient.java
@@ -183,7 +183,7 @@ public class UnconnectedCrossMFOVClient {
         final String pGroupId = String.valueOf(pZ);
         final String qGroupId = String.valueOf(qZ);
 
-        final List<String> mFOVNames = MultiProjectParameters.getMFOVNames(renderDataClient, stack, pZ);
+        final List<String> mFOVNames = MultiProjectParameters.getSortedMFOVNamesForOneLayer(renderDataClient, stack, pZ);
 
         final Map<String, Integer> mFOVToSFOVPairCount = new HashMap<>();
         mFOVNames.forEach(name -> mFOVToSFOVPairCount.put(name, 0));

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVMontageMatchPatchParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVMontageMatchPatchParameters.java
@@ -101,10 +101,12 @@ public class MFOVMontageMatchPatchParameters
     public boolean trimMfovsWithNoConnectedTiles = false;
 
     @Parameter(
-            names = "--onlyPatchCompletelyUnconnectedTiles",
-            description = "If specified, limit patching to tiles that are completely unconnected.",
+            names = "--patchAllUnconnectedPairsWithStageCoordinates",
+            description = "If specified, patch all remaining unconnected pairs with positions based upon SFOV stage locations.  " +
+                          "Omit sameLayerDerivedMatchWeight, crossLayerDerivedMatchWeight, and secondPassDerivedMatchWeight " +
+                          "parameters if you want to patch everything with these stage locations.",
             arity = 0)
-    public boolean onlyPatchCompletelyUnconnectedTiles = false;
+    public boolean patchAllUnconnectedPairsWithStageCoordinates = false;
 
     public MFOVMontageMatchPatchParameters() {
     }
@@ -130,7 +132,7 @@ public class MFOVMontageMatchPatchParameters
         clonedParameters.qTileId = this.qTileId;
         clonedParameters.matchStorageFile = this.matchStorageFile;
         clonedParameters.trimMfovsWithNoConnectedTiles = this.trimMfovsWithNoConnectedTiles;
-        clonedParameters.onlyPatchCompletelyUnconnectedTiles = this.onlyPatchCompletelyUnconnectedTiles;
+        clonedParameters.patchAllUnconnectedPairsWithStageCoordinates = this.patchAllUnconnectedPairsWithStageCoordinates;
         clonedParameters.validateAndSetupDerivedValues(); // make sure values derived from multiFieldOfViewId are rebuilt
         return clonedParameters;
     }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MultiProjectParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MultiProjectParameters.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.janelia.alignment.json.JsonUtils;
@@ -118,9 +120,9 @@ public class MultiProjectParameters
             final StackId stackId = stackWithZValues.getStackId();
             final RenderDataClient dataClient = defaultRenderClient.buildClient(stackId.getOwner(),
                                                                                 stackId.getProject());
-            final List<String> mFOVIdList = getMFOVNames(dataClient,
-                                                         stackId.getStack(),
-                                                         stackWithZValues.getFirstZ());
+            final List<String> mFOVIdList = getSortedMFOVNamesForZValues(dataClient,
+                                                                         stackId.getStack(),
+                                                                         stackWithZValues.getzValues());
 
             LOG.info("buildListOfStackMFOVWithAllZ: found {} MFOVs in {}", mFOVIdList.size(), stackWithZValues);
 
@@ -159,11 +161,25 @@ public class MultiProjectParameters
             new JsonUtils.Helper<>(MultiProjectParameters.class);
 
     /**
+     * @return list of distinct sorted MFOV names for the specified list of stack z-layer values.
+     */
+    public static List<String> getSortedMFOVNamesForZValues(final RenderDataClient renderDataClient,
+                                                            final String stack,
+                                                            final List<Double> zValues)
+            throws IOException {
+        final Set<String> mFOVNames = new HashSet<>();
+        for (final Double z : zValues) {
+            mFOVNames.addAll(getSortedMFOVNamesForOneLayer(renderDataClient, stack, z));
+        }
+        return mFOVNames.stream().sorted().collect(Collectors.toList());
+    }
+
+    /**
      * @return list of distinct sorted MFOV names for the specified stack z-layer.
      */
-    public static List<String> getMFOVNames(final RenderDataClient renderDataClient,
-                                            final String stack,
-                                            final Double z)
+    public static List<String> getSortedMFOVNamesForOneLayer(final RenderDataClient renderDataClient,
+                                                             final String stack,
+                                                             final Double z)
             throws IOException {
         return renderDataClient.getTileBounds(stack, z)
                 .stream()

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/ClusterCountClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/ClusterCountClientTest.java
@@ -18,16 +18,16 @@ public class ClusterCountClientTest {
     public static void main(final String[] args) {
 
         final String[] effectiveArgs = (args != null) && (args.length > 0) ? args : new String[]{
-                "--baseDataUrl", "http://renderer-dev:8080/render-ws/v1",
+                "--baseDataUrl", "http://em-services-1:8080/render-ws/v1",
                 "--owner", "hess_wafers_60_61",
                 "--project", "w60_serial_360_to_369",
-                "--stack", "w60_s360_r00_d20_gc_trim_b",
+                "--stack", "w60_s360_r00_d20_gc",
 //                "--stack", "w60_s360_r00_d20xr",
                 "--matchCollection", "w60_s360_r00_d20_gc_match",
                 "--maxSmallClusterSize", "0",
                 "--includeMatchesOutsideGroup",
                 "--maxLayersPerBatch", "1000",
-                "--maxOverlapLayers", "6"
+                "--maxOverlapLayers", "6",
 //                "--maxSmallClusterSizeToSave", "100"
         };
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVMontageMatchPatchClient.java
@@ -132,7 +132,7 @@ public class MFOVMontageMatchPatchClient
                                    final int passNumber)
             throws IOException {
 
-        final String passName = "pass" + passNumber;
+        final String passName = "pass" + passNumber + " for MFOV " + patchParameters.getMultiFieldOfViewId();
 
         LOG.info("patchPairsForPass: entry, {}", passName);
 


### PR DESCRIPTION
For the MFOV montage patch process, replace onlyPatchCompletelyUnconnectedTiles option with patchAllUnconnectedPairsWithStageCoordinates option.