### PR TITLE
Streak correction plugin

### DIFF
--- a/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/destreak/ConfigurableStreakCorrectorTest.java
@@ -3,12 +3,8 @@ package org.janelia.alignment.destreak;
 import ij.ImageJ;
 import ij.ImagePlus;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import ij.plugin.ImagesToStack;
 import org.janelia.alignment.filter.FilterSpec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -147,102 +143,19 @@ public class ConfigurableStreakCorrectorTest {
         final String srcPath = "/Users/trautmane/Desktop/cellmap_cosem/jrc_hum-airway-14953vc/raw-images/" +
                                HUM_AIRWAY_FILE_NAMES[0]; // change file names index to test different images
 
-        final Map<String, Double> parameters = new HashMap<>();
-        parameters.put("numThreads", 12.0);
-        parameters.put("fftWidth", 5545.0);
-        parameters.put("fftHeight", 10920.0);
-        parameters.put("innerCutoff", 18.0);
-        parameters.put("bandWidth", 8.0);
-        parameters.put("angle", 0.0);
-        parameters.put("gaussianBlurRadius", 20.0);
-        parameters.put("initialThreshold", 7.0);
-        parameters.put("finalThreshold", 0.05);
-
-        // this shows the effect of varying the parameters on the correction process (symmetrically around the value set above)
-        // a good strategy for finding a good parameter set is to start with the actual correction parameters "innerCutoff" and "bandWidth"
-        // once good parameters for correction are found, the locality of correction can be adjusted by varying "gaussianBlurRadius",
-        // "initialThreshold" and "finalThreshold"; the angle only needs to be adjusted if the streaks are not vertical
-        displayParameterRange(srcPath, parameters, "innerCutoff", 3.0, 3, false);
-        displayParameterRange(srcPath, parameters, "bandWidth", 2.0, 3, false);
-        // displayParameterRange(srcPath, parameters, "angle", 0.0, 1.0, 3, false);
-        displayParameterRange(srcPath, parameters, "gaussianBlurRadius", 3.0, 3, true);
-        displayParameterRange(srcPath, parameters, "initialThreshold", 1.0, 3, true);
-        displayParameterRange(srcPath, parameters, "finalThreshold", 0.01, 3, true);
-
-        // this shows the final result of the correction process as well as the end result
-        displayParameterRange(srcPath, parameters, "numThreads", 1.0, 0, true);
         final ImagePlus imp = new ImagePlus(srcPath);
         imp.setTitle("Original");
         imp.show();
         // displayStreakCorrectionDetails(srcPath, HUM_AIRWAY_CORRECTOR);
-    }
 
-    /**
-     * Displays a range of parameter values for a given parameter. The parameter values are centered around the midpoint
-     * (the pre-set parameter value) and steps are taken in both directions from the midpoint. The results are displayed
-     * in a stack.
-     *
-     * @param srcPath the path to the source image.
-     * @param parameters a map of parameters for both {@link SmoothMaskStreakCorrector} and {@link LocalSmoothMaskStreakCorrector}.
-     * @param parameterToVary the name of the parameter to vary.
-     * @param stepsize the size of the steps to take in both directions from the midpoint.
-     * @param steps the number of steps to take in both directions from the midpoint.
-     * @param localizeCorrection whether to use {@link LocalSmoothMaskStreakCorrector} or not.
-     */
-    private static void displayParameterRange(
-            final String srcPath,
-            final Map<String, Double> parameters,
-            final String parameterToVary,
-            final double stepsize,
-            final int steps,
-            final boolean localizeCorrection) {
-
-        final int n = 2 * steps + 1;
-        final List<ImagePlus> images = new ArrayList<>(n);
-        final double midpoint = parameters.get(parameterToVary);
-        final double start = midpoint - steps * stepsize;
-        final double end = midpoint + steps * stepsize;
-        for (double val = start; val <= end; val += stepsize) {
-            parameters.put(parameterToVary, val);
-            final SmoothMaskStreakCorrector globalCorrector = new SmoothMaskStreakCorrector(
-                    parameters.get("numThreads").intValue(),
-                    parameters.get("fftWidth").intValue(),
-                    parameters.get("fftHeight").intValue(),
-                    parameters.get("innerCutoff").intValue(),
-                    parameters.get("bandWidth").intValue(),
-                    parameters.get("angle"));
-
-            final ImagePlus result;
-            if (localizeCorrection) {
-                final StreakCorrector corrector = new LocalSmoothMaskStreakCorrector(
-                        globalCorrector,
-                        parameters.get("gaussianBlurRadius").intValue(),
-                        parameters.get("initialThreshold").floatValue(),
-                        parameters.get("finalThreshold").floatValue());
-                result = computeStreakCorrectionResult(srcPath, corrector);
-            } else {
-                final StreakCorrector corrector = new LocalSmoothMaskStreakCorrector(
-                        globalCorrector,
-                        parameters.get("gaussianBlurRadius").intValue(),
-                        parameters.get("initialThreshold").floatValue(),
-                        parameters.get("finalThreshold").floatValue());
-                result = computeStreakCorrectionResult(srcPath, corrector);
-            }
-            images.add(result);
-        }
-
-        final ImagePlus stack = ImagesToStack.run(images.toArray(new ImagePlus[0]));
-        stack.setTitle("Varying " + parameterToVary);
-        stack.show();
-
-        parameters.put(parameterToVary, midpoint);
-    }
-
-    private static ImagePlus computeStreakCorrectionResult(final String srcPath, final StreakCorrector corrector) {
-        final ImagePlus imp = new ImagePlus(srcPath);
-        corrector.process(imp.getProcessor(), 1.0);
-        imp.setTitle(corrector.toParametersMap().toString());
-        return imp;
+        final SmoothMaskStreakCorrector globalCorrector = new SmoothMaskStreakCorrector(8, 5545,
+                10920, 18, 8, 0.0);
+        final StreakCorrector corrector = new LocalSmoothMaskStreakCorrector(
+                globalCorrector, 20, 7, 0.05f);
+        final ImagePlus corrected = new ImagePlus(srcPath);
+        corrector.process(corrected.getProcessor(), 1.0);
+        corrected.setTitle(corrector.toParametersMap().toString());
+        corrected.show();
     }
 
     // this shows all steps of the correction process

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -12,6 +12,7 @@ import ij.plugin.ImagesToStack;
 import ij.plugin.PlugIn;
 import ij.process.ImageProcessor;
 import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.destreak.LocalSmoothMaskStreakCorrector;
 import org.janelia.alignment.destreak.SmoothMaskStreakCorrector;
 import org.janelia.alignment.destreak.StreakCorrector;
 import org.janelia.alignment.spec.ChannelSpec;
@@ -29,6 +30,7 @@ import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class StreakCorrection_Plugin implements PlugIn {
@@ -51,9 +53,9 @@ public class StreakCorrection_Plugin implements PlugIn {
 		public int tileNumber = 0;
 	}
 
-	private static StreakCorrectionParameters defaultParameters = new StreakCorrectionParameters();
-	private static VariationParameters defaultVariationParameters = new VariationParameters();
-	private static String[] parameterChoices = new String[] { "None", "innerCutoff", "bandWidth", "angle",
+	private static final StreakCorrectionParameters defaultParameters = new StreakCorrectionParameters();
+	private static final VariationParameters defaultVariationParameters = new VariationParameters();
+	private static final String[] parameterChoices = new String[] { "None", "innerCutoff", "bandWidth", "angle",
 			"gaussianBlurRadius", "initialThreshold", "finalThreshold" };
 
 
@@ -96,7 +98,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 		}
 
 		try {
-			correctImage(defaultParameters, defaultVariationParameters);
+			correctImage();
 		} catch (final Exception e) {
 			IJ.log("Streak correction failed: " + e.getMessage());
 		}
@@ -122,7 +124,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 		if (rtsc == null) {
 			throw new IOException("Failed to load tile specs for " + params.stack + " z=" + params.z);
 		}
-		final TileSpec tileSpec = rtsc.getTileSpecs().stream().sorted().findFirst().orElseThrow();
+		final TileSpec tileSpec = rtsc.getTileSpecs().stream().sorted().collect(Collectors.toList()).get(params.tileNumber);
 		IJ.log("Show tile: " + tileSpec.getTileId() + " from z=" + params.z);
 
 		final ImageProcessorCache cache = ImageProcessorCache.DISABLED_CACHE;
@@ -133,29 +135,26 @@ public class StreakCorrection_Plugin implements PlugIn {
 		return new ImagePlus(tileSpec.getTileId(), ip);
 	}
 
-	private static void correctImage(
-			final StreakCorrectionParameters streakParameters,
-			final VariationParameters variationParameters
-	) {
+	private static void correctImage() {
 		final ImagePlus img = IJ.getImage();
 		final int width = img.getWidth();
 		final int height = img.getHeight();
-		IJ.log("Filter data string: " + streakParameters.filterDataString(width, height));
+		IJ.log("Filter data string: " + defaultParameters.filterDataString(width, height));
 
 
-		final String parameterToVary = parameterChoices[variationParameters.parameterIndex];
+		final String parameterToVary = parameterChoices[defaultVariationParameters.parameterIndex];
 		if (parameterToVary.equals("None")) {
-			final StreakCorrector corrector = streakParameters.getCorrector(width, height);
+			final StreakCorrector corrector = defaultParameters.getCorrector(width, height);
 			final ImagePlus corrected = new ImagePlus("Corrected", img.getProcessor().duplicate());
 			corrector.process(corrected.getProcessor(), 1.0);
 			corrected.show();
 		} else {
-			final int nSteps = variationParameters.nSteps;
+			final int nSteps = defaultVariationParameters.nSteps;
 			final List<ImagePlus> correctedImages = new ArrayList<>(2 * nSteps + 1);
 
 			for (int k = -nSteps; k <= nSteps; k++) {
-				final double increment = k * variationParameters.stepSize;
-				final StreakCorrectionParameters variedParameters = new StreakCorrectionParameters(streakParameters);
+				final double increment = k * defaultVariationParameters.stepSize;
+				final StreakCorrectionParameters variedParameters = new StreakCorrectionParameters(defaultParameters);
 				final double value = variedParameters.addToParameter(parameterToVary, increment);
 
 				final String title = parameterToVary + "=" + value;
@@ -216,7 +215,12 @@ public class StreakCorrection_Plugin implements PlugIn {
 			final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
 					Threads.numThreads() / 2, fftDims.width, fftDims.height, innerCutoff, bandWidth, angle);
 
-			return corrector;
+			if (localize) {
+				return new LocalSmoothMaskStreakCorrector(
+						corrector, gaussianBlurRadius, (float) initialThreshold, (float) finalThreshold);
+			} else {
+				return corrector;
+			}
 		}
 
 		private static ImageDims getFftDimensions(final int width, final int height) {
@@ -229,7 +233,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 		}
 
 		public double addToParameter(final String parameter, final double increment) {
-			double newValue = 0.0;
+			final double newValue;
 			switch (parameter) {
 				case "innerCutoff":
 					innerCutoff = (int) (innerCutoff + increment);
@@ -275,8 +279,10 @@ public class StreakCorrection_Plugin implements PlugIn {
 
 		public String filterDataString(final int width, final int height) {
 			final ImageDims fftDims = getFftDimensions(width, height);
-			return fftDims.width + "," + fftDims.height + "," + innerCutoff + "," + bandWidth + "," + angle
+			final String method = localize ? "LocalSmoothMaskStreakCorrector" : "SmoothMaskStreakCorrector";
+			final String parameters = fftDims.width + "," + fftDims.height + "," + innerCutoff + "," + bandWidth + "," + angle
 					+ "," + gaussianBlurRadius + "," + initialThreshold + "," + finalThreshold;
+			return "method=" + method + " data=" + parameters;
 		}
 	}
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -33,6 +33,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 
+/**
+ * ImageJ plugin to facilitate manual exploration of streak correction parameters.
+ * Run this from the command line with parameters according to the documentation and press F1 to open the GUI
+ * to specify parameters and run the streak correction.
+ */
 public class StreakCorrection_Plugin implements PlugIn {
 
 	private static class Parameters extends CommandLineParameters {
@@ -61,7 +66,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 
 	@Override
 	public void run(final String arg) {
-		final GenericDialog dialog = new GenericDialog("Fit shading correction");
+		final GenericDialog dialog = new GenericDialog("Streak correction");
 
 		dialog.addMessage("Streak correction parameters");
 		dialog.addNumericField("Inner cutoff", defaultParameters.innerCutoff);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -1,0 +1,102 @@
+package org.janelia.render.client.destreak;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+import ij.IJ;
+import ij.ImageJ;
+import ij.ImagePlus;
+import ij.plugin.PlugIn;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.spec.ChannelSpec;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.util.ImageProcessorCache;
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.emshading.ShadingCorrection_Plugin;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.SwingUtilities;
+import java.awt.KeyboardFocusManager;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+
+
+public class StreakCorrection_Plugin implements PlugIn {
+
+	private static final Logger LOG = LoggerFactory.getLogger(StreakCorrection_Plugin.class);
+
+	private static class Parameters extends CommandLineParameters {
+		@ParametersDelegate
+		public RenderWebServiceParameters renderWebService = new RenderWebServiceParameters();
+
+		@Parameter(names = "--stack",
+				description = "Name of the stack in the render project",
+				required = true)
+		public String stack;
+
+		@Parameter(names = "--z",
+				description = "Z slice to process")
+		public int z = 1;
+
+		@Parameter(names = "--tileNumber",
+				description = "Number of tile to process (alphabetical order)")
+		public int tileNumber = 0;
+	}
+
+	@Override
+	public void run(final String arg) {
+
+	}
+
+	private static void addKeyListener() {
+		System.out.println("Mapped 'Streak Correction' to F1.");
+
+		new Thread(() -> KeyboardFocusManager.getCurrentKeyboardFocusManager()
+				.addKeyEventDispatcher(e -> {
+					if (e.getID() == KeyEvent.KEY_PRESSED) {
+						if (e.getKeyCode() == KeyEvent.VK_F1) {
+							new ShadingCorrection_Plugin().run(null);
+						}
+					}
+					return false;
+				})
+		).start();
+	}
+
+	private static ImagePlus loadImage(final RenderDataClient client, final Parameters params) throws IOException {
+		final ResolvedTileSpecCollection rtsc = client.getResolvedTiles(params.stack, (double) params.z);
+		if (rtsc == null) {
+			throw new IOException("Failed to load tile specs for " + params.stack + " z=" + params.z);
+		}
+		final TileSpec tileSpec = rtsc.getTileSpecs().stream().sorted().findFirst().orElseThrow();
+		IJ.log("Show tile: " + tileSpec.getTileId() + " from z=" + params.z);
+
+		final ImageProcessorCache cache = ImageProcessorCache.DISABLED_CACHE;
+		final ChannelSpec firstChannel = tileSpec.getAllChannels().stream().findFirst().orElseThrow();
+		final ImageAndMask imageAndMask = firstChannel.getMipmap(0);
+		final ImageProcessor ip = cache.get(imageAndMask.getImageUrl(), 0, false, false, imageAndMask.getImageLoaderType(), null);
+		final FloatProcessor fip = ip.convertToFloatProcessor();
+
+		return new ImagePlus(tileSpec.getTileId(), fip);
+	}
+
+	public static void main(final String[] args) throws IOException {
+		final StreakCorrection_Plugin.Parameters params = new StreakCorrection_Plugin.Parameters();
+		params.parse(args);
+
+		new ImageJ();
+		SwingUtilities.invokeLater(StreakCorrection_Plugin::addKeyListener);
+
+		IJ.log("Opening " + params.renderWebService.owner + "/" + params.renderWebService.project + "/" + params.stack);
+
+		final RenderDataClient client = params.renderWebService.getDataClient();
+		final ImagePlus img = loadImage(client, params);
+
+		img.show();
+	}
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -8,6 +8,7 @@ import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
 import ij.gui.GenericDialog;
+import ij.plugin.ImagesToStack;
 import ij.plugin.PlugIn;
 import ij.process.ImageProcessor;
 import org.janelia.alignment.ImageAndMask;
@@ -26,6 +27,8 @@ import javax.swing.SwingUtilities;
 import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class StreakCorrection_Plugin implements PlugIn {
@@ -49,9 +52,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 	}
 
 	private static StreakCorrectionParameters defaultParameters = new StreakCorrectionParameters();
-	private static int nSteps = 3;
-	private static double stepSize = 1.0;
-	private static int defaultChoice = 0;
+	private static VariationParameters defaultVariationParameters = new VariationParameters();
 	private static String[] parameterChoices = new String[] { "None", "innerCutoff", "bandWidth", "angle",
 			"gaussianBlurRadius", "initialThreshold", "finalThreshold" };
 
@@ -72,31 +73,33 @@ public class StreakCorrection_Plugin implements PlugIn {
 		dialog.addNumericField("Final threshold", defaultParameters.finalThreshold);
 
 		dialog.addMessage("Parameter variation");
-		dialog.addChoice("Parameter to vary", parameterChoices, parameterChoices[defaultChoice]);
-		dialog.addNumericField("Step size", stepSize);
-		dialog.addNumericField("Number of steps", nSteps);
+		dialog.addChoice("Parameter to vary", parameterChoices, parameterChoices[defaultVariationParameters.parameterIndex]);
+		dialog.addNumericField("Number of steps", defaultVariationParameters.nSteps);
+		dialog.addNumericField("Step size", defaultVariationParameters.stepSize);
 
 		dialog.showDialog();
+
+		defaultParameters.innerCutoff = (int) dialog.getNextNumber();
+		defaultParameters.bandWidth = (int) dialog.getNextNumber();
+		defaultParameters.angle = dialog.getNextNumber();
+		defaultParameters.localize = dialog.getNextBoolean();
+		defaultParameters.gaussianBlurRadius = (int) dialog.getNextNumber();
+		defaultParameters.initialThreshold = dialog.getNextNumber();
+		defaultParameters.finalThreshold = dialog.getNextNumber();
+
+		defaultVariationParameters.parameterIndex = dialog.getNextChoiceIndex();
+		defaultVariationParameters.nSteps = (int) dialog.getNextNumber();
+		defaultVariationParameters.stepSize = dialog.getNextNumber();
 
 		if (dialog.wasCanceled()) {
 			return;
 		}
 
-		defaultParameters.setFromDialog(dialog);
-
-		final ImagePlus img = IJ.getImage();
-		final int width = img.getWidth();
-		final int height = img.getHeight();
-		final StreakCorrector corrector = defaultParameters.getCorrector(width, height);
-
 		try {
-			final ImagePlus corrected = new ImagePlus("Corrected", img.getProcessor().duplicate());
-			corrector.process(corrected.getProcessor(), 1.0);
-			corrected.show();
+			correctImage(defaultParameters, defaultVariationParameters);
 		} catch (final Exception e) {
 			IJ.log("Streak correction failed: " + e.getMessage());
 		}
-
 	}
 
 	private static void addKeyListener() {
@@ -129,6 +132,45 @@ public class StreakCorrection_Plugin implements PlugIn {
 
 		return new ImagePlus(tileSpec.getTileId(), ip);
 	}
+
+	private static void correctImage(
+			final StreakCorrectionParameters streakParameters,
+			final VariationParameters variationParameters
+	) {
+		final ImagePlus img = IJ.getImage();
+		final int width = img.getWidth();
+		final int height = img.getHeight();
+		IJ.log("Filter data string: " + streakParameters.filterDataString(width, height));
+
+
+		final String parameterToVary = parameterChoices[variationParameters.parameterIndex];
+		if (parameterToVary.equals("None")) {
+			final StreakCorrector corrector = streakParameters.getCorrector(width, height);
+			final ImagePlus corrected = new ImagePlus("Corrected", img.getProcessor().duplicate());
+			corrector.process(corrected.getProcessor(), 1.0);
+			corrected.show();
+		} else {
+			final int nSteps = variationParameters.nSteps;
+			final List<ImagePlus> correctedImages = new ArrayList<>(2 * nSteps + 1);
+
+			for (int k = -nSteps; k <= nSteps; k++) {
+				final double increment = k * variationParameters.stepSize;
+				final StreakCorrectionParameters variedParameters = new StreakCorrectionParameters(streakParameters);
+				final double value = variedParameters.addToParameter(parameterToVary, increment);
+
+				final String title = parameterToVary + "=" + value;
+				final StreakCorrector corrector = variedParameters.getCorrector(width, height);
+				final ImagePlus corrected = new ImagePlus(title, img.getProcessor().duplicate());
+				corrector.process(corrected.getProcessor(), 1.0);
+				correctedImages.add(corrected);
+			}
+
+			final ImagePlus stack = ImagesToStack.run(correctedImages.toArray(new ImagePlus[0]));
+			stack.setTitle("Varying " + parameterToVary);
+			stack.show();
+		}
+	}
+
 
 	public static void main(final String[] args) throws IOException {
 		final StreakCorrection_Plugin.Parameters params = new StreakCorrection_Plugin.Parameters();
@@ -170,26 +212,91 @@ public class StreakCorrection_Plugin implements PlugIn {
 		}
 
 		public StreakCorrector getCorrector(final int width, final int height) {
+			final ImageDims fftDims = getFftDimensions(width, height);
+			final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
+					Threads.numThreads() / 2, fftDims.width, fftDims.height, innerCutoff, bandWidth, angle);
+
+			return corrector;
+		}
+
+		private static ImageDims getFftDimensions(final int width, final int height) {
 			// The following computations are based on the original code in net.imglib2.algorithm.fft.FourierTransform
 			final int extendedWidth = width + Math.max(Math.round(1.25f * width) - width, 12);
 			final int extendedHeight = height + Math.max(Math.round(1.25f * height) - height, 12);
 			final int fftWidth = FftReal.nfftFast(extendedWidth) / 2 + 1;
 			final int fftHeight = FftComplex.nfftFast(extendedHeight);
-
-			final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
-					Threads.numThreads() / 2, fftWidth, fftHeight, innerCutoff, bandWidth, angle);
-
-			return corrector;
+			return new ImageDims(fftWidth, fftHeight);
 		}
 
-		public void setFromDialog(final GenericDialog dialog) {
-			innerCutoff = (int) dialog.getNextNumber();
-			bandWidth = (int) dialog.getNextNumber();
-			angle = dialog.getNextNumber();
-			localize = dialog.getNextBoolean();
-			gaussianBlurRadius = (int) dialog.getNextNumber();
-			initialThreshold = dialog.getNextNumber();
-			finalThreshold = dialog.getNextNumber();
+		public double addToParameter(final String parameter, final double increment) {
+			double newValue = 0.0;
+			switch (parameter) {
+				case "innerCutoff":
+					innerCutoff = (int) (innerCutoff + increment);
+					newValue = innerCutoff;
+					break;
+				case "bandWidth":
+					bandWidth = (int) (bandWidth + increment);
+					newValue = bandWidth;
+					break;
+				case "angle":
+					angle += increment;
+					newValue = angle;
+					break;
+				case "gaussianBlurRadius":
+					gaussianBlurRadius = (int) (gaussianBlurRadius + increment);
+					newValue = gaussianBlurRadius;
+					break;
+				case "initialThreshold":
+					initialThreshold = (int) (initialThreshold + increment);
+					newValue = initialThreshold;
+					break;
+				case "finalThreshold":
+					finalThreshold += increment;
+					newValue = finalThreshold;
+					break;
+				default:
+					throw new IllegalArgumentException("Unknown parameter: " + parameter);
+			}
+			return newValue;
+		}
+
+		public String toString() {
+			return "StreakCorrectionParameters{" +
+					"innerCutoff=" + innerCutoff +
+					", bandWidth=" + bandWidth +
+					", angle=" + angle +
+					", gaussianBlurRadius=" + gaussianBlurRadius +
+					", initialThreshold=" + initialThreshold +
+					", finalThreshold=" + finalThreshold +
+					", localize=" + localize +
+					'}';
+		}
+
+		public String filterDataString(final int width, final int height) {
+			final ImageDims fftDims = getFftDimensions(width, height);
+			return fftDims.width + "," + fftDims.height + "," + innerCutoff + "," + bandWidth + "," + angle
+					+ "," + gaussianBlurRadius + "," + initialThreshold + "," + finalThreshold;
+		}
+	}
+
+	private static class VariationParameters {
+		public int nSteps = 3;
+		public double stepSize = 1.0;
+		public int parameterIndex = 0;
+
+		public VariationParameters() {
+			// Default constructor
+		}
+	}
+
+	private static class ImageDims {
+		public int width;
+		public int height;
+
+		public ImageDims(final int width, final int height) {
+			this.width = width;
+			this.height = height;
 		}
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -7,21 +7,19 @@ import edu.mines.jtk.dsp.FftReal;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
+import ij.gui.GenericDialog;
 import ij.plugin.PlugIn;
-import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import org.janelia.alignment.ImageAndMask;
 import org.janelia.alignment.destreak.SmoothMaskStreakCorrector;
+import org.janelia.alignment.destreak.StreakCorrector;
 import org.janelia.alignment.spec.ChannelSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.emshading.ShadingCorrection_Plugin;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spim.Threads;
 
 import javax.swing.SwingUtilities;
@@ -50,8 +48,54 @@ public class StreakCorrection_Plugin implements PlugIn {
 		public int tileNumber = 0;
 	}
 
+	private static StreakCorrectionParameters defaultParameters = new StreakCorrectionParameters();
+	private static int nSteps = 3;
+	private static double stepSize = 1.0;
+	private static int defaultChoice = 0;
+	private static String[] parameterChoices = new String[] { "None", "innerCutoff", "bandWidth", "angle",
+			"gaussianBlurRadius", "initialThreshold", "finalThreshold" };
+
+
 	@Override
 	public void run(final String arg) {
+		final GenericDialog dialog = new GenericDialog("Fit shading correction");
+
+		dialog.addMessage("Streak correction parameters");
+		dialog.addNumericField("Inner cutoff", defaultParameters.innerCutoff);
+		dialog.addNumericField("Band width", defaultParameters.bandWidth);
+		dialog.addNumericField("Angle", defaultParameters.angle);
+
+		dialog.addMessage("Localization parameters");
+		dialog.addCheckbox("Localize correction", defaultParameters.localize);
+		dialog.addNumericField("Gaussian blur radius", defaultParameters.gaussianBlurRadius);
+		dialog.addNumericField("Initial threshold", defaultParameters.initialThreshold);
+		dialog.addNumericField("Final threshold", defaultParameters.finalThreshold);
+
+		dialog.addMessage("Parameter variation");
+		dialog.addChoice("Parameter to vary", parameterChoices, parameterChoices[defaultChoice]);
+		dialog.addNumericField("Step size", stepSize);
+		dialog.addNumericField("Number of steps", nSteps);
+
+		dialog.showDialog();
+
+		if (dialog.wasCanceled()) {
+			return;
+		}
+
+		defaultParameters.setFromDialog(dialog);
+
+		final ImagePlus img = IJ.getImage();
+		final int width = img.getWidth();
+		final int height = img.getHeight();
+		final StreakCorrector corrector = defaultParameters.getCorrector(width, height);
+
+		try {
+			final ImagePlus corrected = new ImagePlus("Corrected", img.getProcessor().duplicate());
+			corrector.process(corrected.getProcessor(), 1.0);
+			corrected.show();
+		} catch (final Exception e) {
+			IJ.log("Streak correction failed: " + e.getMessage());
+		}
 
 	}
 
@@ -62,7 +106,7 @@ public class StreakCorrection_Plugin implements PlugIn {
 				.addKeyEventDispatcher(e -> {
 					if (e.getID() == KeyEvent.KEY_PRESSED) {
 						if (e.getKeyCode() == KeyEvent.VK_F1) {
-							new ShadingCorrection_Plugin().run(null);
+							new StreakCorrection_Plugin().run(null);
 						}
 					}
 					return false;
@@ -99,26 +143,53 @@ public class StreakCorrection_Plugin implements PlugIn {
 		final ImagePlus img = loadImage(client, params);
 
 		img.show();
+	}
 
-		final int width = img.getWidth();
-		final int height = img.getHeight();
 
-		// The following computations are based on the original code in net.imglib2.algorithm.fft.FourierTransform
-		final int extendedWidth = width + Math.max(Math.round(1.25f * width) - width, 12);
-		final int extendedHeight = height + Math.max(Math.round(1.25f * height) - height, 12);
-		final int fftWidth = FftReal.nfftFast(extendedWidth) / 2 + 1;
-		final int fftHeight = FftComplex.nfftFast(extendedHeight);
+	private static class StreakCorrectionParameters {
+		public int innerCutoff = 15;
+		public int bandWidth = 10;
+		public double angle = 0.0;
+		public int gaussianBlurRadius = 10;
+		public double initialThreshold = 7.0;
+		public double finalThreshold = 0.05;
+		public boolean localize = true;
 
-		final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
-				Threads.numThreads() / 2,
-				fftWidth,
-				fftHeight,
-				18,
-				8,
-				0.0);
+		public StreakCorrectionParameters() {
+			// Default constructor
+		}
 
-		final ImagePlus corrected = loadImage(client, params);
-		corrector.process(corrected.getProcessor(), 1.0);
-		corrected.show();
+		public StreakCorrectionParameters(final StreakCorrectionParameters other) {
+			this.innerCutoff = other.innerCutoff;
+			this.bandWidth = other.bandWidth;
+			this.angle = other.angle;
+			this.gaussianBlurRadius = other.gaussianBlurRadius;
+			this.initialThreshold = other.initialThreshold;
+			this.finalThreshold = other.finalThreshold;
+			this.localize = other.localize;
+		}
+
+		public StreakCorrector getCorrector(final int width, final int height) {
+			// The following computations are based on the original code in net.imglib2.algorithm.fft.FourierTransform
+			final int extendedWidth = width + Math.max(Math.round(1.25f * width) - width, 12);
+			final int extendedHeight = height + Math.max(Math.round(1.25f * height) - height, 12);
+			final int fftWidth = FftReal.nfftFast(extendedWidth) / 2 + 1;
+			final int fftHeight = FftComplex.nfftFast(extendedHeight);
+
+			final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
+					Threads.numThreads() / 2, fftWidth, fftHeight, innerCutoff, bandWidth, angle);
+
+			return corrector;
+		}
+
+		public void setFromDialog(final GenericDialog dialog) {
+			innerCutoff = (int) dialog.getNextNumber();
+			bandWidth = (int) dialog.getNextNumber();
+			angle = dialog.getNextNumber();
+			localize = dialog.getNextBoolean();
+			gaussianBlurRadius = (int) dialog.getNextNumber();
+			initialThreshold = dialog.getNextNumber();
+			finalThreshold = dialog.getNextNumber();
+		}
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -2,6 +2,8 @@ package org.janelia.render.client.destreak;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import edu.mines.jtk.dsp.FftComplex;
+import edu.mines.jtk.dsp.FftReal;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -9,6 +11,7 @@ import ij.plugin.PlugIn;
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.destreak.SmoothMaskStreakCorrector;
 import org.janelia.alignment.spec.ChannelSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
@@ -19,6 +22,7 @@ import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spim.Threads;
 
 import javax.swing.SwingUtilities;
 import java.awt.KeyboardFocusManager;
@@ -27,8 +31,6 @@ import java.io.IOException;
 
 
 public class StreakCorrection_Plugin implements PlugIn {
-
-	private static final Logger LOG = LoggerFactory.getLogger(StreakCorrection_Plugin.class);
 
 	private static class Parameters extends CommandLineParameters {
 		@ParametersDelegate
@@ -80,9 +82,8 @@ public class StreakCorrection_Plugin implements PlugIn {
 		final ChannelSpec firstChannel = tileSpec.getAllChannels().stream().findFirst().orElseThrow();
 		final ImageAndMask imageAndMask = firstChannel.getMipmap(0);
 		final ImageProcessor ip = cache.get(imageAndMask.getImageUrl(), 0, false, false, imageAndMask.getImageLoaderType(), null);
-		final FloatProcessor fip = ip.convertToFloatProcessor();
 
-		return new ImagePlus(tileSpec.getTileId(), fip);
+		return new ImagePlus(tileSpec.getTileId(), ip);
 	}
 
 	public static void main(final String[] args) throws IOException {
@@ -98,5 +99,26 @@ public class StreakCorrection_Plugin implements PlugIn {
 		final ImagePlus img = loadImage(client, params);
 
 		img.show();
+
+		final int width = img.getWidth();
+		final int height = img.getHeight();
+
+		// The following computations are based on the original code in net.imglib2.algorithm.fft.FourierTransform
+		final int extendedWidth = width + Math.max(Math.round(1.25f * width) - width, 12);
+		final int extendedHeight = height + Math.max(Math.round(1.25f * height) - height, 12);
+		final int fftWidth = FftReal.nfftFast(extendedWidth) / 2 + 1;
+		final int fftHeight = FftComplex.nfftFast(extendedHeight);
+
+		final SmoothMaskStreakCorrector corrector = new SmoothMaskStreakCorrector(
+				Threads.numThreads() / 2,
+				fftWidth,
+				fftHeight,
+				18,
+				8,
+				0.0);
+
+		final ImagePlus corrected = loadImage(client, params);
+		corrector.process(corrected.getProcessor(), 1.0);
+		corrected.show();
 	}
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/emshading/ShadingCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/emshading/ShadingCorrection_Plugin.java
@@ -144,13 +144,8 @@ public class ShadingCorrection_Plugin implements PlugIn {
         new Thread(() -> KeyboardFocusManager.getCurrentKeyboardFocusManager()
 				.addKeyEventDispatcher(e -> {
 					if (e.getID() == KeyEvent.KEY_PRESSED) {
-						switch (e.getKeyCode()) {
-							case KeyEvent.VK_F1:
-								new ShadingCorrection_Plugin().run(null);
-								break;
-							case KeyEvent.VK_F2:
-								System.out.println("F2 key pressed (not assigned)");
-								break;
+						if (e.getKeyCode() == KeyEvent.VK_F1) {
+							new ShadingCorrection_Plugin().run(null);
 						}
 					}
 					return false;


### PR DESCRIPTION
This PR adds a small plugin that facilitates manual exploration of streak correction parameters. The plugin is callable from the command line. It loads the specified image tile and displays a set of parameters for streak correction (see screenshot below).

There is also the option of doing a small parameter scan, which renders the outputs obtained by the different streak correction parameters as a stack for easy comparison.

The following screenshot was obtained by calling the plugin with the command line parameters:
```bash
--baseDataUrl http://renderer-dev.int.janelia.org:8080/render-ws/v1
--owner cellmap
--project jrc_mpi_psc883_2f
--stack v1_acquire
--z 1
```
![image](https://github.com/user-attachments/assets/ca8f0836-5524-4e8b-85aa-ebfee423f3ea)
