### PR TITLE
newsolver_patch_all_unconnected_with_stage_b

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoader.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoader.java
@@ -46,15 +46,16 @@ public class ImageJDefaultLoader
             throws IllegalArgumentException {
 
         final int maxRetries = 3;
-        final int secondsBetweenRetries = 5 << (retryNumber - 1); // retry 1: 5s, retry 2: 10s, retry 3: 20s
         final int nextRetryNumber = retryNumber + 1;
 
         if (retryNumber > 0) {
             try {
-                Thread.sleep(secondsBetweenRetries * 1000L);
-            } catch (final InterruptedException e) {
-                LOG.warn("loadWithRetries: interrupted while sleeping before retry, continuing with retry now ", e);
+                Thread.sleep(getRetrySleepSeconds(retryNumber) * 1000L);
+            } catch (final Throwable t) {
+                LOG.warn("loadWithRetries: exception thrown while sleeping before retry, continuing with retry now ", t);
             }
+        } else if (retryNumber < 0) {
+            throw new IllegalArgumentException("retryNumber '" + retryNumber + "' must be greater than or equal to 0");
         }
 
         ImagePlus imagePlus;
@@ -104,7 +105,7 @@ public class ImageJDefaultLoader
         } catch (final Throwable t) {
             if (nextRetryNumber <= maxRetries) {
                 LOG.warn("loadWithRetries: failed to load {}, will run retry number {} of {} in {} seconds",
-                         urlString, nextRetryNumber, maxRetries, secondsBetweenRetries, t);
+                         urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber), t);
                 imagePlus = loadWithRetries(urlString,
                                             nextRetryNumber);
             } else {
@@ -117,7 +118,7 @@ public class ImageJDefaultLoader
         if (imagePlus == null) {
             if (nextRetryNumber <= maxRetries) {
                 LOG.warn("loadWithRetries: null imagePlus for {}, will run retry number {} of {} in {} seconds",
-                         urlString, nextRetryNumber, maxRetries, secondsBetweenRetries);
+                         urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber));
                 imagePlus = loadWithRetries(urlString,
                                             nextRetryNumber);
             } else {
@@ -127,6 +128,10 @@ public class ImageJDefaultLoader
         }
 
         return imagePlus;
+    }
+
+    private int getRetrySleepSeconds(final int retryNumber) {
+        return retryNumber > 0 ? 5 << (retryNumber - 1) : 0; // retry 1: 5s, retry 2: 10s, retry 3: 20s
     }
 
     /** Copied from protected {@link Opener#openJpegOrGifUsingURL}. */

--- a/render-app/src/main/java/org/janelia/alignment/match/CanvasIdWithRenderContext.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/CanvasIdWithRenderContext.java
@@ -1,9 +1,12 @@
 package org.janelia.alignment.match;
 
+import java.awt.Rectangle;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 import org.janelia.alignment.RenderParameters;
+import org.janelia.alignment.spec.TileSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +104,21 @@ public class CanvasIdWithRenderContext
         }
 
         return renderParametersForRun;
+    }
+
+    public Rectangle getWorldBounds()
+            throws IllegalArgumentException {
+
+        if (originalRenderParameters == null) {
+            originalRenderParameters = RenderParameters.loadFromUrl(url);
+        }
+
+        final List<TileSpec> tileSpecList = originalRenderParameters.getTileSpecs();
+        if (tileSpecList.size() != 1) {
+            throw new IllegalArgumentException(tileSpecList.size() + "tile specs retrieved for " + this + " but only one is expected");
+        }
+        final TileSpec tileSpec = tileSpecList.get(0);
+        return tileSpec.toTileBounds().toRectangle();
     }
 
     @Override

--- a/render-app/src/main/java/org/janelia/alignment/match/MatchTrial.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/MatchTrial.java
@@ -105,6 +105,7 @@ public class MatchTrial implements Serializable {
                                          featureAndMatchParameters.getSiftFeatureParameters(),
                                          featureAndMatchParameters.getMatchDerivationParameters(),
                                          gdmfParameters,
+                                         null,
                                          null);
 
         final String urlTemplateString = getTemplateString(parameters.getpRenderParametersUrl());

--- a/render-app/src/main/java/org/janelia/alignment/match/parameters/MatchStageParameters.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/parameters/MatchStageParameters.java
@@ -26,10 +26,12 @@ public class MatchStageParameters
     private final MatchDerivationParameters featureMatchDerivation;
     private final GeometricDescriptorAndMatchFilterParameters geometricDescriptorAndMatch;
     private final Double maxNeighborDistance;
+    private final Double startPositionMatchWeight;
 
     @SuppressWarnings("unused")
     public MatchStageParameters() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -44,7 +46,8 @@ public class MatchStageParameters
                                 final FeatureExtractionParameters featureExtraction,
                                 final MatchDerivationParameters featureMatchDerivation,
                                 final GeometricDescriptorAndMatchFilterParameters geometricDescriptorAndMatch,
-                                final Double maxNeighborDistance) {
+                                final Double maxNeighborDistance,
+                                final Double startPositionMatchWeight) {
         this.stageName = stageName;
         this.featureRender = featureRender;
         this.featureRenderClip = featureRenderClip;
@@ -52,6 +55,7 @@ public class MatchStageParameters
         this.featureMatchDerivation = featureMatchDerivation;
         this.geometricDescriptorAndMatch = geometricDescriptorAndMatch;
         this.maxNeighborDistance = maxNeighborDistance;
+        this.startPositionMatchWeight = startPositionMatchWeight;
     }
 
     public String getStageName() {
@@ -80,6 +84,10 @@ public class MatchStageParameters
 
     public boolean exceedsMaxNeighborDistance(final Double absoluteDeltaZ) {
         return (maxNeighborDistance != null) && (absoluteDeltaZ != null) && (absoluteDeltaZ > maxNeighborDistance);
+    }
+
+    public Double getStartPositionMatchWeight() {
+        return startPositionMatchWeight;
     }
 
     public void validateAndSetDefaults() throws IllegalArgumentException {

--- a/render-app/src/main/java/org/janelia/alignment/match/stage/MultiStageMatcher.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/stage/MultiStageMatcher.java
@@ -81,14 +81,23 @@ public class MultiStageMatcher
 
             pFeatureContextCanvasId = stageResources.getFeatureContextCanvasId(p, pFeatureContextCanvasId);
             qFeatureContextCanvasId = stageResources.getFeatureContextCanvasId(q, qFeatureContextCanvasId);
-            pPeakContextCanvasId = stageResources.getPeakContextCanvasId(p, pPeakContextCanvasId);
-            qPeakContextCanvasId = stageResources.getPeakContextCanvasId(q, qPeakContextCanvasId);
 
-            final StageMatcher.PairResult stagePairResult =
-                    stageMatcher.generateStageMatchesForPair(pFeatureContextCanvasId,
-                                                             qFeatureContextCanvasId,
-                                                             pPeakContextCanvasId,
-                                                             qPeakContextCanvasId);
+            final StageMatcher.PairResult stagePairResult;
+            final Double startPositionMatchWeight = stageResources.getStartPositionMatchWeight();
+
+            if (startPositionMatchWeight == null) {
+                pPeakContextCanvasId = stageResources.getPeakContextCanvasId(p, pPeakContextCanvasId);
+                qPeakContextCanvasId = stageResources.getPeakContextCanvasId(q, qPeakContextCanvasId);
+
+                stagePairResult = stageMatcher.generateStageMatchesForPair(pFeatureContextCanvasId,
+                                                                           qFeatureContextCanvasId,
+                                                                           pPeakContextCanvasId,
+                                                                           qPeakContextCanvasId);
+            } else {
+                stagePairResult = stageMatcher.generateStartPositionOverlapResult(pFeatureContextCanvasId,
+                                                                                  qFeatureContextCanvasId,
+                                                                                  startPositionMatchWeight);
+            }
 
             multiStagePairResult.addStagePairResult(stagePairResult);
 

--- a/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatchPairCounts.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatchPairCounts.java
@@ -20,6 +20,7 @@ public class StageMatchPairCounts
     private long combinedPoorCoverage = 0;
     private long combinedPoorQuantity = 0;
     private long combinedSaved = 0;
+    private long startPositionSaved = 0;
 
     public long getTotalSaved() {
         return siftSaved + combinedSaved;
@@ -54,9 +55,13 @@ public class StageMatchPairCounts
         this.combinedSaved++;
     }
 
+    public void incrementStartPositionSaved() {
+        this.startPositionSaved++;
+    }
+
     public void logStats(final String stageName) {
         final int percentSaved = (int) ((getTotalSaved() / (double) getTotalProcessed()) * 100);
-        LOG.info("logStats: for stage {}, saved matches for {} out of {} pairs ({}%), siftPoorCoverage: {}, siftPoorQuantity: {}, siftSaved: {}, combinedPoorCoverage: {}, combinedPoorQuantity: {}, combinedSaved: {}, ",
+        LOG.info("logStats: for stage {}, saved matches for {} out of {} pairs ({}%), siftPoorCoverage: {}, siftPoorQuantity: {}, siftSaved: {}, combinedPoorCoverage: {}, combinedPoorQuantity: {}, combinedSaved: {}, startSaved: {},",
                  stageName,
                  getTotalSaved(),
                  getTotalProcessed(),
@@ -66,7 +71,8 @@ public class StageMatchPairCounts
                  siftSaved,
                  combinedPoorCoverage,
                  combinedPoorQuantity,
-                 combinedSaved);
+                 combinedSaved,
+                 startPositionSaved);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(StageMatchPairCounts.class);

--- a/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatcher.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatcher.java
@@ -1,5 +1,6 @@
 package org.janelia.alignment.match.stage;
 
+import java.awt.Rectangle;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,7 @@ import mpicbg.imglib.type.numeric.real.FloatType;
 import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 
+import org.janelia.alignment.match.CanvasId;
 import org.janelia.alignment.match.CanvasIdWithRenderContext;
 import org.janelia.alignment.match.CanvasMatchResult;
 import org.janelia.alignment.match.CanvasMatches;
@@ -240,6 +242,96 @@ public class StageMatcher {
         return stagePairResult;
     }
 
+    public PairResult generateStartPositionOverlapResult(final CanvasIdWithRenderContext pFeatureContextCanvasId,
+                                                         final CanvasIdWithRenderContext qFeatureContextCanvasId,
+                                                         final double matchWeight)
+            throws IllegalArgumentException {
+
+        final PairResult stagePairResult = new PairResult(this);
+
+        final String stageName = stageResources.getStageName();
+        final CanvasId pCanvasId = pFeatureContextCanvasId.getCanvasId();
+        final CanvasId qCanvasId = qFeatureContextCanvasId.getCanvasId();
+
+        LOG.info("generateStartPositionOverlapResult: build matches between {} and {} for stage {}",
+                 pCanvasId, qCanvasId, stageName);
+
+        final CanvasMatches startPositionMatches =
+                generateStartPositionOverlapMatches(pCanvasId,
+                                                    pFeatureContextCanvasId.getWorldBounds(),
+                                                    qCanvasId,
+                                                    qFeatureContextCanvasId.getWorldBounds(),
+                                                    matchWeight);
+
+        if (startPositionMatches != null) {
+            pairCounts.incrementStartPositionSaved();
+            stagePairResult.addCanvasMatches(startPositionMatches);
+        }
+
+        LOG.info("generateStartPositionOverlapResult: exit, returning list with {} element(s) for pair {} and {} in stage {}",
+                 stagePairResult.size(),
+                 pCanvasId,
+                 qCanvasId,
+                 stageName);
+
+        return stagePairResult;
+    }
+
+    public static CanvasMatches generateStartPositionOverlapMatches(final CanvasId pCanvasId,
+                                                                    final Rectangle pWorldBounds,
+                                                                    final CanvasId qCanvasId,
+                                                                    final Rectangle qWorldBounds,
+                                                                    final double matchWeight)
+            throws IllegalArgumentException {
+
+        CanvasMatches startPositionOverlapMatches = null;
+
+        final Rectangle worldOverlap = pWorldBounds.intersection(qWorldBounds);
+
+        if (worldOverlap.isEmpty()) {
+            LOG.info("generateStartPositionOverlapMatches: returning null since there is no overlap between {} and {}",
+                     pCanvasId, qCanvasId);
+        } else {
+
+            final double[][] worldOverlapPoints = new double[][]{
+                    {worldOverlap.x, worldOverlap.y},
+                    {worldOverlap.x + worldOverlap.width, worldOverlap.y},
+                    {worldOverlap.x + worldOverlap.width, worldOverlap.y + worldOverlap.height},
+                    {worldOverlap.x, worldOverlap.y + worldOverlap.height}
+            };
+
+            final int numberOfMatchPoints = 4;
+
+            final double[][] pMatches = new double[2][numberOfMatchPoints];
+            final double[][] qMatches = new double[2][numberOfMatchPoints];
+
+            final double[] matchWeightList = new double[numberOfMatchPoints];
+            Arrays.fill(matchWeightList, matchWeight);
+
+            for (int i = 0; i < numberOfMatchPoints; i++) {
+                final double[] worldOverlapCorner = worldOverlapPoints[i];
+                pMatches[0][i] = worldOverlapCorner[0] - pWorldBounds.x;
+                pMatches[1][i] = worldOverlapCorner[1] - pWorldBounds.y;
+                qMatches[0][i] = worldOverlapCorner[0] - qWorldBounds.x;
+                qMatches[1][i] = worldOverlapCorner[1] - qWorldBounds.y;
+            }
+
+            // constructor normalizes the p/q order so they will be flipped if necessary
+            startPositionOverlapMatches = new CanvasMatches(pCanvasId.getGroupId(),
+                                                            pCanvasId.getId(),
+                                                            qCanvasId.getGroupId(),
+                                                            qCanvasId.getId(),
+                                                            new Matches(pMatches,
+                                                                        qMatches,
+                                                                        matchWeightList));
+
+            LOG.info("generateStartPositionOverlapMatches: returning {} match points since overlap between {} and {} is {}",
+                     numberOfMatchPoints, pCanvasId, qCanvasId, worldOverlap);
+        }
+
+        return startPositionOverlapMatches;
+    }
+
     private void appendGeometricMatchesIfNecessary(final StageMatchingResources stageResources,
                                                    final CachedCanvasFeatures pCanvasFeatures,
                                                    final CachedCanvasFeatures qCanvasFeatures,
@@ -367,7 +459,7 @@ public class StageMatcher {
         final List<PointMatch> siftScaledInliers = siftMatchResult.getInlierPointMatchList();
 
         CanvasMatches combinedCanvasMatches = null;
-        if (siftScaledInliers.size() > 0) {
+        if (! siftScaledInliers.isEmpty()) {
 
             final List<Point> pInlierPoints = new ArrayList<>();
             final List<Point> qInlierPoints = new ArrayList<>();

--- a/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatchingResources.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/stage/StageMatchingResources.java
@@ -139,6 +139,10 @@ public class StageMatchingResources
         return stageParameters.getStageName();
     }
 
+    public Double getStartPositionMatchWeight() {
+        return stageParameters.getStartPositionMatchWeight();
+    }
+
     public FeatureRenderParameters getFeatureRender() {
         return stageParameters.getFeatureRender();
     }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVPositionPairMatchData.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVPositionPairMatchData.java
@@ -21,6 +21,7 @@ import org.janelia.alignment.match.CanvasId;
 import org.janelia.alignment.match.CanvasMatches;
 import org.janelia.alignment.match.Matches;
 import org.janelia.alignment.match.OrderedCanvasIdPair;
+import org.janelia.alignment.match.stage.StageMatcher;
 import org.janelia.alignment.multisem.MultiSemUtilities;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.render.client.RenderDataClient;
@@ -90,12 +91,6 @@ public class MFOVPositionPairMatchData
         if (sameLayerPair != null) {
             this.groupIdToSameLayerPairForPosition.put(sameLayerPair.getP().getGroupId(), sameLayerPair);
         }
-    }
-
-    public Set<OrderedCanvasIdPair> getConnectedPairsForPosition() {
-        return allPairsForPosition.stream()
-                .filter(p -> ! unconnectedPairsForPosition.contains(p))
-                .collect(Collectors.toSet());
     }
 
     @Override
@@ -328,12 +323,7 @@ public class MFOVPositionPairMatchData
 
         LOG.info("deriveMatchesUsingStartPositions: entry, {}", this);
 
-        final int numberOfMatchPoints = 4;
-        final double[] derivedWeightList = new double[numberOfMatchPoints];
-        Arrays.fill(derivedWeightList, derivedMatchWeight);
-
         for (final OrderedCanvasIdPair pair : unconnectedPairsAtStart) {
-
             final CanvasId p = pair.getP();
             final TileSpec pTileSpec = idToTileSpec.get(p.getId());
             final Rectangle pWorldBounds = pTileSpec.toTileBounds().toRectangle();
@@ -342,40 +332,12 @@ public class MFOVPositionPairMatchData
             final TileSpec qTileSpec = idToTileSpec.get(q.getId());
             final Rectangle qWorldBounds = qTileSpec.toTileBounds().toRectangle();
 
-            final Rectangle worldOverlap = pWorldBounds.intersection(qWorldBounds);
-            LOG.info("deriveMatchesUsingStartPositions: overlap between {} and {} is {}",
-                     pTileSpec.getTileId(), qTileSpec.getTileId(), worldOverlap);
-
-            if (worldOverlap.height <= 0 || worldOverlap.width <= 0) {
-                throw new IOException("no overlap between " + pTileSpec.getTileId() + " and " + qTileSpec.getTileId());
-            }
-
-            final double[][] worldOverlapPoints = new double[][] {
-                    { worldOverlap.x, worldOverlap.y },
-                    { worldOverlap.x + worldOverlap.width, worldOverlap.y },
-                    { worldOverlap.x + worldOverlap.width, worldOverlap.y + worldOverlap.height },
-                    { worldOverlap.x, worldOverlap.y + worldOverlap.height }
-            };
-
-            final double[][] pMatches = new double[2][numberOfMatchPoints];
-            final double[][] qMatches = new double[2][numberOfMatchPoints];
-
-            for (int i = 0; i < numberOfMatchPoints; i++) {
-                final double[] worldOverlapCorner = worldOverlapPoints[i];
-                pMatches[0][i] = worldOverlapCorner[0] - pWorldBounds.x;
-                pMatches[1][i] = worldOverlapCorner[1] - pWorldBounds.y;
-                qMatches[0][i] = worldOverlapCorner[0] - qWorldBounds.x;
-                qMatches[1][i] = worldOverlapCorner[1] - qWorldBounds.y;
-            }
-
-            // constructor normalizes the p/q order so they will be flipped if necessary
-            final CanvasMatches startPositionMatches = new CanvasMatches(p.getGroupId(),
-                                                                         p.getId(),
-                                                                         q.getGroupId(),
-                                                                         q.getId(),
-                                                                         new Matches(pMatches,
-                                                                                     qMatches,
-                                                                                     derivedWeightList));
+            final CanvasMatches startPositionMatches =
+                    StageMatcher.generateStartPositionOverlapMatches(p,
+                                                                     pWorldBounds,
+                                                                     q,
+                                                                     qWorldBounds,
+                                                                     derivedMatchWeight);
             derivedMatchesList.add(startPositionMatches);
         }
 


### PR DESCRIPTION
Move core start position overlap match generation logic from MFOVPositionMatchPairData to the StageMatcher so that the start position matches can be generated as a "last stage" of a montage matching pass instead of adding them in a later match "patch" process.  This ensures that matches are generated for all potential tile pairs. The prior MFOV-based patch approach cannot create start position matches across MFOVs. If a stack has MFOVs that only contain resin/substrate SFOVs, that approach leaves multiple small clusters of connected tiles separated from the primary tile cluster ... which ultimately breaks the alignment solve process.