### PR TITLE
Multi-sem inpainting for wafer 60/61

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/inpainting/InterpolatingZInpainter.java
+++ b/render-app/src/main/java/org/janelia/alignment/inpainting/InterpolatingZInpainter.java
@@ -100,7 +100,7 @@ public class InterpolatingZInpainter {
 		final List<Interval> nonEmptyMaskBlocks = new ArrayList<>();
 		for (final Grid.Block block : maskBlocks) {
 			final IntervalView<FloatType> pixels = Views.interval(mask, block);
-			for (final FloatType pixel : Views.iterable(pixels)) {
+			for (final FloatType pixel : pixels) {
 				if (pixel.get() > 0) {
 					nonEmptyMaskBlocks.add(block);
 					break;

--- a/render-app/src/main/java/org/janelia/alignment/inpainting/RayCastingInpainter.java
+++ b/render-app/src/main/java/org/janelia/alignment/inpainting/RayCastingInpainter.java
@@ -50,7 +50,7 @@ public class RayCastingInpainter {
 	 * @param mask the mask
 	 */
 	public void inpaint(final RandomAccessibleInterval<FloatType> img, final RandomAccessibleInterval<FloatType> mask) {
-		final Cursor<FloatType> imgCursor = Views.iterable(img).localizingCursor();
+		final Cursor<FloatType> imgCursor = img.localizingCursor();
 
 		final RealRandomAccess<FloatType> imageAccess = Views.interpolate(Views.extendBorder(img), new NLinearInterpolatorFactory<>()).realRandomAccess();
 		final RealRandomAccess<FloatType> maskAccess = Views.interpolate(Views.extendBorder(mask), new NLinearInterpolatorFactory<>()).realRandomAccess();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -3,6 +3,7 @@ package org.janelia.render.client.spark.multisem;
 
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
+import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -98,31 +99,27 @@ public class Wafer6061Inpainter {
 		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.getDimensions(), tissueAttributes.getBlockSize());
 		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.getDimensions(), maskAttributes.getBlockSize());
 
-		// Filter empty blocks in the mask
+		// Filter all blocks that either have no mask, or are completely covered by the mask
 		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
 		final Img<UnsignedByteType> mask = N5Utils.open(n5, maskDataset);
-		final List<Interval> nonEmptyMaskBlocks = new ArrayList<>();
+		final List<Interval> nonHomogeneousMaskBlocks = new ArrayList<>();
 		for (final Grid.Block block : maskBlocks) {
-			final IntervalView<UnsignedByteType> pixels = Views.interval(mask, block);
-			for (final UnsignedByteType pixel : pixels) {
-				final float value = pixel.get();
-				if (value > 0 && value < 255) {
-					nonEmptyMaskBlocks.add(block);
-					break;
-				}
+			final IntervalView<UnsignedByteType> maskPixels = Views.interval(mask, block);
+			if (! isHomogeneous(maskPixels)) {
+				nonHomogeneousMaskBlocks.add(block);
 			}
 		}
-		LOG.info("Found {} non-empty mask blocks", nonEmptyMaskBlocks.size());
+		LOG.info("Found {} non-homogeneous mask blocks", nonHomogeneousMaskBlocks.size());
 
-		// See which tissue blocks are covered by the mask
-		final List<Interval> translatedNonEmptyMaskBlocks = nonEmptyMaskBlocks.stream()
+		// Check which tissue blocks are covered by the mask
+		final List<Interval> translatedNonHomogeneousMaskBlocks = nonHomogeneousMaskBlocks.stream()
 				.map(b -> Intervals.translate(b, maskMin))
 				.collect(Collectors.toList());
 		final List<Grid.Block> tissueBlocksToInpaint = new ArrayList<>();
 
 		for (final Grid.Block block : tissueBlocks) {
 			final Interval blockInterval = Intervals.translate(block, tissueMin);
-			for (final Interval maskBlock : translatedNonEmptyMaskBlocks) {
+			for (final Interval maskBlock : translatedNonHomogeneousMaskBlocks) {
 				final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(blockInterval, maskBlock));
 				if (!intervalsAreDisjoint) {
 					tissueBlocksToInpaint.add(block);
@@ -133,6 +130,16 @@ public class Wafer6061Inpainter {
 		LOG.info("Found {} tissue blocks to inpaint", tissueBlocksToInpaint.size());
 
 		return tissueBlocksToInpaint;
+	}
+
+	private static boolean isHomogeneous(final IterableInterval<UnsignedByteType> pixels) {
+		final UnsignedByteType firstPixel = pixels.firstElement();
+		for (final UnsignedByteType pixel : pixels) {
+			if (pixel.equals(firstPixel)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private void inpaintBlocks(final List<Grid.Block> blocksToInpaint) {
@@ -176,7 +183,7 @@ public class Wafer6061Inpainter {
 		final String dataset = "tissue";
 		final String maskDataset = "mask";
 		final String outputDataset = "inpainted";
-		final int stepSize = 10;
+		final int stepSize = 20;
 
 		final Wafer6061Inpainter inpainter = new Wafer6061Inpainter(n5Path, dataset, maskDataset, outputDataset, stepSize);
 		inpainter.inpaint();
@@ -227,7 +234,7 @@ public class Wafer6061Inpainter {
 				tissueAccess.move(2, 2);
 				final int below = tissueAccess.get().get();
 
-				return UnsignedByteType.getCodedSignedByteChecked((above + below) >>> 2);
+				return UnsignedByteType.getCodedSignedByteChecked((above + below) >>> 1);
 			} else if (hasContentAbove) {
 				tissueAccess.move(-1, 2);
 				return tissueAccess.get().get();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -12,8 +12,11 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.util.Intervals;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
 import org.janelia.alignment.util.Grid;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.parameter.CommandLineParameters;
@@ -24,10 +27,12 @@ import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+import scala.xml.PrettyPrinter;
 
-import java.util.ArrayList;
+import java.io.Serializable;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 
 /**
@@ -85,11 +90,8 @@ public class Wafer6061Inpainter {
 
 	private final Parameters param;
 
-	private N5Reader n5;
-	private DatasetAttributes tissueAttributes;
-	private DatasetAttributes maskAttributes;
-	private long[] tissueMin;
-	private long[] maskMin;
+	private ExtendedAttributes tissueAttributes;
+	private ExtendedAttributes maskAttributes;
 
 
 	public Wafer6061Inpainter(final Parameters parameters) {
@@ -103,67 +105,113 @@ public class Wafer6061Inpainter {
 
 		// Read and cache some metadata of the tissue and mask datasets
 		// Assume that the tissue is a multiscale pyramid / mask is a standalone dataset
-		n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path);
-		tissueAttributes = n5.getDatasetAttributes(param.fullDataset());
-		maskAttributes = n5.getDatasetAttributes(param.mask);
-		tissueMin = n5.getAttribute(param.dataset, "translate", long[].class);
-		maskMin = n5.getAttribute(param.mask, "translate", long[].class);
+		try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path)) {
+			LOG.info("Reading metadata from {}", param.n5Path);
+			tissueAttributes = ExtendedAttributes.read(n5, param.fullDataset(), param.dataset);
+			maskAttributes = ExtendedAttributes.read(n5, param.mask, param.mask);
 
-		if (param.output == null) {
-			param.output = param.fullDataset();
-			LOG.info("Output dataset equals input dataset. Overwriting blocks in the input dataset '{}'", param.output);
-		} else if (n5.exists(param.output)) {
-			throw new IllegalArgumentException("Dataset '" + param.output + "' is different from the input dataset and already exists. Stopping.");
-		} else {
-			LOG.info("Output dataset is '{}'. Creating new dataset.", param.output);
-			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
-				n5Writer.createDataset(param.output, tissueAttributes);
-			}
-		}
-
-		final List<Grid.Block> blocksToInpaint = getBlocksToInpaint();
-		inpaintBlocks(blocksToInpaint);
-
-		n5.close();
-	}
-
-	private List<Grid.Block> getBlocksToInpaint() {
-		LOG.info("Reading metadata from {}", param.n5Path);
-
-		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.getDimensions(), tissueAttributes.getBlockSize());
-		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.getDimensions(), maskAttributes.getBlockSize());
-
-		// Filter all blocks that either have no mask, or are completely covered by the mask
-		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
-		final Img<UnsignedByteType> mask = N5Utils.open(n5, param.mask);
-		final List<Interval> nonHomogeneousMaskBlocks = new ArrayList<>();
-		for (final Grid.Block block : maskBlocks) {
-			final IntervalView<UnsignedByteType> maskPixels = Views.interval(mask, block);
-			if (! isHomogeneous(maskPixels)) {
-				nonHomogeneousMaskBlocks.add(block);
-			}
-		}
-		LOG.info("Found {} non-homogeneous mask blocks", nonHomogeneousMaskBlocks.size());
-
-		// Check which tissue blocks are covered by the mask
-		final List<Interval> translatedNonHomogeneousMaskBlocks = nonHomogeneousMaskBlocks.stream()
-				.map(b -> Intervals.translate(b, maskMin))
-				.collect(Collectors.toList());
-		final List<Grid.Block> tissueBlocksToInpaint = new ArrayList<>();
-
-		for (final Grid.Block block : tissueBlocks) {
-			final Interval blockInterval = Intervals.translate(block, tissueMin);
-			for (final Interval maskBlock : translatedNonHomogeneousMaskBlocks) {
-				final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(blockInterval, maskBlock));
-				if (!intervalsAreDisjoint) {
-					tissueBlocksToInpaint.add(block);
-					break;
+			if (param.output == null) {
+				param.output = param.fullDataset();
+				LOG.info("Output dataset equals input dataset. Overwriting blocks in the input dataset '{}'", param.output);
+			} else if (n5.exists(param.output)) {
+				throw new IllegalArgumentException("Dataset '" + param.output + "' is different from the input dataset and already exists. Stopping.");
+			} else {
+				LOG.info("Output dataset is '{}'. Creating new dataset.", param.output);
+				try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
+					n5Writer.createDataset(param.output, tissueAttributes.attrs);
 				}
 			}
 		}
+
+		final SparkConf conf = new SparkConf().setAppName("Wafer6061Inpainter");
+		try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+			runWithSparkContext(sparkContext);
+		}
+	}
+
+	private void runWithSparkContext(final JavaSparkContext sparkContext) {
+		// Find out which blocks need inpainting
+		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.attrs.getDimensions(), maskAttributes.attrs.getBlockSize());
+		final JavaRDD<Grid.Block> maskRDD = sparkContext.parallelize(maskBlocks);
+		final Broadcast<ExtendedAttributes> maskAttributesBroadcast = sparkContext.broadcast(maskAttributes);
+		final Broadcast<Parameters> paramBroadcast = sparkContext.broadcast(param);
+		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
+
+		// Filter all blocks that either have no mask, or are completely covered by the mask
+		final List<Grid.Block> nonHomogeneousMaskBlocks = maskRDD.mapToPair(
+						block -> {
+					final Interval blockInterval = Intervals.translate(block, maskAttributesBroadcast.value().min);
+					final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
+					final boolean isHomogeneous;
+					try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
+						final Img<UnsignedByteType> mask1 = N5Utils.open(n5, paramBroadcast.value().mask);
+						final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask1, translatedBlock);
+						isHomogeneous = isHomogeneous(maskPixels);
+					}
+					return new Tuple2<>(translatedBlock, isHomogeneous);
+				})
+				.filter(tuple -> !tuple._2)
+				.map(Tuple2::_1)
+				.collect();
+		LOG.info("Found {} non-homogeneous mask blocks", nonHomogeneousMaskBlocks.size());
+
+		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.attrs.getDimensions(), tissueAttributes.attrs.getBlockSize());
+		final JavaRDD<Grid.Block> tissueBlocksRDD = sparkContext.parallelize(tissueBlocks);
+		final Broadcast<ExtendedAttributes> tissueAttributesBroadcast = sparkContext.broadcast(tissueAttributes);
+		final Broadcast<List<Grid.Block>> maskBlocksBroadcast = sparkContext.broadcast(nonHomogeneousMaskBlocks);
+
+		// Check which tissue blocks are covered by the interesting mask blocks determined above
+		final List<Grid.Block> tissueBlocksToInpaint = tissueBlocksRDD.map(
+						block -> {
+					final Interval blockInterval = Intervals.translate(block, tissueAttributesBroadcast.value().min);
+					final List<Grid.Block> interestingMaskBlocks = maskBlocksBroadcast.getValue();
+					for (final Interval maskBlock : interestingMaskBlocks) {
+						final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(blockInterval, maskBlock));
+						if (!intervalsAreDisjoint) {
+							return block;
+						}
+					}
+					return null;
+				})
+				.filter(Objects::nonNull)
+				.collect();
 		LOG.info("Found {} tissue blocks to inpaint", tissueBlocksToInpaint.size());
 
-		return tissueBlocksToInpaint;
+		final JavaRDD<Grid.Block> inpaintingBlocksRDD = sparkContext.parallelize(tissueBlocksToInpaint);
+		inpaintingBlocksRDD.foreach(block -> {
+			final long[] tissueMin = tissueAttributesBroadcast.value().min;
+			final long[] maskMin = maskAttributesBroadcast.value().min;
+			final Interval blockInterval = Intervals.translate(block, tissueMin);
+			final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(blockInterval.dimensionsAsLongArray());
+
+			try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
+				final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, paramBroadcast.value().fullDataset());
+				final Img<UnsignedByteType> rawMask = N5Utils.open(n5, paramBroadcast.value().mask);
+
+				final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
+				final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
+				LOG.info("Inpainting block {} at {}", block.gridPosition, blockInterval.minAsLongArray());
+
+
+				final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, blockInterval.minAsLongArray()).localizingCursor();
+				final long[] location = new long[3];
+				final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, blockInterval),
+																 Views.interval(mask, blockInterval),
+																 paramBroadcast.value().stepSize);
+
+				while (targetCursor.hasNext()) {
+					final UnsignedByteType targetPixel = targetCursor.next();
+					targetCursor.localize(location);
+					final int value = interpolator.getPixel(location);
+					targetPixel.set(value);
+				}
+			}
+
+			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
+				final DatasetAttributes targetAttributes = tissueAttributesBroadcast.value().attrs;
+				N5Utils.saveBlock(inpaintedBlock, n5Writer, paramBroadcast.value().output, targetAttributes, block.gridPosition);
+			}
+		});
 	}
 
 	private static boolean isHomogeneous(final IterableInterval<UnsignedByteType> pixels) {
@@ -175,39 +223,6 @@ public class Wafer6061Inpainter {
 		}
 		return true;
 	}
-
-	private void inpaintBlocks(final List<Grid.Block> blocksToInpaint) {
-		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.fullDataset());
-		final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
-
-		final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
-		final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
-
-		for (final Grid.Block block : blocksToInpaint) {
-			final Interval blockInterval = Intervals.translate(block, tissueMin);
-			LOG.info("Inpainting block {} at {}", block.gridPosition, blockInterval.minAsLongArray());
-
-			final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(blockInterval.dimensionsAsLongArray());
-
-			final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, blockInterval.minAsLongArray()).localizingCursor();
-			final long[] location = new long[3];
-			final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, blockInterval),
-															 Views.interval(mask, blockInterval),
-															 param.stepSize);
-
-			while (targetCursor.hasNext()) {
-				final UnsignedByteType targetPixel = targetCursor.next();
-				targetCursor.localize(location);
-				final int value = interpolator.getPixel(location);
-				targetPixel.set(value);
-			}
-
-			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
-				N5Utils.saveBlock(inpaintedBlock, n5Writer, param.output, tissueAttributes, block.gridPosition);
-			}
-		}
-	}
-
 
 	public static void main(final String[] args) {
 		final String[] testArgs = {
@@ -317,5 +332,21 @@ public class Wafer6061Inpainter {
 			return hasContentRight && hasContentLeft;
 		}
 
+	}
+
+	private static class ExtendedAttributes implements Serializable {
+		public final DatasetAttributes attrs;
+		public final long[] min;
+
+		public ExtendedAttributes(final DatasetAttributes attrs, final long[] min) {
+			this.attrs = attrs;
+			this.min = min;
+		}
+
+		public static ExtendedAttributes read(final N5Reader n5, final String attrsPath, final String minPath) {
+			final DatasetAttributes attrs = n5.getDatasetAttributes(attrsPath);
+			final long[] min = n5.getAttribute(minPath, "translate", long[].class);
+			return new ExtendedAttributes(attrs, min);
+		}
 	}
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -27,6 +27,7 @@ import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.annotation.meta.param;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -164,8 +165,11 @@ public class Wafer6061Inpainter {
 		// Inpaint the blocks
 		final JavaRDD<Grid.Block> inpaintingBlocksRDD = sparkContext.parallelize(tissueBlocksToInpaint);
 
-		inpaintingBlocksRDD.foreach(block -> {
-		});
+		inpaintingBlocksRDD.foreach(block -> inpaintBlock(block,
+														  maskAttributesBroadcast.value().min,
+														  tissueAttributesBroadcast.value().min,
+														  paramBroadcast.value(),
+														  tissueAttributesBroadcast.value().attrs));
 	}
 
 	private static Grid.Block translateAndCheckHomogeneity(
@@ -186,16 +190,17 @@ public class Wafer6061Inpainter {
 			final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask, translatedBlock);
 
 			final UnsignedByteType firstPixel = maskPixels.firstElement();
-			for (final UnsignedByteType pixel : maskPixels) {
-				if (! pixel.equals(firstPixel)) {
-					isHomogeneous = false;
-					break;
-				}
-			}
+//			for (final UnsignedByteType pixel : maskPixels) {
+//				if (! pixel.equals(firstPixel)) {
+//					isHomogeneous = false;
+//					break;
+//				}
+//			}
+			isHomogeneous = false;
 		}
 
 		final String blockType = isHomogeneous ? "homogeneous -> skip" : "non-homogeneous -> possibly inpaint";
-		LOG.info("Mask block {} at {} is {}", block.gridPosition, blockInterval.minAsLongArray(), blockType);
+		LOG.info("Mask block {} at {} is {}", translatedBlock.gridPosition, translatedBlock.offset, blockType);
 		return isHomogeneous ? null : translatedBlock;
 	}
 
@@ -209,6 +214,7 @@ public class Wafer6061Inpainter {
 		// Translate the block to physical coordinates
 		final Interval blockInterval = Intervals.translate(block, shift);
 		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
+		System.out.println(" **********            translated block offset: " + Arrays.toString(translatedBlock.offset));
 
 		// Check if the block overlaps with any of the mask blocks that might need inpainting
 		for (final Interval maskBlock : blocksToCheckAgainst) {
@@ -216,7 +222,7 @@ public class Wafer6061Inpainter {
 			if (! intervalsAreDisjoint) {
 				LOG.info("Tissue block {} at {} is determined a candidate for inpainting",
 						 translatedBlock.gridPosition, translatedBlock.minAsLongArray());
-				return block;
+				return translatedBlock;
 			}
 		}
 
@@ -225,9 +231,10 @@ public class Wafer6061Inpainter {
 		return null;
 	}
 
-	private void inpaintBlock(
+	private static void inpaintBlock(
 			final Grid.Block block,
 			final long[] maskMin,
+			final long[] tissueMin,
 			final Parameters param,
 			final DatasetAttributes targetAttributes
 	) {
@@ -242,8 +249,8 @@ public class Wafer6061Inpainter {
 			final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.fullDataset());
 			final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
 
-			final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, block.offset);
-			final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
+			final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
+			final RandomAccessible<UnsignedByteType> mask = Views.translate(rawMask, maskMin);
 
 			// For each pixel, determine if it should be inpainted and if so, inpaint it by interpolating in z
 			LOG.info("Start inpainting");
@@ -273,8 +280,8 @@ public class Wafer6061Inpainter {
 	public static void main(final String[] args) {
 		final String[] testArgs = {
 				"--n5Path", "/Users/innerbergerm/Data/render-exports/wafer60.n5",
-				"--dataset", "tissue",
-				"--mask", "mask",
+				"--dataset", "tissue_boundary",
+				"--mask", "mask_boundary",
 //				"--output", "inpainted",
 				"--inpaintingSize", "20"
 		};
@@ -313,7 +320,7 @@ public class Wafer6061Inpainter {
 				final int stepSize
 		) {
 			this.tissueAccess = tissue.randomAccess();
-			this.maskAccess = mask.randomAccess();
+			this.maskAccess = Views.extendZero(mask).randomAccess();
 			this.posStep = stepSize;
 			this.negStep = -2 * stepSize;
 		}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -4,7 +4,6 @@ package org.janelia.render.client.spark.multisem;
 import com.beust.jcommander.Parameter;
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -20,6 +19,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.janelia.alignment.util.Grid;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -28,7 +28,6 @@ import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
-import scala.xml.PrettyPrinter;
 
 import java.io.Serializable;
 import java.util.List;
@@ -138,18 +137,10 @@ public class Wafer6061Inpainter {
 		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
 
 		// Filter all blocks that either have no mask, or are completely covered by the mask
-		final List<Grid.Block> nonHomogeneousMaskBlocks = maskRDD.mapToPair(
-						block -> {
-					final Interval blockInterval = Intervals.translate(block, maskAttributesBroadcast.value().min);
-					final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
-					final boolean isHomogeneous;
-					try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
-						final Img<UnsignedByteType> mask1 = N5Utils.open(n5, paramBroadcast.value().mask);
-						final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask1, translatedBlock);
-						isHomogeneous = isHomogeneous(maskPixels);
-					}
-					return new Tuple2<>(translatedBlock, isHomogeneous);
-				})
+		final List<Grid.Block> nonHomogeneousMaskBlocks = maskRDD
+				.mapToPair(block -> translateAndCheckHomogeneity(block,
+												 maskAttributesBroadcast.value().min,
+												 paramBroadcast.value()))
 				.filter(tuple -> !tuple._2)
 				.map(Tuple2::_1)
 				.collect();
@@ -214,14 +205,35 @@ public class Wafer6061Inpainter {
 		});
 	}
 
-	private static boolean isHomogeneous(final IterableInterval<UnsignedByteType> pixels) {
-		final UnsignedByteType firstPixel = pixels.firstElement();
-		for (final UnsignedByteType pixel : pixels) {
-			if (pixel.equals(firstPixel)) {
-				return false;
+	private static Tuple2<Grid.Block, Boolean> translateAndCheckHomogeneity(
+			final Grid.Block block,
+			final long[] shift,
+			final Parameters param
+	) {
+		LogUtilities.setupExecutorLog4j("");
+
+		// Translate the block to physical coordinates
+		final Interval blockInterval = Intervals.translate(block, shift);
+		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
+
+		// Read the mask block and check if it is homogeneous
+		boolean isHomogeneous = true;
+		try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path)) {
+			final Img<UnsignedByteType> mask = N5Utils.open(n5, param.mask);
+			final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask, translatedBlock);
+
+			final UnsignedByteType firstPixel = maskPixels.firstElement();
+			for (final UnsignedByteType pixel : maskPixels) {
+				if (! pixel.equals(firstPixel)) {
+					isHomogeneous = false;
+					break;
+				}
 			}
 		}
-		return true;
+
+		LOG.info("Block {} at {} is {}",
+				 block.gridPosition, blockInterval.minAsLongArray(), isHomogeneous ? "homogeneous -> skip" : "non-homogeneous -> inpaint");
+		return new Tuple2<>(translatedBlock, isHomogeneous);
 	}
 
 	public static void main(final String[] args) {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -1,6 +1,7 @@
 package org.janelia.render.client.spark.multisem;
 
 
+import com.beust.jcommander.Parameter;
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
@@ -14,6 +15,8 @@ import net.imglib2.util.Intervals;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import org.janelia.alignment.util.Grid;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -37,11 +40,46 @@ public class Wafer6061Inpainter {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Wafer6061Inpainter.class);
 
-	private final String n5Path;
-	private final String dataset;
-	private final String maskDataset;
-	private final String outputDataset;
-	private final int stepSize;
+	public static class Parameters extends CommandLineParameters {
+		@Parameter(
+				names = "--n5Path",
+				description = "Path to the N5 container containing the data and the mask.",
+				required = true)
+		public String n5Path;
+
+		@Parameter(
+				names = "--dataset",
+				description = "Name of the dataset to inpaint; assumed to be a multiscale pyramid, only s0 is inpainted.",
+				required = true)
+		public String dataset;
+
+		@Parameter(
+				names = "--mask",
+				description = "Name of the mask dataset. This is supposed be a binary uint8 mask covering the whole dataset.",
+				required = true)
+		public String mask;
+
+		@Parameter(
+				names = "--output",
+				description = "Name of the dataset to write the inpainted data to. Only blocks that are inpainted are written.",
+				required = true)
+		public String output;
+
+		@Parameter(
+				names = "--inpaintingSize",
+				description = "Rough size of the inpainting region in pixels. This is used to determine the regions to inpaint, so better to be too large than too small.",
+				required = true)
+		public int stepSize;
+
+
+		public void validate() {
+			if (stepSize <= 0) {
+				throw new IllegalArgumentException("Inpainting size must be positive");
+			}
+		}
+	}
+
+	private final Parameters param;
 
 	private N5Reader n5;
 	private DatasetAttributes tissueAttributes;
@@ -49,42 +87,25 @@ public class Wafer6061Inpainter {
 	private long[] tissueMin;
 	private long[] maskMin;
 
-	/**
-	 * @param n5Path path to the N5 container containing the data and the mask
-	 * @param dataset name of the dataset to inpaint; assumed to be a multiscale pyramid, only s0 is inpainted
-	 * @param maskDataset name of the mask dataset; this is supposed to only cover a small z-range of the dataset and
-	 *                    translated to the correct location in the stack coordinates (with an attribute "translate"
-	 *                    containing the translation vector)
-	 * @param outputDataset name of the dataset to write the inpainted data to; only blocks that are inpainted are written
-	 * @param stepSize step size in pixels to look for non-masked pixels in the x/y directions
-	 */
-	public Wafer6061Inpainter(
-			final String n5Path,
-			final String dataset,
-			final String maskDataset,
-			final String outputDataset,
-			final int stepSize
-	) {
-		this.n5Path = n5Path;
-		this.dataset = dataset;
-		this.maskDataset = maskDataset;
-		this.outputDataset = outputDataset;
-		this.stepSize = stepSize;
+
+	public Wafer6061Inpainter(final Parameters parameters) {
+		this.param = parameters;
 	}
 
 	public void inpaint() {
-		LOG.info("Inpainting {} in {} using mask {} and writing to {}", dataset, n5Path, maskDataset, outputDataset);
+		LOG.info("Inpainting {} in {} using mask {} and writing to {}",
+				 param.dataset, param.n5Path, param.mask, param.output);
 
 		// Read and cache some metadata of the tissue and mask datasets
 		// Assume that the tissue is a multiscale pyramid / mask is a standalone dataset
-		n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, n5Path);
-		tissueAttributes = n5.getDatasetAttributes(dataset + "/s0");
-		maskAttributes = n5.getDatasetAttributes(maskDataset);
-		tissueMin = n5.getAttribute(dataset, "translate", long[].class);
-		maskMin = n5.getAttribute(maskDataset, "translate", long[].class);
+		n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path);
+		tissueAttributes = n5.getDatasetAttributes(param.dataset + "/s0");
+		maskAttributes = n5.getDatasetAttributes(param.mask);
+		tissueMin = n5.getAttribute(param.dataset, "translate", long[].class);
+		maskMin = n5.getAttribute(param.mask, "translate", long[].class);
 
-		if (n5.exists(outputDataset)) {
-			throw new RuntimeException("Dataset '" + outputDataset + "' already exists");
+		if (n5.exists(param.output)) {
+			throw new RuntimeException("Dataset '" + param.output + "' already exists");
 		}
 
 		final List<Grid.Block> blocksToInpaint = getBlocksToInpaint();
@@ -94,14 +115,14 @@ public class Wafer6061Inpainter {
 	}
 
 	private List<Grid.Block> getBlocksToInpaint() {
-		LOG.info("Reading metadata from {}", n5Path);
+		LOG.info("Reading metadata from {}", param.n5Path);
 
 		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.getDimensions(), tissueAttributes.getBlockSize());
 		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.getDimensions(), maskAttributes.getBlockSize());
 
 		// Filter all blocks that either have no mask, or are completely covered by the mask
 		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
-		final Img<UnsignedByteType> mask = N5Utils.open(n5, maskDataset);
+		final Img<UnsignedByteType> mask = N5Utils.open(n5, param.mask);
 		final List<Interval> nonHomogeneousMaskBlocks = new ArrayList<>();
 		for (final Grid.Block block : maskBlocks) {
 			final IntervalView<UnsignedByteType> maskPixels = Views.interval(mask, block);
@@ -143,18 +164,18 @@ public class Wafer6061Inpainter {
 	}
 
 	private void inpaintBlocks(final List<Grid.Block> blocksToInpaint) {
-		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, dataset + "/s0");
-		final Img<UnsignedByteType> rawMask = N5Utils.open(n5, maskDataset);
+		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.dataset + "/s0");
+		final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
 
 		final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
 		final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
 
-		final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, n5Path);
-		n5Writer.createDataset(outputDataset, tissueAttributes);
+		final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path);
+		n5Writer.createDataset(param.output, tissueAttributes);
 
 		for (final Grid.Block block : blocksToInpaint) {
 			final Interval blockInterval = Intervals.translate(block, tissueMin);
-			LOG.info("Inpainting block at {}", blockInterval.minAsLongArray());
+			LOG.info("Inpainting block {} at {}", block.gridPosition, blockInterval.minAsLongArray());
 
 			final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(blockInterval.dimensionsAsLongArray());
 
@@ -162,7 +183,7 @@ public class Wafer6061Inpainter {
 			final long[] location = new long[3];
 			final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, blockInterval),
 															 Views.interval(mask, blockInterval),
-															 stepSize);
+															 param.stepSize);
 
 			while (targetCursor.hasNext()) {
 				final UnsignedByteType targetPixel = targetCursor.next();
@@ -171,7 +192,7 @@ public class Wafer6061Inpainter {
 				targetPixel.set(value);
 			}
 
-			N5Utils.saveBlock(inpaintedBlock, n5Writer, outputDataset, tissueAttributes, block.gridPosition);
+			N5Utils.saveBlock(inpaintedBlock, n5Writer, param.output, tissueAttributes, block.gridPosition);
 		}
 
 		n5Writer.close();
@@ -179,14 +200,29 @@ public class Wafer6061Inpainter {
 
 
 	public static void main(final String[] args) {
-		final String n5Path = "/Users/innerbergerm/Data/render-exports/wafer60.n5";
-		final String dataset = "tissue";
-		final String maskDataset = "mask";
-		final String outputDataset = "inpainted";
-		final int stepSize = 20;
+		final String[] testArgs = {
+				"--n5Path", "/Users/innerbergerm/Data/render-exports/wafer60.n5",
+				"--dataset", "tissue",
+				"--mask", "mask",
+				"--output", "inpainted",
+				"--inpaintingSize", "20"
+		};
 
-		final Wafer6061Inpainter inpainter = new Wafer6061Inpainter(n5Path, dataset, maskDataset, outputDataset, stepSize);
-		inpainter.inpaint();
+		final ClientRunner clientRunner = new ClientRunner(testArgs) {
+			@Override
+			public void runClient(final String[] args) {
+
+				final Wafer6061Inpainter.Parameters parameters = new Wafer6061Inpainter.Parameters();
+				parameters.parse(args);
+				parameters.validate();
+
+				LOG.info("runClient: entry, parameters={}", parameters);
+
+				final Wafer6061Inpainter inpainter = new Wafer6061Inpainter(parameters);
+				inpainter.inpaint();
+			}
+		};
+		clientRunner.run();
 	}
 
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -27,7 +27,6 @@ import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.annotation.meta.param;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -179,25 +178,25 @@ public class Wafer6061Inpainter {
 	) {
 		LogUtilities.setupExecutorLog4j("");
 
-		// Translate the block to physical coordinates
-		final Interval blockInterval = Intervals.translate(block, shift);
-		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
-
 		// Read the mask block and check if it is homogeneous
 		boolean isHomogeneous = true;
 		try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path)) {
 			final Img<UnsignedByteType> mask = N5Utils.open(n5, param.mask);
-			final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask, translatedBlock);
+			final Interval interval = Intervals.intersect(mask, block);
+			final RandomAccessibleInterval<UnsignedByteType> maskPixels = Views.interval(mask, interval);
 
 			final UnsignedByteType firstPixel = maskPixels.firstElement();
-//			for (final UnsignedByteType pixel : maskPixels) {
-//				if (! pixel.equals(firstPixel)) {
-//					isHomogeneous = false;
-//					break;
-//				}
-//			}
-			isHomogeneous = false;
+			for (final UnsignedByteType pixel : maskPixels) {
+				if (! pixel.equals(firstPixel)) {
+					isHomogeneous = false;
+					break;
+				}
+			}
 		}
+
+		// Translate the block to physical coordinates
+		final Interval blockInterval = Intervals.translate(block, shift);
+		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
 
 		final String blockType = isHomogeneous ? "homogeneous -> skip" : "non-homogeneous -> possibly inpaint";
 		LOG.info("Mask block {} at {} is {}", translatedBlock.gridPosition, translatedBlock.offset, blockType);
@@ -214,7 +213,6 @@ public class Wafer6061Inpainter {
 		// Translate the block to physical coordinates
 		final Interval blockInterval = Intervals.translate(block, shift);
 		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
-		System.out.println(" **********            translated block offset: " + Arrays.toString(translatedBlock.offset));
 
 		// Check if the block overlaps with any of the mask blocks that might need inpainting
 		for (final Interval maskBlock : blocksToCheckAgainst) {
@@ -250,14 +248,14 @@ public class Wafer6061Inpainter {
 			final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
 
 			final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
-			final RandomAccessible<UnsignedByteType> mask = Views.translate(rawMask, maskMin);
+			final RandomAccessibleInterval<UnsignedByteType> mask = Views.translate(rawMask, maskMin);
 
 			// For each pixel, determine if it should be inpainted and if so, inpaint it by interpolating in z
 			LOG.info("Start inpainting");
 			final long start = System.currentTimeMillis();
 			final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, block.offset).localizingCursor();
 			final long[] location = new long[3];
-			final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, block), Views.interval(mask, block), param.stepSize);
+			final PixelFiller interpolator = new PixelFiller(tissue, mask, param.stepSize);
 
 			while (targetCursor.hasNext()) {
 				final UnsignedByteType targetPixel = targetCursor.next();
@@ -280,8 +278,8 @@ public class Wafer6061Inpainter {
 	public static void main(final String[] args) {
 		final String[] testArgs = {
 				"--n5Path", "/Users/innerbergerm/Data/render-exports/wafer60.n5",
-				"--dataset", "tissue_boundary",
-				"--mask", "mask_boundary",
+				"--dataset", "tissue",
+				"--mask", "mask",
 //				"--output", "inpainted",
 				"--inpaintingSize", "20"
 		};

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -1,0 +1,268 @@
+package org.janelia.render.client.spark.multisem;
+
+
+import net.imglib2.Cursor;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+import org.janelia.alignment.util.Grid;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * Class for inpainting small gaps between tiles in the wafer 60/61 dataset.
+ * <p>
+ * The regions to inpaint are determined by looking at mask pixels: if an unmasked pixel is encountered,
+ * the algorithm looks at the =/- x/y directions in increments of to find non-masked pixels
+ */
+public class Wafer6061Inpainter {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Wafer6061Inpainter.class);
+
+	private final String n5Path;
+	private final String dataset;
+	private final String maskDataset;
+	private final String outputDataset;
+	private final int stepSize;
+
+	private N5Reader n5;
+	private DatasetAttributes tissueAttributes;
+	private DatasetAttributes maskAttributes;
+	private long[] tissueMin;
+	private long[] maskMin;
+
+	/**
+	 * @param n5Path path to the N5 container containing the data and the mask
+	 * @param dataset name of the dataset to inpaint; assumed to be a multiscale pyramid, only s0 is inpainted
+	 * @param maskDataset name of the mask dataset; this is supposed to only cover a small z-range of the dataset and
+	 *                    translated to the correct location in the stack coordinates (with an attribute "translate"
+	 *                    containing the translation vector)
+	 * @param outputDataset name of the dataset to write the inpainted data to; only blocks that are inpainted are written
+	 * @param stepSize step size in pixels to look for non-masked pixels in the x/y directions
+	 */
+	public Wafer6061Inpainter(
+			final String n5Path,
+			final String dataset,
+			final String maskDataset,
+			final String outputDataset,
+			final int stepSize
+	) {
+		this.n5Path = n5Path;
+		this.dataset = dataset;
+		this.maskDataset = maskDataset;
+		this.outputDataset = outputDataset;
+		this.stepSize = stepSize;
+	}
+
+	public void inpaint() {
+		LOG.info("Inpainting {} in {} using mask {} and writing to {}", dataset, n5Path, maskDataset, outputDataset);
+
+		// Read and cache some metadata of the tissue and mask datasets
+		// Assume that the tissue is a multiscale pyramid / mask is a standalone dataset
+		n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, n5Path);
+		tissueAttributes = n5.getDatasetAttributes(dataset + "/s0");
+		maskAttributes = n5.getDatasetAttributes(maskDataset);
+		tissueMin = n5.getAttribute(dataset, "translate", long[].class);
+		maskMin = n5.getAttribute(maskDataset, "translate", long[].class);
+
+		if (n5.exists(outputDataset)) {
+			throw new RuntimeException("Dataset '" + outputDataset + "' already exists");
+		}
+
+		final List<Grid.Block> blocksToInpaint = getBlocksToInpaint();
+		inpaintBlocks(blocksToInpaint);
+
+		n5.close();
+	}
+
+	private List<Grid.Block> getBlocksToInpaint() {
+		LOG.info("Reading metadata from {}", n5Path);
+
+		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.getDimensions(), tissueAttributes.getBlockSize());
+		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.getDimensions(), maskAttributes.getBlockSize());
+
+		// Filter empty blocks in the mask
+		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
+		final Img<UnsignedByteType> mask = N5Utils.open(n5, maskDataset);
+		final List<Interval> nonEmptyMaskBlocks = new ArrayList<>();
+		for (final Grid.Block block : maskBlocks) {
+			final IntervalView<UnsignedByteType> pixels = Views.interval(mask, block);
+			for (final UnsignedByteType pixel : pixels) {
+				final float value = pixel.get();
+				if (value > 0 && value < 255) {
+					nonEmptyMaskBlocks.add(block);
+					break;
+				}
+			}
+		}
+		LOG.info("Found {} non-empty mask blocks", nonEmptyMaskBlocks.size());
+
+		// See which tissue blocks are covered by the mask
+		final List<Interval> translatedNonEmptyMaskBlocks = nonEmptyMaskBlocks.stream()
+				.map(b -> Intervals.translate(b, maskMin))
+				.collect(Collectors.toList());
+		final List<Grid.Block> tissueBlocksToInpaint = new ArrayList<>();
+
+		for (final Grid.Block block : tissueBlocks) {
+			final Interval blockInterval = Intervals.translate(block, tissueMin);
+			for (final Interval maskBlock : translatedNonEmptyMaskBlocks) {
+				final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(blockInterval, maskBlock));
+				if (!intervalsAreDisjoint) {
+					tissueBlocksToInpaint.add(block);
+					break;
+				}
+			}
+		}
+		LOG.info("Found {} tissue blocks to inpaint", tissueBlocksToInpaint.size());
+
+		return tissueBlocksToInpaint;
+	}
+
+	private void inpaintBlocks(final List<Grid.Block> blocksToInpaint) {
+		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, dataset + "/s0");
+		final Img<UnsignedByteType> rawMask = N5Utils.open(n5, maskDataset);
+
+		final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
+		final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
+
+		final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, n5Path);
+		n5Writer.createDataset(outputDataset, tissueAttributes);
+
+		for (final Grid.Block block : blocksToInpaint) {
+			final Interval blockInterval = Intervals.translate(block, tissueMin);
+			LOG.info("Inpainting block at {}", blockInterval.minAsLongArray());
+
+			final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(blockInterval.dimensionsAsLongArray());
+
+			final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, blockInterval.minAsLongArray()).localizingCursor();
+			final long[] location = new long[3];
+			final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, blockInterval),
+															 Views.interval(mask, blockInterval),
+															 stepSize);
+
+			while (targetCursor.hasNext()) {
+				final UnsignedByteType targetPixel = targetCursor.next();
+				targetCursor.localize(location);
+				final int value = interpolator.getPixel(location);
+				targetPixel.set(value);
+			}
+
+			N5Utils.saveBlock(inpaintedBlock, n5Writer, outputDataset, tissueAttributes, block.gridPosition);
+		}
+
+		n5Writer.close();
+	}
+
+
+	public static void main(final String[] args) {
+		final String n5Path = "/Users/innerbergerm/Data/render-exports/wafer60.n5";
+		final String dataset = "tissue";
+		final String maskDataset = "mask";
+		final String outputDataset = "inpainted";
+		final int stepSize = 10;
+
+		final Wafer6061Inpainter inpainter = new Wafer6061Inpainter(n5Path, dataset, maskDataset, outputDataset, stepSize);
+		inpainter.inpaint();
+	}
+
+
+	/**
+	 * Performs all the inpainting-logic, i.e., when and how to inpaint.
+	 */
+	private static class PixelFiller {
+
+		private final RandomAccess<UnsignedByteType> tissueAccess;
+		private final RandomAccess<UnsignedByteType> maskAccess;
+		private final int posStep;
+		private final int negStep;
+
+		public PixelFiller(
+				final RandomAccessibleInterval<UnsignedByteType> tissue,
+				final RandomAccessibleInterval<UnsignedByteType> mask,
+				final int stepSize
+		) {
+			this.tissueAccess = tissue.randomAccess();
+			this.maskAccess = mask.randomAccess();
+			this.posStep = stepSize;
+			this.negStep = -2 * stepSize;
+		}
+
+		public int getPixel(final long[] position) {
+			if (shouldBeInpainted(position)) {
+				return zAverage(position);
+			} else {
+				return tissueAccess.setPositionAndGet(position).get();
+			}
+		}
+
+		private int zAverage(final long[] position) {
+			maskAccess.setPosition(position);
+			maskAccess.move(-1, 2);
+			final boolean hasContentAbove = maskAccess.get().get() > 0;
+			maskAccess.move(2, 2);
+			final boolean hasContentBelow = maskAccess.get().get() > 0;
+
+			tissueAccess.setPositionAndGet(position);
+			if (hasContentAbove && hasContentBelow) {
+				tissueAccess.move(-1, 2);
+				final int above = tissueAccess.get().get();
+
+				tissueAccess.move(2, 2);
+				final int below = tissueAccess.get().get();
+
+				return UnsignedByteType.getCodedSignedByteChecked((above + below) >>> 2);
+			} else if (hasContentAbove) {
+				tissueAccess.move(-1, 2);
+				return tissueAccess.get().get();
+			} else if (hasContentBelow) {
+				tissueAccess.move(2, 2);
+				return tissueAccess.get().get();
+			} else {
+				return 0;
+			}
+		}
+
+		private boolean shouldBeInpainted(final long[] position) {
+			final boolean hasContent = maskAccess.setPositionAndGet(position).get() > 0;
+			if (hasContent) {
+				return false;
+			}
+
+			// If the pixel has no content, check the pixels in +/- y direction
+			// Only if both have content, the pixel should be inpainted (otherwise, it is a border pixel)
+			maskAccess.move(posStep, 1);
+			final boolean hasContentFront = maskAccess.get().get() > 0;
+			maskAccess.move(negStep, 1);
+			final boolean hasContentBack = maskAccess.get().get() > 0;
+			if (hasContentFront && hasContentBack) {
+				return true;
+			}
+
+			// If that is inconclusive, check the pixels in +/- x direction
+			maskAccess.move(posStep, 1);
+			maskAccess.move(posStep, 0);
+			final boolean hasContentRight = maskAccess.get().get() > 0;
+			maskAccess.move(negStep, 0);
+			final boolean hasContentLeft = maskAccess.get().get() > 0;
+			return hasContentRight && hasContentLeft;
+		}
+
+	}
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -61,8 +61,8 @@ public class Wafer6061Inpainter {
 
 		@Parameter(
 				names = "--output",
-				description = "Name of the dataset to write the inpainted data to. Only blocks that are inpainted are written.",
-				required = true)
+				description = "Name of the dataset to write the inpainted data to. Only blocks that are inpainted are written. "
+						+ "If omitted, input blocks are overwritten.")
 		public String output;
 
 		@Parameter(
@@ -76,6 +76,10 @@ public class Wafer6061Inpainter {
 			if (stepSize <= 0) {
 				throw new IllegalArgumentException("Inpainting size must be positive");
 			}
+		}
+
+		public String fullDataset() {
+			return dataset + "/s0";
 		}
 	}
 
@@ -92,20 +96,29 @@ public class Wafer6061Inpainter {
 		this.param = parameters;
 	}
 
-	public void inpaint() {
-		LOG.info("Inpainting {} in {} using mask {} and writing to {}",
-				 param.dataset, param.n5Path, param.mask, param.output);
+	public void run() {
+		final String output = param.output == null ? "input dataset" : "'" + param.output + "'";
+		LOG.info("Inpainting dataset '{}' in '{}' using mask '{}' and writing to {}",
+				 param.dataset, param.n5Path, param.mask, output);
 
 		// Read and cache some metadata of the tissue and mask datasets
 		// Assume that the tissue is a multiscale pyramid / mask is a standalone dataset
 		n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path);
-		tissueAttributes = n5.getDatasetAttributes(param.dataset + "/s0");
+		tissueAttributes = n5.getDatasetAttributes(param.fullDataset());
 		maskAttributes = n5.getDatasetAttributes(param.mask);
 		tissueMin = n5.getAttribute(param.dataset, "translate", long[].class);
 		maskMin = n5.getAttribute(param.mask, "translate", long[].class);
 
-		if (n5.exists(param.output)) {
-			throw new RuntimeException("Dataset '" + param.output + "' already exists");
+		if (param.output == null) {
+			param.output = param.fullDataset();
+			LOG.info("Output dataset equals input dataset. Overwriting blocks in the input dataset '{}'", param.output);
+		} else if (n5.exists(param.output)) {
+			throw new IllegalArgumentException("Dataset '" + param.output + "' is different from the input dataset and already exists. Stopping.");
+		} else {
+			LOG.info("Output dataset is '{}'. Creating new dataset.", param.output);
+			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
+				n5Writer.createDataset(param.output, tissueAttributes);
+			}
 		}
 
 		final List<Grid.Block> blocksToInpaint = getBlocksToInpaint();
@@ -164,14 +177,11 @@ public class Wafer6061Inpainter {
 	}
 
 	private void inpaintBlocks(final List<Grid.Block> blocksToInpaint) {
-		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.dataset + "/s0");
+		final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.fullDataset());
 		final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
 
 		final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
 		final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
-
-		final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path);
-		n5Writer.createDataset(param.output, tissueAttributes);
 
 		for (final Grid.Block block : blocksToInpaint) {
 			final Interval blockInterval = Intervals.translate(block, tissueMin);
@@ -192,10 +202,10 @@ public class Wafer6061Inpainter {
 				targetPixel.set(value);
 			}
 
-			N5Utils.saveBlock(inpaintedBlock, n5Writer, param.output, tissueAttributes, block.gridPosition);
+			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
+				N5Utils.saveBlock(inpaintedBlock, n5Writer, param.output, tissueAttributes, block.gridPosition);
+			}
 		}
-
-		n5Writer.close();
 	}
 
 
@@ -204,7 +214,7 @@ public class Wafer6061Inpainter {
 				"--n5Path", "/Users/innerbergerm/Data/render-exports/wafer60.n5",
 				"--dataset", "tissue",
 				"--mask", "mask",
-				"--output", "inpainted",
+//				"--output", "inpainted",
 				"--inpaintingSize", "20"
 		};
 
@@ -219,7 +229,7 @@ public class Wafer6061Inpainter {
 				LOG.info("runClient: entry, parameters={}", parameters);
 
 				final Wafer6061Inpainter inpainter = new Wafer6061Inpainter(parameters);
-				inpainter.inpaint();
+				inpainter.run();
 			}
 		};
 		clientRunner.run();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -27,9 +27,9 @@ import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Tuple2;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -38,7 +38,10 @@ import java.util.Objects;
  * Class for inpainting small gaps between tiles in the wafer 60/61 dataset.
  * <p>
  * The regions to inpaint are determined by looking at mask pixels: if an unmasked pixel is encountered,
- * the algorithm looks at the =/- x/y directions in increments of to find non-masked pixels
+ * the algorithm looks at pairs of pixels `stepSize` away in the x and y directions to find non-masked pixels.
+ * If such a pair is found, the pixel is most likely in a narrow gap between tiles and needs inpainting. The
+ * inpainting is done by averaging the image data from the adjacent pixels in the z direction. If only one of the
+ * image values in z is available, that value is used. If neither is available, the pixel is set to 0.
  */
 public class Wafer6061Inpainter {
 
@@ -129,83 +132,43 @@ public class Wafer6061Inpainter {
 	}
 
 	private void runWithSparkContext(final JavaSparkContext sparkContext) {
-		// Find out which blocks need inpainting
+		// Find out which blocks need inpainting (i.e., find blocks that are neither all mask or all void)
 		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.attrs.getDimensions(), maskAttributes.attrs.getBlockSize());
 		final JavaRDD<Grid.Block> maskRDD = sparkContext.parallelize(maskBlocks);
 		final Broadcast<ExtendedAttributes> maskAttributesBroadcast = sparkContext.broadcast(maskAttributes);
 		final Broadcast<Parameters> paramBroadcast = sparkContext.broadcast(param);
 		LOG.info("Filtering empty mask blocks from {} blocks", maskBlocks.size());
 
-		// Filter all blocks that either have no mask, or are completely covered by the mask
 		final List<Grid.Block> nonHomogeneousMaskBlocks = maskRDD
-				.mapToPair(block -> translateAndCheckHomogeneity(block,
-												 maskAttributesBroadcast.value().min,
-												 paramBroadcast.value()))
-				.filter(tuple -> !tuple._2)
-				.map(Tuple2::_1)
+				.map(block -> translateAndCheckHomogeneity(block,
+														   maskAttributesBroadcast.value().min,
+														   paramBroadcast.value()))
+				.filter(Objects::nonNull)
 				.collect();
 		LOG.info("Found {} non-homogeneous mask blocks", nonHomogeneousMaskBlocks.size());
 
+		// Check which tissue blocks are covered by the potentially inpainted mask blocks determined above
 		final List<Grid.Block> tissueBlocks = Grid.create(tissueAttributes.attrs.getDimensions(), tissueAttributes.attrs.getBlockSize());
 		final JavaRDD<Grid.Block> tissueBlocksRDD = sparkContext.parallelize(tissueBlocks);
 		final Broadcast<ExtendedAttributes> tissueAttributesBroadcast = sparkContext.broadcast(tissueAttributes);
 		final Broadcast<List<Grid.Block>> maskBlocksBroadcast = sparkContext.broadcast(nonHomogeneousMaskBlocks);
 
-		// Check which tissue blocks are covered by the interesting mask blocks determined above
 		final List<Grid.Block> tissueBlocksToInpaint = tissueBlocksRDD.map(
-						block -> {
-					final Interval blockInterval = Intervals.translate(block, tissueAttributesBroadcast.value().min);
-					final List<Grid.Block> interestingMaskBlocks = maskBlocksBroadcast.getValue();
-					for (final Interval maskBlock : interestingMaskBlocks) {
-						final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(blockInterval, maskBlock));
-						if (!intervalsAreDisjoint) {
-							return block;
-						}
-					}
-					return null;
-				})
+						block -> translateAndCheckIfOverlaps(block,
+															 tissueAttributesBroadcast.value().min,
+															 maskBlocksBroadcast.value()))
 				.filter(Objects::nonNull)
 				.collect();
 		LOG.info("Found {} tissue blocks to inpaint", tissueBlocksToInpaint.size());
 
+		// Inpaint the blocks
 		final JavaRDD<Grid.Block> inpaintingBlocksRDD = sparkContext.parallelize(tissueBlocksToInpaint);
+
 		inpaintingBlocksRDD.foreach(block -> {
-			final long[] tissueMin = tissueAttributesBroadcast.value().min;
-			final long[] maskMin = maskAttributesBroadcast.value().min;
-			final Interval blockInterval = Intervals.translate(block, tissueMin);
-			final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(blockInterval.dimensionsAsLongArray());
-
-			try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
-				final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, paramBroadcast.value().fullDataset());
-				final Img<UnsignedByteType> rawMask = N5Utils.open(n5, paramBroadcast.value().mask);
-
-				final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, tissueMin);
-				final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
-				LOG.info("Inpainting block {} at {}", block.gridPosition, blockInterval.minAsLongArray());
-
-
-				final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, blockInterval.minAsLongArray()).localizingCursor();
-				final long[] location = new long[3];
-				final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, blockInterval),
-																 Views.interval(mask, blockInterval),
-																 paramBroadcast.value().stepSize);
-
-				while (targetCursor.hasNext()) {
-					final UnsignedByteType targetPixel = targetCursor.next();
-					targetCursor.localize(location);
-					final int value = interpolator.getPixel(location);
-					targetPixel.set(value);
-				}
-			}
-
-			try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, paramBroadcast.value().n5Path)) {
-				final DatasetAttributes targetAttributes = tissueAttributesBroadcast.value().attrs;
-				N5Utils.saveBlock(inpaintedBlock, n5Writer, paramBroadcast.value().output, targetAttributes, block.gridPosition);
-			}
 		});
 	}
 
-	private static Tuple2<Grid.Block, Boolean> translateAndCheckHomogeneity(
+	private static Grid.Block translateAndCheckHomogeneity(
 			final Grid.Block block,
 			final long[] shift,
 			final Parameters param
@@ -231,10 +194,81 @@ public class Wafer6061Inpainter {
 			}
 		}
 
-		LOG.info("Block {} at {} is {}",
-				 block.gridPosition, blockInterval.minAsLongArray(), isHomogeneous ? "homogeneous -> skip" : "non-homogeneous -> inpaint");
-		return new Tuple2<>(translatedBlock, isHomogeneous);
+		final String blockType = isHomogeneous ? "homogeneous -> skip" : "non-homogeneous -> possibly inpaint";
+		LOG.info("Mask block {} at {} is {}", block.gridPosition, blockInterval.minAsLongArray(), blockType);
+		return isHomogeneous ? null : translatedBlock;
 	}
+
+	private static Grid.Block translateAndCheckIfOverlaps(
+			final Grid.Block block,
+			final long[] shift,
+			final List<Grid.Block> blocksToCheckAgainst
+	) {
+		LogUtilities.setupExecutorLog4j("");
+
+		// Translate the block to physical coordinates
+		final Interval blockInterval = Intervals.translate(block, shift);
+		final Grid.Block translatedBlock = new Grid.Block(blockInterval, block.gridPosition);
+
+		// Check if the block overlaps with any of the mask blocks that might need inpainting
+		for (final Interval maskBlock : blocksToCheckAgainst) {
+			final boolean intervalsAreDisjoint = Intervals.isEmpty(Intervals.intersect(translatedBlock, maskBlock));
+			if (! intervalsAreDisjoint) {
+				LOG.info("Tissue block {} at {} is determined a candidate for inpainting",
+						 translatedBlock.gridPosition, translatedBlock.minAsLongArray());
+				return block;
+			}
+		}
+
+		LOG.info("Tissue block {} at {} is not a candidate for inpainting",
+				 translatedBlock.gridPosition, translatedBlock.minAsLongArray());
+		return null;
+	}
+
+	private void inpaintBlock(
+			final Grid.Block block,
+			final long[] maskMin,
+			final Parameters param,
+			final DatasetAttributes targetAttributes
+	) {
+		LogUtilities.setupExecutorLog4j("Block " + Arrays.toString(block.gridPosition));
+
+		// Preallocate the inpainted block
+		final Img<UnsignedByteType> inpaintedBlock = ArrayImgs.unsignedBytes(block.dimensions);
+
+		try (final N5Reader n5 = new N5Factory().openReader(N5Factory.StorageFormat.N5, param.n5Path)) {
+			// Load and translate the tissue and mask data
+			LOG.info("Loading data at {}", block.offset);
+			final Img<UnsignedByteType> rawTissue = N5Utils.open(n5, param.fullDataset());
+			final Img<UnsignedByteType> rawMask = N5Utils.open(n5, param.mask);
+
+			final RandomAccessibleInterval<UnsignedByteType> tissue = Views.translate(rawTissue, block.offset);
+			final RandomAccessible<UnsignedByteType> mask = Views.translate(Views.extendValue(rawMask, 0.0f), maskMin);
+
+			// For each pixel, determine if it should be inpainted and if so, inpaint it by interpolating in z
+			LOG.info("Start inpainting");
+			final long start = System.currentTimeMillis();
+			final Cursor<UnsignedByteType> targetCursor = Views.translate(inpaintedBlock, block.offset).localizingCursor();
+			final long[] location = new long[3];
+			final PixelFiller interpolator = new PixelFiller(Views.interval(tissue, block), Views.interval(mask, block), param.stepSize);
+
+			while (targetCursor.hasNext()) {
+				final UnsignedByteType targetPixel = targetCursor.next();
+				targetCursor.localize(location);
+				final int value = interpolator.getPixel(location);
+				targetPixel.set(value);
+			}
+			LOG.info("Finished inpainting in {} ms", System.currentTimeMillis() - start);
+		}
+
+		try (final N5Writer n5Writer = new N5Factory().openWriter(N5Factory.StorageFormat.N5, param.n5Path)) {
+			N5Utils.saveBlock(inpaintedBlock, n5Writer, param.output, targetAttributes, block.gridPosition);
+			LOG.info("Wrote tissue block to '{}'", param.output);
+		} catch (final Exception e) {
+			LOG.error("Failed to write inpainted block", e);
+		}
+	}
+
 
 	public static void main(final String[] args) {
 		final String[] testArgs = {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/Wafer6061Inpainter.java
@@ -5,7 +5,6 @@ import com.beust.jcommander.Parameter;
 import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
@@ -132,7 +131,7 @@ public class Wafer6061Inpainter {
 	}
 
 	private void runWithSparkContext(final JavaSparkContext sparkContext) {
-		// Find out which blocks need inpainting (i.e., find blocks that are neither all mask or all void)
+		// Find out which blocks need inpainting (i.e., find blocks that are neither all mask nor all void)
 		final List<Grid.Block> maskBlocks = Grid.create(maskAttributes.attrs.getDimensions(), maskAttributes.attrs.getBlockSize());
 		final JavaRDD<Grid.Block> maskRDD = sparkContext.parallelize(maskBlocks);
 		final Broadcast<ExtendedAttributes> maskAttributesBroadcast = sparkContext.broadcast(maskAttributes);
@@ -276,15 +275,7 @@ public class Wafer6061Inpainter {
 
 
 	public static void main(final String[] args) {
-		final String[] testArgs = {
-				"--n5Path", "/Users/innerbergerm/Data/render-exports/wafer60.n5",
-				"--dataset", "tissue",
-				"--mask", "mask",
-//				"--output", "inpainted",
-				"--inpaintingSize", "20"
-		};
-
-		final ClientRunner clientRunner = new ClientRunner(testArgs) {
+		final ClientRunner clientRunner = new ClientRunner(args) {
 			@Override
 			public void runClient(final String[] args) {
 
@@ -331,6 +322,11 @@ public class Wafer6061Inpainter {
 			}
 		}
 
+		/**
+		 * Average the z-values of the pixels above and below the current pixel.
+		 * If only one of the pixels is available, that value is used.
+		 * If neither is available, the pixel is set to 0.
+		 */
 		private int zAverage(final long[] position) {
 			maskAccess.setPosition(position);
 			maskAccess.move(-1, 2);
@@ -358,6 +354,9 @@ public class Wafer6061Inpainter {
 			}
 		}
 
+		/**
+		 * Determines if the pixel at the given position should be inpainted based on the local environment.
+		 */
 		private boolean shouldBeInpainted(final long[] position) {
 			final boolean hasContent = maskAccess.setPositionAndGet(position).get() > 0;
 			if (hasContent) {


### PR DESCRIPTION
This PR adds a simple inpainting algorithm for the narrow gaps between tiles present in the wafer 60/61 data. It inpaints by:
- For each non-masked pixel, check if the pixels [+/- n in x-direction] or [+/- n in y-direction] are masked. If yes, were probably in a narrow gap that needs inpainting.
- Inpaint these pixels by averaging the values +/- 1 in z-direction. If either does not exist, only take the one that does exist, and return 0 if neither exists.

Generally, I tested the following cases:
- Gaps completely surrounded by image tiles
- Gaps that are connected to the boundary of the tiled area on one side
- Chunks that either have tiles but no gaps, or no tiles at all (those won't be re-written)
- Chunks at the boundary of the image that have sizes smaller than the nominal chunk size

Let me know if you think I overlooked a particular case that's important enough to test before applying this to real data.

@trautmane The arguments to launch this are the following:
```
--n5Path <path to n5>
--dataset <dataset to inpaint from n5 root (multi-level pyramid)>
--mask <mask dataset from n5 root (single full-res dataset)>
[--output <inpainted dataset from n5 root>]
--inpaintingSize <the approximate size of the gaps, i.e., n above>
```
I've ran my tests with `--inpaintingSize 20` so far, which seemed sufficient, but we might want to set it higher to not miss larger gaps. If the output dataset is not given, input blocks are overwritten. I'd suggest running it with a dedicated output dataset once to see if it works before omitting that argument to overwrite blocks.