### PR TITLE
newsolver_add_retry_to_imagej_load_process_attempt_b

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/ImageAndMask.java
+++ b/render-app/src/main/java/org/janelia/alignment/ImageAndMask.java
@@ -95,6 +95,18 @@ public class ImageAndMask implements Serializable {
                                 this.maskSliceNumber);
     }
 
+    public ImageAndMask copyWithDerivedUrls(final String derivedImageUrl,
+                                            final LoaderType changedImageLoaderType,
+                                            final Integer changedImageSliceNumber,
+                                            final String derivedMaskUrl) {
+        return new ImageAndMask(derivedImageUrl,
+                                changedImageLoaderType,
+                                changedImageSliceNumber,
+                                derivedMaskUrl,
+                                this.maskLoaderType,
+                                this.maskSliceNumber);
+    }
+
     public ImageAndMask copyWithoutMask() {
         return copyWithMask(null, null, null);
     }

--- a/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoader.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoader.java
@@ -28,6 +28,9 @@ public class ImageJDefaultLoader
     /** Shareable instance of this loader. */
     public static final ImageJDefaultLoader INSTANCE = new ImageJDefaultLoader();
 
+    /** The maximum number of retries for each load. */
+    public static int DEFAULT_MAX_RETRIES = 3;
+
     /**
      * @return true (always) because the default ImageJ loader handles 2D sources.
      */
@@ -38,21 +41,36 @@ public class ImageJDefaultLoader
 
     public ImageProcessor load(final String urlString)
             throws IllegalArgumentException {
-        return loadWithRetries(urlString, 0).getProcessor();
+        return loadImagePlus(urlString, 0, DEFAULT_MAX_RETRIES, true).getProcessor();
     }
 
-    private ImagePlus loadWithRetries(final String urlString,
-                                      final int retryNumber)
+    /**
+     * Loads an imagePlus from the specified URL and potentially retries failed loads.
+     *
+     * @param  urlString      the URL of the image to load.
+     * @param  retryNumber    number of the current retry (0 for the first load).
+     * @param  maxRetries     maximum number of times to retry a failed load.
+     * @param  retryAsNeeded  true indicates that failed load retries should be handled by this method and
+     *                        false indicates that the caller will handle retries.
+     *
+     * @return ImagePlus instance for the specified URL.
+     *
+     * @throws IllegalArgumentException
+     *   if the imagePlus cannot be created for any reason.
+     */
+    protected ImagePlus loadImagePlus(final String urlString,
+                                      final int retryNumber,
+                                      final int maxRetries,
+                                      final boolean retryAsNeeded)
             throws IllegalArgumentException {
 
-        final int maxRetries = 3;
         final int nextRetryNumber = retryNumber + 1;
 
         if (retryNumber > 0) {
             try {
                 Thread.sleep(getRetrySleepSeconds(retryNumber) * 1000L);
             } catch (final Throwable t) {
-                LOG.warn("loadWithRetries: exception thrown while sleeping before retry, continuing with retry now ", t);
+                LOG.info("loadImagePlus: exception thrown while sleeping before retry, continuing with retry now ", t);
             }
         } else if (retryNumber < 0) {
             throw new IllegalArgumentException("retryNumber '" + retryNumber + "' must be greater than or equal to 0");
@@ -104,10 +122,18 @@ public class ImageJDefaultLoader
 
         } catch (final Throwable t) {
             if (nextRetryNumber <= maxRetries) {
-                LOG.warn("loadWithRetries: failed to load {}, will run retry number {} of {} in {} seconds",
-                         urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber), t);
-                imagePlus = loadWithRetries(urlString,
-                                            nextRetryNumber);
+                if (retryAsNeeded) {
+                    LOG.info("loadImagePlus: failed to load {}, will run retry number {} of {} in {} seconds",
+                             urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber), t);
+                    imagePlus = loadImagePlus(urlString,
+                                              nextRetryNumber,
+                                              maxRetries,
+                                              true);
+                } else {
+                    LOG.info("loadImagePlus: failed to load {} on retry number {} of {}",
+                             urlString, retryNumber, maxRetries, t);
+                    imagePlus = null;
+                }
             } else {
                 throw new IllegalArgumentException(
                         getErrorMessage(urlString) + " after " + retryNumber + " retries",
@@ -117,10 +143,17 @@ public class ImageJDefaultLoader
 
         if (imagePlus == null) {
             if (nextRetryNumber <= maxRetries) {
-                LOG.warn("loadWithRetries: null imagePlus for {}, will run retry number {} of {} in {} seconds",
-                         urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber));
-                imagePlus = loadWithRetries(urlString,
-                                            nextRetryNumber);
+                if (retryAsNeeded) {
+                    LOG.info("loadImagePlus: null imagePlus for {}, will run retry number {} of {} in {} seconds",
+                             urlString, nextRetryNumber, maxRetries, getRetrySleepSeconds(nextRetryNumber));
+                    imagePlus = loadImagePlus(urlString,
+                                              nextRetryNumber,
+                                              maxRetries,
+                                              true);
+                } else {
+                    LOG.info("loadImagePlus: null imagePlus for {} on retry number {} of {}",
+                             urlString, retryNumber, maxRetries);
+                }
             } else {
                 throw new IllegalArgumentException(
                         getErrorMessage(urlString) + " (null imagePlus) after " + retryNumber + " retries");

--- a/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoaderWithTimeout.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoaderWithTimeout.java
@@ -1,0 +1,72 @@
+package org.janelia.alignment.loader;
+
+import ij.ImagePlus;
+import ij.process.ImageProcessor;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension of {@link ImageJDefaultLoader} that wraps each load in
+ * a Thread that will time out after {@link #TIMEOUT_SECONDS} seconds.
+ */
+public class ImageJDefaultLoaderWithTimeout
+        extends ImageJDefaultLoader {
+
+    /** Shareable instance of this loader. */
+    public static final ImageJDefaultLoaderWithTimeout INSTANCE = new ImageJDefaultLoaderWithTimeout();
+
+    public ImageProcessor load(final String urlString)
+            throws IllegalArgumentException {
+
+        ImagePlus imagePlus = null;
+        for (int retryNumber = 0; retryNumber <= DEFAULT_MAX_RETRIES; retryNumber++) {
+            imagePlus = loadImagePlusWithTimedThread(urlString, retryNumber, DEFAULT_MAX_RETRIES);
+            if (imagePlus != null) {
+                break;
+            }
+        }
+
+        if (imagePlus == null) {
+            throw new IllegalArgumentException("failed to load image from " + urlString);
+        }
+
+        return imagePlus.getProcessor();
+    }
+
+    private ImagePlus loadImagePlusWithTimedThread(final String urlString,
+                                                   final int retryNumber,
+                                                   final int maxRetries) {
+        ImagePlus imagePlus = null;
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Future<ImagePlus> future =
+                executor.submit(() -> super.loadImagePlus(urlString,
+                                                          retryNumber,
+                                                          maxRetries,
+                                                          false));
+        try {
+            imagePlus = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (final TimeoutException t) {
+            future.cancel(true);
+            LOG.info("loadImagePlusWithTimedThread: load of {} timed-out for retry number {} of {}",
+                     urlString, retryNumber, maxRetries);
+        } catch (final Throwable t) {
+            LOG.info("loadImagePlusWithTimedThread: load of {} failed for retry number {} of {} with exception",
+                     urlString, retryNumber, maxRetries, t);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        return imagePlus;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImageJDefaultLoaderWithTimeout.class);
+
+    private static final int TIMEOUT_SECONDS = 45;
+}

--- a/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoaderWithTimeout.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/ImageJDefaultLoaderWithTimeout.java
@@ -44,6 +44,8 @@ public class ImageJDefaultLoaderWithTimeout
                                                    final int retryNumber,
                                                    final int maxRetries) {
         ImagePlus imagePlus = null;
+
+        // TODO: consider using a shared Executors.newCachedThreadPool
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         final Future<ImagePlus> future =
                 executor.submit(() -> super.loadImagePlus(urlString,

--- a/render-app/src/main/java/org/janelia/alignment/loader/ImageLoader.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/ImageLoader.java
@@ -11,7 +11,7 @@ import ij.process.ImageProcessor;
 public interface ImageLoader {
 
     enum LoaderType {
-        IMAGEJ_DEFAULT, IMAGEJ_TIFF_STACK, H5_SLICE, N5_SLICE, IMAGEJ_COMPOSITE, DYNAMIC_MASK
+        IMAGEJ_DEFAULT, IMAGEJ_DEFAULT_W_TIMEOUT, IMAGEJ_TIFF_STACK, H5_SLICE, N5_SLICE, IMAGEJ_COMPOSITE, DYNAMIC_MASK
     }
 
     boolean hasSame3DContext(final ImageLoader otherLoader);
@@ -34,6 +34,10 @@ public interface ImageLoader {
             switch (loaderType) {
 
                 case IMAGEJ_DEFAULT:
+                    break;
+
+                case IMAGEJ_DEFAULT_W_TIMEOUT:
+                    imageLoader = ImageJDefaultLoaderWithTimeout.INSTANCE;
                     break;
 
                 case IMAGEJ_TIFF_STACK:

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/HackImageUrlPathClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/HackImageUrlPathClient.java
@@ -10,6 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.loader.ImageLoader;
 import org.janelia.alignment.spec.ChannelSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
@@ -107,13 +108,13 @@ public class HackImageUrlPathClient {
     private final RenderDataClient renderDataClient;
     private final UnaryOperator<String> pathTransformation;
 
-    private HackImageUrlPathClient(final Parameters parameters, final UnaryOperator<String> pathTransformation) {
+    public HackImageUrlPathClient(final Parameters parameters, final UnaryOperator<String> pathTransformation) {
         this.parameters = parameters;
         this.renderDataClient = parameters.renderWeb.getDataClient();
         this.pathTransformation = pathTransformation;
     }
 
-    private void fixStackData() throws Exception {
+    public void fixStackData() throws Exception {
         final StackMetaData fromStackMetaData = renderDataClient.getStackMetaData(parameters.stack);
 
         // remove mipmap path builder if it is defined since we did not generate mipmaps for the hacked source images
@@ -161,8 +162,17 @@ public class HackImageUrlPathClient {
                 derivedImageUrl = transformedUrl;
             }
 
-            final ImageAndMask hackedImageAndMask = sourceImageAndMask.copyWithDerivedUrls(derivedImageUrl,
-                                                                                           sourceImageAndMask.getMaskUrl());
+            final ImageAndMask hackedImageAndMask;
+            if (transformedUrl.startsWith("https://storage.googleapis.com/")) {
+                hackedImageAndMask = sourceImageAndMask.copyWithDerivedUrls(derivedImageUrl,
+                                                                            ImageLoader.LoaderType.IMAGEJ_DEFAULT_W_TIMEOUT,
+                                                                            sourceImageAndMask.getImageSliceNumber(),
+                                                                            sourceImageAndMask.getMaskUrl());
+            } else {
+                hackedImageAndMask = sourceImageAndMask.copyWithDerivedUrls(derivedImageUrl,
+                                                                            sourceImageAndMask.getMaskUrl());
+            }
+
             channelSpec.putMipmap(zeroLevelKey, hackedImageAndMask);
         }
     }

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/HackImageUrlPathClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/multisem/HackImageUrlPathClientTest.java
@@ -1,5 +1,7 @@
 package org.janelia.render.client.multisem;
 
+import java.util.function.UnaryOperator;
+
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.junit.Test;
 
@@ -14,15 +16,55 @@ public class HackImageUrlPathClientTest {
     }
 
     public static void main(final String[] args) {
+
+//        final String[] effectiveArgs = {
+//                "--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
+//                "--owner", "hess_wafers_60_61",
+//                "--project", "w60_serial_360_to_369",
+//                "--stack", "w60_s360_r00_d30",
+//                "--targetStack", "w60_s360_r00_d30_gc",
+//                "--transformationType", "GOOGLE_CLOUD_WAFER_60"
+//        };
+//         HackImageUrlPathClient.main(effectiveArgs);
+
+        for (int serialNumber = 360; serialNumber < 370; serialNumber++) {
+            final String stack = String.format("w60_s%d_r00_d30", serialNumber);
+            createGoogleCloudStackWithTimeoutLoader("hess_wafers_60_61",
+                                                    "w60_serial_360_to_369",
+                                                    stack,
+                                                    "_gc_timeout");
+        }
+
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void createGoogleCloudStackWithTimeoutLoader(final String owner,
+                                                                final String project,
+                                                                final String stack,
+                                                                final String targetStackSuffix) {
+
         final String[] effectiveArgs = {
                 "--baseDataUrl", "http://renderer-dev.int.janelia.org:8080/render-ws/v1",
-                "--owner", "hess_wafers_60_61",
-                "--project", "w60_serial_360_to_369",
-                "--stack", "w60_s360_r00_d30",
-                "--targetStack", "w60_s360_r00_d30_gc",
+                "--owner", owner,
+                "--project", project,
+                "--stack", stack,
+                "--targetStack", stack + targetStackSuffix,
                 "--transformationType", "GOOGLE_CLOUD_WAFER_60"
         };
 
-        HackImageUrlPathClient.main(effectiveArgs);
+        final HackImageUrlPathClient.Parameters parameters = new HackImageUrlPathClient.Parameters();
+        parameters.parse(effectiveArgs);
+
+        final UnaryOperator<String> pathTransformation =
+                HackImageUrlPathClient.PathTransformationType.GOOGLE_CLOUD_WAFER_60.getOperator();
+        final HackImageUrlPathClient client = new HackImageUrlPathClient(parameters, pathTransformation);
+
+        try {
+            client.fixStackData();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+
     }
+
 }


### PR DESCRIPTION
Add ImageJDefaultLoaderWithTimeout implementation coupled with new IMAGEJ_DEFAULT_W_TIMEOUT LoaderType that wraps each load in a Thread that will time out after 45 seconds.