### PR TITLE
Store PNGs to google cloud

### DIFF
--- a/render-ws-java-client/pom.xml
+++ b/render-ws-java-client/pom.xml
@@ -255,6 +255,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.janelia.saalfeldlab</groupId>
+            <artifactId>n5-universe</artifactId>
+        </dependency>
     </dependencies>
 
     <!--

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -51,9 +52,12 @@ import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.LockedChannel;
 import org.janelia.saalfeldlab.n5.googlecloud.GoogleCloudStorageKeyValueAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
 
 
 /**
@@ -626,7 +630,15 @@ public class RenderTilesClient {
                         final URI uri,
                         final String format,
                         final RenderParameters renderParameters) throws IOException {
+            if (! Utils.PNG_FORMAT.equals(format)) {
+                throw new IllegalArgumentException("Only PNG format is supported for cloud storage: " + format);
+            }
 
+            try (final LockedChannel lockedChannel = keyValueAccess.lockForWriting(uri.toString())) {
+                final ByteArrayOutputStream oStream = new ByteArrayOutputStream();
+                ImageIO.write(image, format, oStream);
+                lockedChannel.newOutputStream().write(oStream.toByteArray());
+            }
         }
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -646,9 +646,6 @@ public class RenderTilesClient {
                         final URI uri,
                         final String format,
                         final RenderParameters renderParameters) throws IOException {
-            if (! Utils.PNG_FORMAT.equals(format)) {
-                throw new IllegalArgumentException("Only PNG format is supported for cloud storage: " + format);
-            }
 
             try (final LockedChannel lockedChannel = keyValueAccess.lockForWriting(uri.getPath())) {
                 final ByteArrayOutputStream oStream = new ByteArrayOutputStream();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -431,10 +431,11 @@ public class RenderTilesClient {
                 Renderer.renderImageProcessorWithMasks(renderParameters, imageProcessorCache, null);
 
         // Get URI for the tile file and convert to File for backwards compatibility
+        final String format = clientParameters.format.toLowerCase();
         final URI parentDirUri, tileUri;
         try {
             parentDirUri = getTileParentUri(tileSpec);
-            final String fileName = tileSpec.getTileId() + "." + clientParameters.format.toLowerCase();
+            final String fileName = tileSpec.getTileId() + "." + format;
             tileUri = storageBackend.compose(parentDirUri, fileName);
         } catch (final URISyntaxException e) {
             throw new IOException("Failed to create URI for tile " + tileId, e);
@@ -458,10 +459,7 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("unsupported render type: " + clientParameters.renderType);
         }
 
-        Utils.saveImage(bufferedImage,
-                        new File(tileUri),
-                        renderParameters.isConvertToGray(),
-                        renderParameters.getQuality());
+        storageBackend.writeImage(bufferedImage, tileUri, format, renderParameters);
 
         if (clientParameters.hackStack != null) {
             final ResolvedTileSpecCollection resolvedTiles = zToResolvedTiles.get(tileSpec.getZ());
@@ -494,7 +492,7 @@ public class RenderTilesClient {
                                                                              null);
                 } else if (imageProcessorWithMasks.mask != null) {
                     // if we rendered a new mask, save it to disk and update the tile spec reference
-                    final String maskFileName = tileSpec.getTileId() + ".mask." + clientParameters.format.toLowerCase();
+                    final String maskFileName = tileSpec.getTileId() + ".mask." + format;
 
                     // Create mask URI based on the same parent directory
                     final URI maskUri;
@@ -503,10 +501,7 @@ public class RenderTilesClient {
                     } catch (final URISyntaxException e) {
                         throw new IOException("Failed to create URI for mask file", e);
                     }
-                    Utils.saveImage(imageProcessorWithMasks.mask.getBufferedImage(),
-                                    new File(maskUri),
-                                    renderParameters.convertToGray,
-                                    renderParameters.quality);
+                    storageBackend.writeImage(imageProcessorWithMasks.mask.getBufferedImage(), maskUri, format, renderParameters);
 
                     renderedImageAndMask = renderedImageAndMask.copyWithMask(maskUri.toString(),
                                                                              null,
@@ -582,6 +577,8 @@ public class RenderTilesClient {
 
         abstract void ensureWritableDirectory(URI uri);
 
+        abstract void writeImage(BufferedImage image, URI uri, String format, RenderParameters parameters) throws IOException;
+
         URI compose(final URI baseUri, final String... paths) throws URISyntaxException {
             final URI base = keyValueAccess.uri(keyValueAccess.normalize(baseUri.toString()));
             return keyValueAccess.uri(keyValueAccess.compose(base, paths));
@@ -596,6 +593,15 @@ public class RenderTilesClient {
         @Override
         void ensureWritableDirectory(final URI uri) {
             FileUtil.ensureWritableDirectory(new File(uri));
+        }
+
+        @Override
+        void writeImage(final BufferedImage image,
+                        final URI uri,
+                        final String format,
+                        final RenderParameters parameters) throws IOException {
+            Utils.saveImage(image, new File(uri).toString(), format, parameters.convertToGray, parameters.quality);
+
         }
     }
 
@@ -613,6 +619,14 @@ public class RenderTilesClient {
                     throw new RuntimeException("Could not create directory " + uri, e);
                 }
             }
+        }
+
+        @Override
+        void writeImage(final BufferedImage image,
+                        final URI uri,
+                        final String format,
+                        final RenderParameters renderParameters) throws IOException {
+
         }
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -256,7 +256,7 @@ public class RenderTilesClient {
             pathSegments.add(clientParameters.stack);
 
             final URI rootUri = uriBuilder.setPathSegments(pathSegments).build();
-            this.storageBackend = getStorageBackend(rootUri);
+            this.storageBackend = StorageBackend.create(rootUri);
             storageBackend.ensureWritableDirectory(storageBackend.root);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
@@ -305,26 +305,6 @@ public class RenderTilesClient {
 
         this.renderParametersQueryString = queryParameters.toString();
         this.zToResolvedTiles = new HashMap<>();
-    }
-
-    private static StorageBackend getStorageBackend(URI uri) {
-        final String scheme = uri.getScheme();
-        if (scheme == null) {
-            // Ensure that file scheme is explicit
-            try {
-                uri = new URI("file", uri.getAuthority(), uri.getPath(), null, null);
-            } catch (final URISyntaxException e) {
-                throw new IllegalArgumentException("Invalid URI: " + uri, e);
-            }
-        }
-
-        if (scheme == null || scheme.equals("file")) {
-            return new FileStorage(uri);
-        } else if (GoogleCloudUtils.GS_SCHEME.asPredicate().test(scheme)) {
-            return new CloudStorage(uri);
-        } else {
-            throw new IllegalArgumentException("Unsupported URI scheme: " + uri.getScheme());
-        }
     }
 
     private void collectTileInfo()
@@ -566,11 +546,36 @@ public class RenderTilesClient {
     }
 
 
+    /**
+     * An abstract class that provides a common interface for different storage backends.
+     * It handles the creation of the appropriate backend based on the URI scheme.
+     */
     private abstract static class StorageBackend {
         final URI root;
 
-        StorageBackend(final URI root) {
-            this.root = root;
+        StorageBackend(final URI uri) {
+            this.root = uri;
+        }
+
+        static StorageBackend create(URI uri) {
+            String scheme = uri.getScheme();
+            if (scheme == null) {
+                // Ensure that file scheme is explicit
+                try {
+                    uri = new URI("file", uri.getAuthority(), uri.getPath(), null, null);
+                } catch (final URISyntaxException e) {
+                    throw new IllegalArgumentException("Invalid URI: " + uri, e);
+                }
+            }
+
+            scheme = uri.getScheme();
+            if (scheme.equals("file")) {
+                return new FileStorage(uri);
+            } else if (GoogleCloudUtils.GS_SCHEME.asPredicate().test(scheme)) {
+                return new CloudStorage(uri);
+            } else {
+                throw new IllegalArgumentException("Unsupported URI scheme: " + scheme);
+            }
         }
 
         abstract void ensureWritableDirectory(URI uri);
@@ -589,6 +594,9 @@ public class RenderTilesClient {
         }
     }
 
+    /**
+     * A concrete implementation of StorageBackend that handles file system storage.
+     */
     private static class FileStorage extends StorageBackend {
         FileStorage(final URI uri) {
             super(uri);
@@ -609,6 +617,9 @@ public class RenderTilesClient {
         }
     }
 
+    /**
+     * A concrete implementation of StorageBackend that handles cloud storage (only Google Cloud Storage so far).
+     */
     private static class CloudStorage extends StorageBackend {
         final KeyValueAccess keyValueAccess;
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
@@ -258,6 +259,7 @@ public class RenderTilesClient {
 
             final URI rootUri = uriBuilder.setPathSegments(pathSegments).build();
             this.storageBackend = StorageBackend.create(rootUri);
+            storageBackend.validateFormat(clientParameters.format);
             storageBackend.ensureWritableDirectory(storageBackend.root);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
@@ -578,6 +580,17 @@ public class RenderTilesClient {
         }
 
         abstract void ensureWritableDirectory(URI uri);
+
+        void validateFormat(final String format) throws IllegalArgumentException {
+            final Set<String> lowerCaseFormatNames = Arrays.stream(ImageIO.getWriterFormatNames())
+                    .map(String::toLowerCase)
+                    .collect(Collectors.toSet());
+            if (! lowerCaseFormatNames.contains(format.toLowerCase())) {
+                throw new IllegalArgumentException(
+                        "Unsupported image format '" + format + "'. Supported formats are " +
+                        lowerCaseFormatNames.stream().sorted().collect(Collectors.joining(", ")));
+            }
+        }
 
         abstract String writeImage(BufferedImage image, URI uri, String format, RenderParameters parameters) throws IOException;
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.FileSystems;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -26,6 +25,7 @@ import java.util.stream.Collectors;
 import mpicbg.trakem2.transform.TransformMeshMappingWithMasks;
 import mpicbg.trakem2.transform.TranslationModel2D;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.janelia.alignment.ArgbRenderer;
 import org.janelia.alignment.ByteRenderer;
 import org.janelia.alignment.ImageAndMask;
@@ -50,7 +50,6 @@ import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
-import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.LockedChannel;
 import org.janelia.saalfeldlab.n5.googlecloud.GoogleCloudStorageKeyValueAccess;
@@ -239,7 +238,6 @@ public class RenderTilesClient {
 
     private final Parameters clientParameters;
 
-    private final URI tileDirectoryUri;
     private final ImageProcessorCache imageProcessorCache;
     private final RenderDataClient renderDataClient;
     private final List<String> tileIds;
@@ -250,17 +248,19 @@ public class RenderTilesClient {
     private RenderTilesClient(final Parameters clientParameters) {
 
         this.clientParameters = clientParameters;
-        final URI rootUri = URI.create(clientParameters.rootDirectory);
-        this.storageBackend = getStorageBackend(rootUri);
 
         try {
-            this.tileDirectoryUri = storageBackend.compose(rootUri, clientParameters.renderWeb.project, clientParameters.stack);
+            final URIBuilder uriBuilder = new URIBuilder(clientParameters.rootDirectory);
+            final List<String> pathSegments = uriBuilder.getPathSegments();
+            pathSegments.add(clientParameters.renderWeb.project);
+            pathSegments.add(clientParameters.stack);
+
+            final URI rootUri = uriBuilder.setPathSegments(pathSegments).build();
+            this.storageBackend = getStorageBackend(rootUri);
+            storageBackend.ensureWritableDirectory(storageBackend.root);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
         }
-
-        // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
-        storageBackend.ensureWritableDirectory(tileDirectoryUri);
 
         // set cache size to 50MB so that masks get cached but most of RAM is left for target images
         final int maxCachedPixels = 50 * 1000000;
@@ -307,17 +307,21 @@ public class RenderTilesClient {
         this.zToResolvedTiles = new HashMap<>();
     }
 
-    private static StorageBackend getStorageBackend(final URI uri) {
+    private static StorageBackend getStorageBackend(URI uri) {
         final String scheme = uri.getScheme();
+        if (scheme == null) {
+            // Ensure that file scheme is explicit
+            try {
+                uri = new URI("file", uri.getAuthority(), uri.getPath(), null, null);
+            } catch (final URISyntaxException e) {
+                throw new IllegalArgumentException("Invalid URI: " + uri, e);
+            }
+        }
 
         if (scheme == null || scheme.equals("file")) {
-            final KeyValueAccess keyValueAccess = new FileSystemKeyValueAccess(FileSystems.getDefault());
-            return new FileStorage(keyValueAccess);
+            return new FileStorage(uri);
         } else if (GoogleCloudUtils.GS_SCHEME.asPredicate().test(scheme)) {
-            final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI(uri);
-            final KeyValueAccess keyValueAccess =
-                    new GoogleCloudStorageKeyValueAccess(GoogleCloudUtils.createGoogleCloudStorage(null), googleCloudUri, true);
-            return new CloudStorage(keyValueAccess);
+            return new CloudStorage(uri);
         } else {
             throw new IllegalArgumentException("Unsupported URI scheme: " + uri.getScheme());
         }
@@ -436,15 +440,8 @@ public class RenderTilesClient {
 
         // Get URI for the tile file and convert to File for backwards compatibility
         final String format = clientParameters.format.toLowerCase();
-        final URI parentDirUri, tileUri;
-        try {
-            parentDirUri = getTileParentUri(tileSpec);
-            final String fileName = tileSpec.getTileId() + "." + format;
-            tileUri = storageBackend.compose(parentDirUri, fileName);
-        } catch (final URISyntaxException e) {
-            throw new IOException("Failed to create URI for tile " + tileId, e);
-        }
-
+        final List<String> imagePathSegments = getImagePathSegments(tileSpec, format);
+        final URI imageUri = storageBackend.resolvePath(imagePathSegments);
 
         final BufferedImage bufferedImage;
         if ((clientParameters.renderType == RenderType.ARGB) || (! clientParameters.excludeMask)) {
@@ -463,7 +460,7 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("unsupported render type: " + clientParameters.renderType);
         }
 
-        storageBackend.writeImage(bufferedImage, tileUri, format, renderParameters);
+        storageBackend.writeImage(bufferedImage, imageUri, format, renderParameters);
 
         if (clientParameters.hackStack != null) {
             final ResolvedTileSpecCollection resolvedTiles = zToResolvedTiles.get(tileSpec.getZ());
@@ -481,7 +478,7 @@ public class RenderTilesClient {
 
             // Use the URI string directly instead of file path
             ImageAndMask renderedImageAndMask =
-                    channelSpec.getFirstMipmapImageAndMask(tileId).copyWithImage(tileUri.toString(),
+                    channelSpec.getFirstMipmapImageAndMask(tileId).copyWithImage(imageUri.toString(),
                                                                                  null,
                                                                                  null);
             if (channelSpec.hasMask()) {
@@ -496,15 +493,12 @@ public class RenderTilesClient {
                                                                              null);
                 } else if (imageProcessorWithMasks.mask != null) {
                     // if we rendered a new mask, save it to disk and update the tile spec reference
+                    final List<String> maskPathSegments = new ArrayList<>(imagePathSegments);
                     final String maskFileName = tileSpec.getTileId() + ".mask." + format;
+                    maskPathSegments.set(maskPathSegments.size() - 1, maskFileName);
+                    final URI maskUri = storageBackend.resolvePath(maskPathSegments);
 
                     // Create mask URI based on the same parent directory
-                    final URI maskUri;
-                    try {
-                        maskUri = storageBackend.compose(parentDirUri, maskFileName);
-                    } catch (final URISyntaxException e) {
-                        throw new IOException("Failed to create URI for mask file", e);
-                    }
                     storageBackend.writeImage(imageProcessorWithMasks.mask.getBufferedImage(), maskUri, format, renderParameters);
 
                     renderedImageAndMask = renderedImageAndMask.copyWithMask(maskUri.toString(),
@@ -553,45 +547,51 @@ public class RenderTilesClient {
         }
     }
 
-    private URI getTileParentUri(final TileSpec tileSpec) throws URISyntaxException {
-
+    private List<String> getImagePathSegments(final TileSpec tileSpec, final String format) {
         final int zInt = tileSpec.getZ().intValue();
         final int thousands = zInt / 1000;
 
         // Build relative path components
-        final String thousandsPath = String.format("%03d", thousands);
-        final String hundredsPath = String.valueOf((zInt % 1000) / 100);
-        final String zPath = String.valueOf(zInt);
+        final List<String> relativePathSegments = new ArrayList<>();
+        relativePathSegments.add(String.format("%03d", thousands));
+        relativePathSegments.add(String.valueOf((zInt % 1000) / 100));
+        relativePathSegments.add(String.valueOf(zInt));
 
-        // Create a URI for the parent directory
-        final URI parentDirUri = storageBackend.compose(tileDirectoryUri, thousandsPath, hundredsPath, zPath);
+        // Ensure the directory exists and if so append file name
+        final URI parentUri = storageBackend.resolvePath(relativePathSegments);
+        storageBackend.ensureWritableDirectory(parentUri);
+        relativePathSegments.add(tileSpec.getTileId() + "." + format);
 
-        // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
-        storageBackend.ensureWritableDirectory(parentDirUri);
-        return parentDirUri;
+        return relativePathSegments;
     }
 
 
     private abstract static class StorageBackend {
-        final KeyValueAccess keyValueAccess;
+        final URI root;
 
-        StorageBackend(final KeyValueAccess keyValueAccess) {
-            this.keyValueAccess = keyValueAccess;
+        StorageBackend(final URI root) {
+            this.root = root;
         }
 
         abstract void ensureWritableDirectory(URI uri);
 
         abstract void writeImage(BufferedImage image, URI uri, String format, RenderParameters parameters) throws IOException;
 
-        URI compose(final URI baseUri, final String... paths) throws URISyntaxException {
-            final URI base = keyValueAccess.uri(keyValueAccess.normalize(baseUri.toString()));
-            return keyValueAccess.uri(keyValueAccess.compose(base, paths));
-		}
+        URI resolvePath(final List<String> relativePathSegments) {
+            try {
+                final URIBuilder uriBuilder = new URIBuilder(root);
+                final List<String> pathSegments = uriBuilder.getPathSegments();
+                pathSegments.addAll(relativePathSegments);
+                return uriBuilder.setPathSegments(pathSegments).build();
+            } catch (final URISyntaxException e) {
+                throw new IllegalArgumentException("Failed to resolve root " + root + " with segments " + relativePathSegments, e);
+            }
+        }
     }
 
     private static class FileStorage extends StorageBackend {
-        FileStorage(final KeyValueAccess keyValueAccess) {
-            super(keyValueAccess);
+        FileStorage(final URI uri) {
+            super(uri);
         }
 
         @Override
@@ -610,15 +610,21 @@ public class RenderTilesClient {
     }
 
     private static class CloudStorage extends StorageBackend {
-        CloudStorage(final KeyValueAccess keyValueAccess) {
-            super(keyValueAccess);
+        final KeyValueAccess keyValueAccess;
+
+        CloudStorage(final URI uri) {
+            super(uri);
+            this.keyValueAccess = new GoogleCloudStorageKeyValueAccess(
+                    GoogleCloudUtils.createGoogleCloudStorage(null),
+                    new GoogleCloudStorageURI(uri),
+                    true);
         }
 
         @Override
         void ensureWritableDirectory(final URI uri) {
-            if (!keyValueAccess.exists(uri.toString())) {
+            if (!keyValueAccess.exists(uri.getPath())) {
                 try {
-                    keyValueAccess.createDirectories(uri.toString());
+                    keyValueAccess.createDirectories(uri.getPath());
                 } catch (final IOException e) {
                     throw new RuntimeException("Could not create directory " + uri, e);
                 }
@@ -638,6 +644,7 @@ public class RenderTilesClient {
                 final ByteArrayOutputStream oStream = new ByteArrayOutputStream();
                 ImageIO.write(image, format, oStream);
                 lockedChannel.newOutputStream().write(oStream.toByteArray());
+                LOG.info("image written to {}", uri);
             }
         }
     }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -440,7 +440,7 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("unsupported render type: " + clientParameters.renderType);
         }
 
-        storageBackend.writeImage(bufferedImage, imageUri, format, renderParameters);
+        final String imageUrl = storageBackend.writeImage(bufferedImage, imageUri, format, renderParameters);
 
         if (clientParameters.hackStack != null) {
             final ResolvedTileSpecCollection resolvedTiles = zToResolvedTiles.get(tileSpec.getZ());
@@ -457,10 +457,10 @@ public class RenderTilesClient {
             final ChannelSpec channelSpec = allChannels.get(0);
 
             // Use the URI string directly instead of file path
-            ImageAndMask renderedImageAndMask =
-                    channelSpec.getFirstMipmapImageAndMask(tileId).copyWithImage(imageUri.toString(),
-                                                                                 null,
-                                                                                 null);
+            ImageAndMask renderedImageAndMask = channelSpec
+                    .getFirstMipmapImageAndMask(tileId)
+                    .copyWithImage(imageUrl, null, null);
+
             if (channelSpec.hasMask()) {
                 if (ImageLoader.LoaderType.DYNAMIC_MASK.equals(renderedImageAndMask.getMaskLoaderType())) {
                     // if original tile spec has a dynamic mask, update the width and height to match rendered tile
@@ -479,11 +479,9 @@ public class RenderTilesClient {
                     final URI maskUri = storageBackend.resolvePath(maskPathSegments);
 
                     // Create mask URI based on the same parent directory
-                    storageBackend.writeImage(imageProcessorWithMasks.mask.getBufferedImage(), maskUri, format, renderParameters);
+                    final String maskUrl = storageBackend.writeImage(imageProcessorWithMasks.mask.getBufferedImage(), maskUri, format, renderParameters);
 
-                    renderedImageAndMask = renderedImageAndMask.copyWithMask(maskUri.toString(),
-                                                                             null,
-                                                                             null);
+                    renderedImageAndMask = renderedImageAndMask.copyWithMask(maskUrl, null, null);
                 }
             }
 
@@ -580,7 +578,7 @@ public class RenderTilesClient {
 
         abstract void ensureWritableDirectory(URI uri);
 
-        abstract void writeImage(BufferedImage image, URI uri, String format, RenderParameters parameters) throws IOException;
+        abstract String writeImage(BufferedImage image, URI uri, String format, RenderParameters parameters) throws IOException;
 
         URI resolvePath(final List<String> relativePathSegments) {
             try {
@@ -608,12 +606,13 @@ public class RenderTilesClient {
         }
 
         @Override
-        void writeImage(final BufferedImage image,
+        String writeImage(final BufferedImage image,
                         final URI uri,
                         final String format,
                         final RenderParameters parameters) throws IOException {
-            Utils.saveImage(image, new File(uri).toString(), format, parameters.convertToGray, parameters.quality);
-
+            final String fullPath = new File(uri).toString();
+            Utils.saveImage(image, fullPath, format, parameters.convertToGray, parameters.quality);
+            return fullPath;
         }
     }
 
@@ -643,7 +642,7 @@ public class RenderTilesClient {
         }
 
         @Override
-        void writeImage(final BufferedImage image,
+        String writeImage(final BufferedImage image,
                         final URI uri,
                         final String format,
                         final RenderParameters renderParameters) throws IOException {
@@ -651,12 +650,15 @@ public class RenderTilesClient {
                 throw new IllegalArgumentException("Only PNG format is supported for cloud storage: " + format);
             }
 
-            try (final LockedChannel lockedChannel = keyValueAccess.lockForWriting(uri.toString())) {
+            try (final LockedChannel lockedChannel = keyValueAccess.lockForWriting(uri.getPath())) {
                 final ByteArrayOutputStream oStream = new ByteArrayOutputStream();
                 ImageIO.write(image, format, oStream);
                 lockedChannel.newOutputStream().write(oStream.toByteArray());
                 LOG.info("image written to {}", uri);
             }
+
+            // This yields the public URL for the image
+            return "https://storage.googleapis.com" + uri.toString().substring(4);
         }
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -647,6 +647,7 @@ public class RenderTilesClient {
                         final String format,
                         final RenderParameters renderParameters) throws IOException {
 
+            // TODO: render parameters are currently ignored, so the behavior might differ from the file system version!
             try (final LockedChannel lockedChannel = keyValueAccess.lockForWriting(uri.getPath())) {
                 final ByteArrayOutputStream oStream = new ByteArrayOutputStream();
                 ImageIO.write(image, format, oStream);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -6,6 +6,8 @@ import com.beust.jcommander.ParametersDelegate;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
@@ -228,7 +230,7 @@ public class RenderTilesClient {
 
     private final Parameters clientParameters;
 
-    private final File tileDirectory;
+    private final URI tileDirectoryUri;
     private final ImageProcessorCache imageProcessorCache;
     private final RenderDataClient renderDataClient;
     private final List<String> tileIds;
@@ -243,9 +245,10 @@ public class RenderTilesClient {
                                                  clientParameters.renderWeb.project,
                                                  clientParameters.stack,
                                                  clientParameters.getRunTimestamp());
-        this.tileDirectory = tileDirectoryPath.toAbsolutePath().toFile();
+        this.tileDirectoryUri = tileDirectoryPath.toAbsolutePath().toUri();
 
-        FileUtil.ensureWritableDirectory(this.tileDirectory);
+        // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
+        FileUtil.ensureWritableDirectory(new File(tileDirectoryUri));
 
         // set cache size to 50MB so that masks get cached but most of RAM is left for target images
         final int maxCachedPixels = 50 * 1000000;
@@ -403,7 +406,15 @@ public class RenderTilesClient {
         final TransformMeshMappingWithMasks.ImageProcessorWithMasks imageProcessorWithMasks =
                 Renderer.renderImageProcessorWithMasks(renderParameters, imageProcessorCache, null);
 
-        final File tileFile = getTileFile(tileSpec);
+        // Get URI for the tile file and convert to File for backwards compatibility
+        final URI tileUri;
+        try {
+            tileUri = getTileUri(tileSpec);
+        } catch (final URISyntaxException e) {
+            throw new IOException("Failed to create URI for tile " + tileId, e);
+        }
+        final File tileFile = new File(tileUri);
+
         final BufferedImage bufferedImage;
         if ((clientParameters.renderType == RenderType.ARGB) || (! clientParameters.excludeMask)) {
             // this incorporates the mask if it exists into the rendered image
@@ -440,8 +451,9 @@ public class RenderTilesClient {
             }
             final ChannelSpec channelSpec = allChannels.get(0);
 
+            // Use the URI string directly instead of file path
             ImageAndMask renderedImageAndMask =
-                    channelSpec.getFirstMipmapImageAndMask(tileId).copyWithImage(tileFile.getAbsolutePath(),
+                    channelSpec.getFirstMipmapImageAndMask(tileId).copyWithImage(tileUri.toString(),
                                                                                  null,
                                                                                  null);
             if (channelSpec.hasMask()) {
@@ -459,14 +471,24 @@ public class RenderTilesClient {
                     final String maskFileName =
                             tileFile.getName().replace(clientParameters.format,
                                                        "mask." + clientParameters.format);
-                    final File maskFile = new File(tileFile.getParentFile().getAbsolutePath(), maskFileName);
-                    final String maskPath = maskFile.getAbsolutePath();
+                    // Create mask URI based on the same parent directory
+                    final URI maskUri;
+                    try {
+                        maskUri = new URI(tileUri.getScheme(),
+                                          tileUri.getAuthority(),
+                                          tileUri.getPath().substring(0, tileUri.getPath().lastIndexOf('/') + 1) + maskFileName,
+                                          null,
+                                          null);
+                    } catch (final URISyntaxException e) {
+                        throw new IOException("Failed to create URI for mask file", e);
+                    }
                     Utils.saveImage(imageProcessorWithMasks.mask.getBufferedImage(),
-                                    maskPath,
+                                    new File(maskUri).toString(),
                                     clientParameters.format,
                                     renderParameters.convertToGray,
                                     renderParameters.quality);
-                    renderedImageAndMask = renderedImageAndMask.copyWithMask(maskPath,
+
+                    renderedImageAndMask = renderedImageAndMask.copyWithMask(maskUri.toString(),
                                                                              null,
                                                                              null);
                 }
@@ -512,20 +534,33 @@ public class RenderTilesClient {
         }
     }
 
-    private File getTileFile(final TileSpec tileSpec) {
+    private URI getTileUri(final TileSpec tileSpec) throws URISyntaxException {
 
         final int zInt = tileSpec.getZ().intValue();
         final int thousands = zInt / 1000;
-        final File thousandsDir = new File(tileDirectory, String.format("%03d", thousands));
 
-        final int hundreds = (zInt % 1000) / 100;
-        final File hundredsDirectory = new File(thousandsDir, String.valueOf(hundreds));
+        // Build relative path components
+        final String thousandsPath = String.format("%03d", thousands);
+        final String hundredsPath = String.valueOf((zInt % 1000) / 100);
+        final String zPath = String.valueOf(zInt);
+        final String fileName = tileSpec.getTileId() + "." + clientParameters.format.toLowerCase();
 
-        final File parentDirectory = new File(hundredsDirectory, String.valueOf(zInt));
+        // Create a URI for the parent directory
+        final URI parentDirUri = new URI(tileDirectoryUri.getScheme(),
+                                         tileDirectoryUri.getAuthority(),
+                                         tileDirectoryUri.getPath() + "/" + thousandsPath + "/" + hundredsPath + "/" + zPath,
+                                         null,
+                                         null);
 
-        FileUtil.ensureWritableDirectory(parentDirectory);
+        // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
+        FileUtil.ensureWritableDirectory(new File(parentDirUri));
 
-        return new File(parentDirectory, tileSpec.getTileId() + "." + clientParameters.format.toLowerCase());
+        // Create and return final URI for the tile
+        return new URI(parentDirUri.getScheme(),
+                       parentDirUri.getAuthority(),
+                       parentDirUri.getPath() + "/" + fileName,
+                       null,
+                       null);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(RenderTilesClient.class);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -8,8 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.FileSystems;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -48,8 +47,11 @@ import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.alignment.util.RenderWebServiceUrls;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
+import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Java client for rendering individual tiles.  Images are placed in:
@@ -236,16 +238,21 @@ public class RenderTilesClient {
     private final List<String> tileIds;
     private final String renderParametersQueryString;
     private final Map<Double, ResolvedTileSpecCollection> zToResolvedTiles;
+    private final KeyValueAccess keyValueAccess;
 
     private RenderTilesClient(final Parameters clientParameters) {
 
         this.clientParameters = clientParameters;
+        this.keyValueAccess = new FileSystemKeyValueAccess(FileSystems.getDefault());
 
-        final Path tileDirectoryPath = Paths.get(clientParameters.rootDirectory,
-                                                 clientParameters.renderWeb.project,
-                                                 clientParameters.stack,
-                                                 clientParameters.getRunTimestamp());
-        this.tileDirectoryUri = tileDirectoryPath.toAbsolutePath().toUri();
+        final URI rootUri;
+        try {
+            rootUri = keyValueAccess.uri(clientParameters.rootDirectory);
+            final String tileDirectoryPath = keyValueAccess.compose(rootUri, clientParameters.renderWeb.project, clientParameters.stack);
+            this.tileDirectoryUri = this.keyValueAccess.uri(tileDirectoryPath);
+        } catch (final URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
+        }
 
         // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
         FileUtil.ensureWritableDirectory(new File(tileDirectoryUri));
@@ -413,7 +420,6 @@ public class RenderTilesClient {
         } catch (final URISyntaxException e) {
             throw new IOException("Failed to create URI for tile " + tileId, e);
         }
-        final File tileFile = new File(tileUri);
 
         final BufferedImage bufferedImage;
         if ((clientParameters.renderType == RenderType.ARGB) || (! clientParameters.excludeMask)) {
@@ -433,7 +439,7 @@ public class RenderTilesClient {
         }
 
         Utils.saveImage(bufferedImage,
-                        tileFile,
+                        new File(tileUri),
                         renderParameters.isConvertToGray(),
                         renderParameters.getQuality());
 
@@ -469,7 +475,7 @@ public class RenderTilesClient {
                 } else if (imageProcessorWithMasks.mask != null) {
                     // if we rendered a new mask, save it to disk and update the tile spec reference
                     final String maskFileName =
-                            tileFile.getName().replace(clientParameters.format,
+                            new File(tileUri).getName().replace(clientParameters.format,
                                                        "mask." + clientParameters.format);
                     // Create mask URI based on the same parent directory
                     final URI maskUri;
@@ -546,21 +552,15 @@ public class RenderTilesClient {
         final String fileName = tileSpec.getTileId() + "." + clientParameters.format.toLowerCase();
 
         // Create a URI for the parent directory
-        final URI parentDirUri = new URI(tileDirectoryUri.getScheme(),
-                                         tileDirectoryUri.getAuthority(),
-                                         tileDirectoryUri.getPath() + "/" + thousandsPath + "/" + hundredsPath + "/" + zPath,
-                                         null,
-                                         null);
+        final String parentPath = keyValueAccess.compose(tileDirectoryUri, thousandsPath, hundredsPath, zPath);
+        final URI parentDirUri = keyValueAccess.uri(parentPath);
 
         // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
         FileUtil.ensureWritableDirectory(new File(parentDirUri));
 
         // Create and return final URI for the tile
-        return new URI(parentDirUri.getScheme(),
-                       parentDirUri.getAuthority(),
-                       parentDirUri.getPath() + "/" + fileName,
-                       null,
-                       null);
+        final String filePath = keyValueAccess.compose(parentDirUri, fileName);
+        return keyValueAccess.uri(filePath);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(RenderTilesClient.class);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -47,8 +47,11 @@ import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.alignment.util.RenderWebServiceUrls;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.googlecloud.GoogleCloudStorageKeyValueAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,24 +241,22 @@ public class RenderTilesClient {
     private final List<String> tileIds;
     private final String renderParametersQueryString;
     private final Map<Double, ResolvedTileSpecCollection> zToResolvedTiles;
-    private final KeyValueAccess keyValueAccess;
+    private final StorageBackend storageBackend;
 
     private RenderTilesClient(final Parameters clientParameters) {
 
         this.clientParameters = clientParameters;
-        this.keyValueAccess = new FileSystemKeyValueAccess(FileSystems.getDefault());
+        final URI rootUri = URI.create(clientParameters.rootDirectory);
+        this.storageBackend = getStorageBackend(rootUri);
 
-        final URI rootUri;
         try {
-            rootUri = keyValueAccess.uri(clientParameters.rootDirectory);
-            final String tileDirectoryPath = keyValueAccess.compose(rootUri, clientParameters.renderWeb.project, clientParameters.stack);
-            this.tileDirectoryUri = this.keyValueAccess.uri(tileDirectoryPath);
+            this.tileDirectoryUri = storageBackend.compose(rootUri, clientParameters.renderWeb.project, clientParameters.stack);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
         }
 
         // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
-        FileUtil.ensureWritableDirectory(new File(tileDirectoryUri));
+        storageBackend.ensureWritableDirectory(tileDirectoryUri);
 
         // set cache size to 50MB so that masks get cached but most of RAM is left for target images
         final int maxCachedPixels = 50 * 1000000;
@@ -300,6 +301,22 @@ public class RenderTilesClient {
 
         this.renderParametersQueryString = queryParameters.toString();
         this.zToResolvedTiles = new HashMap<>();
+    }
+
+    private static StorageBackend getStorageBackend(final URI uri) {
+        final String scheme = uri.getScheme();
+
+        if (scheme == null || scheme.equals("file")) {
+            final KeyValueAccess keyValueAccess = new FileSystemKeyValueAccess(FileSystems.getDefault());
+            return new FileStorage(keyValueAccess);
+        } else if (GoogleCloudUtils.GS_SCHEME.asPredicate().test(scheme)) {
+            final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI(uri);
+            final KeyValueAccess keyValueAccess =
+                    new GoogleCloudStorageKeyValueAccess(GoogleCloudUtils.createGoogleCloudStorage(null), googleCloudUri, true);
+            return new CloudStorage(keyValueAccess);
+        } else {
+            throw new IllegalArgumentException("Unsupported URI scheme: " + uri.getScheme());
+        }
     }
 
     private void collectTileInfo()
@@ -414,12 +431,15 @@ public class RenderTilesClient {
                 Renderer.renderImageProcessorWithMasks(renderParameters, imageProcessorCache, null);
 
         // Get URI for the tile file and convert to File for backwards compatibility
-        final URI tileUri;
+        final URI parentDirUri, tileUri;
         try {
-            tileUri = getTileUri(tileSpec);
+            parentDirUri = getTileParentUri(tileSpec);
+            final String fileName = tileSpec.getTileId() + "." + clientParameters.format.toLowerCase();
+            tileUri = storageBackend.compose(parentDirUri, fileName);
         } catch (final URISyntaxException e) {
             throw new IOException("Failed to create URI for tile " + tileId, e);
         }
+
 
         final BufferedImage bufferedImage;
         if ((clientParameters.renderType == RenderType.ARGB) || (! clientParameters.excludeMask)) {
@@ -474,23 +494,17 @@ public class RenderTilesClient {
                                                                              null);
                 } else if (imageProcessorWithMasks.mask != null) {
                     // if we rendered a new mask, save it to disk and update the tile spec reference
-                    final String maskFileName =
-                            new File(tileUri).getName().replace(clientParameters.format,
-                                                       "mask." + clientParameters.format);
+                    final String maskFileName = tileSpec.getTileId() + ".mask." + clientParameters.format.toLowerCase();
+
                     // Create mask URI based on the same parent directory
                     final URI maskUri;
                     try {
-                        maskUri = new URI(tileUri.getScheme(),
-                                          tileUri.getAuthority(),
-                                          tileUri.getPath().substring(0, tileUri.getPath().lastIndexOf('/') + 1) + maskFileName,
-                                          null,
-                                          null);
+                        maskUri = storageBackend.compose(parentDirUri, maskFileName);
                     } catch (final URISyntaxException e) {
                         throw new IOException("Failed to create URI for mask file", e);
                     }
                     Utils.saveImage(imageProcessorWithMasks.mask.getBufferedImage(),
-                                    new File(maskUri).toString(),
-                                    clientParameters.format,
+                                    new File(maskUri),
                                     renderParameters.convertToGray,
                                     renderParameters.quality);
 
@@ -540,7 +554,7 @@ public class RenderTilesClient {
         }
     }
 
-    private URI getTileUri(final TileSpec tileSpec) throws URISyntaxException {
+    private URI getTileParentUri(final TileSpec tileSpec) throws URISyntaxException {
 
         final int zInt = tileSpec.getZ().intValue();
         final int thousands = zInt / 1000;
@@ -549,19 +563,59 @@ public class RenderTilesClient {
         final String thousandsPath = String.format("%03d", thousands);
         final String hundredsPath = String.valueOf((zInt % 1000) / 100);
         final String zPath = String.valueOf(zInt);
-        final String fileName = tileSpec.getTileId() + "." + clientParameters.format.toLowerCase();
 
         // Create a URI for the parent directory
-        final String parentPath = keyValueAccess.compose(tileDirectoryUri, thousandsPath, hundredsPath, zPath);
-        final URI parentDirUri = keyValueAccess.uri(parentPath);
+        final URI parentDirUri = storageBackend.compose(tileDirectoryUri, thousandsPath, hundredsPath, zPath);
 
         // Ensure the directory exists (still need to convert to File for compatibility with FileUtil)
-        FileUtil.ensureWritableDirectory(new File(parentDirUri));
-
-        // Create and return final URI for the tile
-        final String filePath = keyValueAccess.compose(parentDirUri, fileName);
-        return keyValueAccess.uri(filePath);
+        storageBackend.ensureWritableDirectory(parentDirUri);
+        return parentDirUri;
     }
+
+
+    private abstract static class StorageBackend {
+        final KeyValueAccess keyValueAccess;
+
+        StorageBackend(final KeyValueAccess keyValueAccess) {
+            this.keyValueAccess = keyValueAccess;
+        }
+
+        abstract void ensureWritableDirectory(URI uri);
+
+        URI compose(final URI baseUri, final String... paths) throws URISyntaxException {
+            final URI base = keyValueAccess.uri(keyValueAccess.normalize(baseUri.toString()));
+            return keyValueAccess.uri(keyValueAccess.compose(base, paths));
+		}
+    }
+
+    private static class FileStorage extends StorageBackend {
+        FileStorage(final KeyValueAccess keyValueAccess) {
+            super(keyValueAccess);
+        }
+
+        @Override
+        void ensureWritableDirectory(final URI uri) {
+            FileUtil.ensureWritableDirectory(new File(uri));
+        }
+    }
+
+    private static class CloudStorage extends StorageBackend {
+        CloudStorage(final KeyValueAccess keyValueAccess) {
+            super(keyValueAccess);
+        }
+
+        @Override
+        void ensureWritableDirectory(final URI uri) {
+            if (!keyValueAccess.exists(uri.toString())) {
+                try {
+                    keyValueAccess.createDirectories(uri.toString());
+                } catch (final IOException e) {
+                    throw new RuntimeException("Could not create directory " + uri, e);
+                }
+            }
+        }
+    }
+
 
     private static final Logger LOG = LoggerFactory.getLogger(RenderTilesClient.class);
 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/RenderTilesClient.java
@@ -254,6 +254,7 @@ public class RenderTilesClient {
             final List<String> pathSegments = uriBuilder.getPathSegments();
             pathSegments.add(clientParameters.renderWeb.project);
             pathSegments.add(clientParameters.stack);
+            pathSegments.add(clientParameters.getRunTimestamp());
 
             final URI rootUri = uriBuilder.setPathSegments(pathSegments).build();
             this.storageBackend = StorageBackend.create(rootUri);
@@ -262,7 +263,7 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
         }
 
-        // set cache size to 50MB so that masks get cached but most of RAM is left for target images
+        // set cache size to 50MB so that masks get cached but most RAM is left for target images
         final int maxCachedPixels = 50 * 1000000;
         this.imageProcessorCache = new ImageProcessorCache(maxCachedPixels,
                                                            false,
@@ -456,14 +457,14 @@ public class RenderTilesClient {
             }
             final ChannelSpec channelSpec = allChannels.get(0);
 
-            // Use the URI string directly instead of file path
+            // Use the URI string directly instead of the file path
             ImageAndMask renderedImageAndMask = channelSpec
                     .getFirstMipmapImageAndMask(tileId)
                     .copyWithImage(imageUrl, null, null);
 
             if (channelSpec.hasMask()) {
                 if (ImageLoader.LoaderType.DYNAMIC_MASK.equals(renderedImageAndMask.getMaskLoaderType())) {
-                    // if original tile spec has a dynamic mask, update the width and height to match rendered tile
+                    // if the original tile spec has a dynamic mask, update the width and height to match the rendered tile
                     final DynamicMaskLoader.DynamicMaskDescription description =
                             DynamicMaskLoader.parseUrl(renderedImageAndMask.getMaskUrl())
                                     .withWidthAndHeight(imageProcessorWithMasks.getWidth(),

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
@@ -1,0 +1,173 @@
+package org.janelia.render.client.parameter;
+
+import com.beust.jcommander.Parameter;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.janelia.alignment.Utils;
+import org.janelia.alignment.json.JsonUtils;
+import org.janelia.alignment.util.FileUtil;
+
+/**
+ * Parameters for rendering tiles to storage.
+ */
+public class TileRenderParameters
+        implements Serializable {
+
+    public enum RenderType {
+        EIGHT_BIT, SIXTEEN_BIT, ARGB
+    }
+
+    @Parameter(
+            names = "--rootDirectory",
+            description = "Root directory for rendered tiles (e.g. /nrs/flyem/render/tiles)",
+            required = true)
+    public String rootDirectory;
+
+    @Parameter(
+            names = "--runTimestamp",
+            description = "Run timestamp to use in directory path for rendered tiles (e.g. 20220830_093700).  " +
+                          "Omit to use calculated timestamp.  " +
+                          "Include for array jobs to ensure all tiles are rendered under same base path")
+    public String runTimestamp;
+
+    @Parameter(
+            names = "--scale",
+            description = "Scale for each rendered tile"
+    )
+    public Double scale = 1.0;
+
+    @Parameter(
+            names = "--format",
+            description = "Format for rendered tiles"
+    )
+    public String format = Utils.PNG_FORMAT;
+
+    @Parameter(
+            names = "--doFilter",
+            description = "Use ad hoc filter to support alignment",
+            arity = 0)
+    public boolean doFilter = false;
+
+    @Parameter(
+            names = "--renderType",
+            description = "How the tiles should be rendered")
+    public RenderType renderType = RenderType.EIGHT_BIT;
+
+    @Parameter(
+            names = "--filterListName",
+            description = "Apply this filter list to all rendering (overrides doFilter option)"
+    )
+    public String filterListName;
+
+    @Parameter(
+            names = "--channels",
+            description = "Specify channel(s) and weights to render (e.g. 'DAPI' or 'DAPI__0.7__TdTomato__0.3')"
+    )
+    public String channels;
+
+    @Parameter(
+            names = "--fillWithNoise",
+            description = "Fill image with noise before rendering to improve point match derivation",
+            arity = 0)
+    public boolean fillWithNoise = false;
+
+    @Parameter(
+            names = "--maxIntensity",
+            description = "Max intensity to render image"
+    )
+    public Integer maxIntensity;
+
+    @Parameter(
+            names = "--minIntensity",
+            description = "Min intensity to render image"
+    )
+    public Integer minIntensity;
+
+    @Parameter(
+            names = "--excludeMask",
+            description = "Exclude tile masks when rendering",
+            arity = 0)
+    public boolean excludeMask = false;
+
+    @Parameter(
+            names = "--excludeAllTransforms",
+            description = "Exclude all tile transforms when rendering",
+            arity = 0)
+    public boolean excludeAllTransforms = false;
+
+    @Parameter(
+            names = "--renderMaskOnly",
+            description = "Only render transformed mask for each tile",
+            arity = 0)
+    public boolean renderMaskOnly = false;
+
+    @Parameter(
+            names = "--z",
+            description = "Z values for tiles to render",
+            variableArity = true)
+    public List<Double> zValues;
+
+    @Parameter(
+            names = "--tileIds",
+            description = "Explicit IDs for tiles to render",
+            variableArity = true
+    )
+    public List<String> tileIds;
+
+    @Parameter(
+            names = "--tileIdPattern",
+            description = "Only include tileIds that match this pattern (filters z based and explicit tile ids)"
+    )
+    public String tileIdPattern;
+
+    @Parameter(
+            names = "--hackStack",
+            description = "If specified, create tile specs that reference the rendered tiles " +
+                          "and save them to this stack.  The hackTransformCount determines how " +
+                          "many transforms are rendered and how many are included in each tile spec.")
+    public String hackStack;
+
+    @Parameter(
+            names = "--hackTransformCount",
+            description = "Number of transforms to remove from the end of each tile spec's list " +
+                          "during rendering but then include in the hack stack's tile specs")
+    public Integer hackTransformCount;
+
+    @Parameter(
+            names = "--completeHackStack",
+            description = "Complete the hack stack after saving all tile specs",
+            arity = 0)
+    public boolean completeHackStack = false;
+
+    public String getRunTimestamp() {
+        if (this.runTimestamp == null) {
+            final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+            this.runTimestamp = sdf.format(new Date());
+        }
+        return this.runTimestamp;
+    }
+    public static TileRenderParameters fromJson(final Reader json) {
+        return JSON_HELPER.fromJson(json);
+    }
+
+    public static TileRenderParameters fromJsonFile(final String dataFile)
+            throws IOException {
+        final TileRenderParameters parameters;
+        final Path path = FileSystems.getDefault().getPath(dataFile).toAbsolutePath();
+        try (final Reader reader = FileUtil.DEFAULT_INSTANCE.getExtensionBasedReader(path.toString())) {
+            parameters = fromJson(reader);
+        }
+        return parameters;
+    }
+
+    private static final JsonUtils.Helper<TileRenderParameters> JSON_HELPER =
+            new JsonUtils.Helper<>(TileRenderParameters.class);
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
@@ -110,12 +110,6 @@ public class TileRenderParameters
     public boolean renderMaskOnly = false;
 
     @Parameter(
-            names = "--z",
-            description = "Z values for tiles to render",
-            variableArity = true)
-    public List<Double> zValues;
-
-    @Parameter(
             names = "--tileIds",
             description = "Explicit IDs for tiles to render",
             variableArity = true

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
@@ -9,11 +9,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,6 +20,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import javax.imageio.ImageIO;
 
 import mpicbg.trakem2.transform.TransformMeshMappingWithMasks;
 import mpicbg.trakem2.transform.TranslationModel2D;
@@ -51,6 +51,7 @@ import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.parameter.TileRenderParameters;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
@@ -58,8 +59,6 @@ import org.janelia.saalfeldlab.n5.LockedChannel;
 import org.janelia.saalfeldlab.n5.googlecloud.GoogleCloudStorageKeyValueAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.imageio.ImageIO;
 
 
 /**
@@ -72,10 +71,6 @@ import javax.imageio.ImageIO;
  */
 public class RenderTilesClient {
 
-    public enum RenderType {
-        EIGHT_BIT, SIXTEEN_BIT, ARGB
-    }
-
     public static class Parameters extends CommandLineParameters {
 
         @ParametersDelegate
@@ -87,135 +82,8 @@ public class RenderTilesClient {
                 required = true)
         public String stack;
 
-        @Parameter(
-                names = "--rootDirectory",
-                description = "Root directory for rendered tiles (e.g. /nrs/flyem/render/tiles)",
-                required = true)
-        public String rootDirectory;
-
-        @Parameter(
-                names = "--runTimestamp",
-                description = "Run timestamp to use in directory path for rendered tiles (e.g. 20220830_093700).  " +
-                              "Omit to use calculated timestamp.  " +
-                              "Include for array jobs to ensure all tiles are rendered under same base path")
-        public String runTimestamp;
-
-        @Parameter(
-                names = "--scale",
-                description = "Scale for each rendered tile"
-        )
-        public Double scale = 1.0;
-
-        @Parameter(
-                names = "--format",
-                description = "Format for rendered tiles"
-        )
-        public String format = Utils.PNG_FORMAT;
-
-        @Parameter(
-                names = "--doFilter",
-                description = "Use ad hoc filter to support alignment",
-                arity = 0)
-        public boolean doFilter = false;
-
-        @Parameter(
-                names = "--renderType",
-                description = "How the tiles should be rendered")
-        public RenderType renderType = RenderType.EIGHT_BIT;
-
-        @Parameter(
-                names = "--filterListName",
-                description = "Apply this filter list to all rendering (overrides doFilter option)"
-        )
-        public String filterListName;
-
-        @Parameter(
-                names = "--channels",
-                description = "Specify channel(s) and weights to render (e.g. 'DAPI' or 'DAPI__0.7__TdTomato__0.3')"
-        )
-        public String channels;
-
-        @Parameter(
-                names = "--fillWithNoise",
-                description = "Fill image with noise before rendering to improve point match derivation",
-                arity = 0)
-        public boolean fillWithNoise = false;
-
-        @Parameter(
-                names = "--maxIntensity",
-                description = "Max intensity to render image"
-        )
-        public Integer maxIntensity;
-
-        @Parameter(
-                names = "--minIntensity",
-                description = "Min intensity to render image"
-        )
-        public Integer minIntensity;
-
-        @Parameter(
-                names = "--excludeMask",
-                description = "Exclude tile masks when rendering",
-                arity = 0)
-        public boolean excludeMask = false;
-
-        @Parameter(
-                names = "--excludeAllTransforms",
-                description = "Exclude all tile transforms when rendering",
-                arity = 0)
-        public boolean excludeAllTransforms = false;
-
-        @Parameter(
-                names = "--renderMaskOnly",
-                description = "Only render transformed mask for each tile",
-                arity = 0)
-        public boolean renderMaskOnly = false;
-
-        @Parameter(
-                names = "--z",
-                description = "Z values for tiles to render",
-                variableArity = true)
-        public List<Double> zValues;
-
-        @Parameter(
-                names = "--tileIds",
-                description = "Explicit IDs for tiles to render",
-                variableArity = true
-        )
-        public List<String> tileIds;
-
-        @Parameter(
-                names = "--tileIdPattern",
-                description = "Only include tileIds that match this pattern (filters z based and explicit tile ids)"
-        )
-        public String tileIdPattern;
-
-        @Parameter(
-                names = "--hackStack",
-                description = "If specified, create tile specs that reference the rendered tiles " +
-                              "and save them to this stack.  The hackTransformCount determines how " +
-                              "many transforms are rendered and how many are included in each tile spec.")
-        public String hackStack;
-
-        @Parameter(
-                names = "--hackTransformCount",
-                description = "Number of transforms to remove from the end of each tile spec's list " +
-                              "during rendering but then include in the hack stack's tile specs")
-        public Integer hackTransformCount;
-
-        @Parameter(
-                names = "--completeHackStack",
-                description = "Complete the hack stack after saving all tile specs",
-                arity = 0)
-        public boolean completeHackStack = false;
-
-        public String getRunTimestamp() {
-            if (this.runTimestamp == null) {
-                final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
-                this.runTimestamp = sdf.format(new Date());
-            }
-            return this.runTimestamp;
-        }
+        @ParametersDelegate
+        public TileRenderParameters tileRender = new TileRenderParameters();
     }
 
     /**
@@ -231,7 +99,9 @@ public class RenderTilesClient {
 
                 LOG.info("runClient: entry, parameters={}", parameters);
 
-                final RenderTilesClient client = new RenderTilesClient(parameters);
+                final RenderTilesClient client = new RenderTilesClient(parameters.renderWeb,
+                                                                       parameters.stack,
+                                                                       parameters.tileRender);
                 client.collectTileInfo();
                 client.renderTiles();
             }
@@ -239,7 +109,8 @@ public class RenderTilesClient {
         clientRunner.run();
     }
 
-    private final Parameters clientParameters;
+    private final String stack;
+    private final TileRenderParameters tileRender;
 
     private final ImageProcessorCache imageProcessorCache;
     private final RenderDataClient renderDataClient;
@@ -248,23 +119,26 @@ public class RenderTilesClient {
     private final Map<Double, ResolvedTileSpecCollection> zToResolvedTiles;
     private final StorageBackend storageBackend;
 
-    private RenderTilesClient(final Parameters clientParameters) {
+    public RenderTilesClient(final RenderWebServiceParameters renderWeb,
+                             final String stack,
+                             final TileRenderParameters tileRender) {
 
-        this.clientParameters = clientParameters;
+        this.stack = stack;
+        this.tileRender = tileRender;
 
         try {
-            final URIBuilder uriBuilder = new URIBuilder(clientParameters.rootDirectory);
+            final URIBuilder uriBuilder = new URIBuilder(tileRender.rootDirectory);
             final List<String> pathSegments = uriBuilder.getPathSegments();
-            pathSegments.add(clientParameters.renderWeb.project);
-            pathSegments.add(clientParameters.stack);
-            pathSegments.add(clientParameters.getRunTimestamp());
+            pathSegments.add(renderWeb.project);
+            pathSegments.add(stack);
+            pathSegments.add(tileRender.getRunTimestamp());
 
             final URI rootUri = uriBuilder.setPathSegments(pathSegments).build();
             this.storageBackend = StorageBackend.create(rootUri);
-            storageBackend.validateFormat(clientParameters.format);
+            storageBackend.validateFormat(tileRender.format);
             storageBackend.ensureWritableDirectory(storageBackend.root);
         } catch (final URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid root directory URI: " + clientParameters.rootDirectory, e);
+            throw new IllegalArgumentException("Invalid root directory URI: " + tileRender.rootDirectory, e);
         }
 
         // set cache size to 50MB so that masks get cached but most RAM is left for target images
@@ -273,37 +147,37 @@ public class RenderTilesClient {
                                                            false,
                                                            false);
 
-        this.renderDataClient = clientParameters.renderWeb.getDataClient();
+        this.renderDataClient = renderWeb.getDataClient();
 
         this.tileIds = new ArrayList<>();
 
         final StringBuilder queryParameters = new StringBuilder();
-        queryParameters.append("?scale=").append(clientParameters.scale);
-        if (clientParameters.doFilter) {
+        queryParameters.append("?scale=").append(tileRender.scale);
+        if (tileRender.doFilter) {
             queryParameters.append("&doFilter=true");
         }
-        if (clientParameters.filterListName != null) {
-            queryParameters.append("&filterListName=").append(clientParameters.filterListName);
+        if (tileRender.filterListName != null) {
+            queryParameters.append("&filterListName=").append(tileRender.filterListName);
         }
-        if (clientParameters.channels != null) {
-            if (clientParameters.hackStack != null) {
+        if (tileRender.channels != null) {
+            if (tileRender.hackStack != null) {
                 throw new IllegalArgumentException("explicit channels cannot be specified when creating a hack stack");
             }
-            queryParameters.append("&channels=").append(clientParameters.channels);
+            queryParameters.append("&channels=").append(tileRender.channels);
         }
-        if (clientParameters.fillWithNoise) {
+        if (tileRender.fillWithNoise) {
             queryParameters.append("&fillWithNoise=true");
         }
-        if (clientParameters.minIntensity != null) {
-            queryParameters.append("&minIntensity=").append(clientParameters.minIntensity);
+        if (tileRender.minIntensity != null) {
+            queryParameters.append("&minIntensity=").append(tileRender.minIntensity);
         }
-        if (clientParameters.maxIntensity != null) {
-            queryParameters.append("&maxIntensity=").append(clientParameters.maxIntensity);
+        if (tileRender.maxIntensity != null) {
+            queryParameters.append("&maxIntensity=").append(tileRender.maxIntensity);
         }
-        if (clientParameters.excludeMask) {
+        if (tileRender.excludeMask) {
             queryParameters.append("&excludeMask=true");
         }
-        if (clientParameters.excludeAllTransforms) {
+        if (tileRender.excludeAllTransforms) {
             queryParameters.append("&excludeAllTransforms=true");
         }
         // excludeSource needs to be handled locally (not supported by web service)
@@ -315,31 +189,31 @@ public class RenderTilesClient {
     private void collectTileInfo()
             throws IOException {
 
-        if (clientParameters.zValues != null) {
-            for (final Double z : clientParameters.zValues) {
-                if (clientParameters.hackStack == null) {
-                    final List<TileBounds> tileBoundsList = renderDataClient.getTileBounds(clientParameters.stack, z);
+        if (tileRender.zValues != null) {
+            for (final Double z : tileRender.zValues) {
+                if (tileRender.hackStack == null) {
+                    final List<TileBounds> tileBoundsList = renderDataClient.getTileBounds(stack, z);
                     tileBoundsList.forEach(tileBounds -> this.tileIds.add(tileBounds.getTileId()));
                 } else {
                     final ResolvedTileSpecCollection resolvedTiles =
-                            renderDataClient.getResolvedTiles(clientParameters.stack, z);
+                            renderDataClient.getResolvedTiles(stack, z);
                     zToResolvedTiles.put(z, resolvedTiles);
                     resolvedTiles.getTileSpecs().forEach(tileSpec -> this.tileIds.add(tileSpec.getTileId()));
                 }
             }
         }
 
-        if (clientParameters.tileIds != null) {
-            if (clientParameters.hackStack != null) {
+        if (tileRender.tileIds != null) {
+            if (tileRender.hackStack != null) {
                 throw new IllegalArgumentException("explicit tile ids cannot be specified when creating a hack stack");
             }
-            tileIds.addAll(clientParameters.tileIds);
+            tileIds.addAll(tileRender.tileIds);
         }
 
-        if (clientParameters.tileIdPattern != null) {
-             final Pattern tileIdPattern = Pattern.compile(clientParameters.tileIdPattern);
+        if (tileRender.tileIdPattern != null) {
+             final Pattern tileIdPattern = Pattern.compile(tileRender.tileIdPattern);
              tileIds.removeIf(tileId -> ! tileIdPattern.matcher(tileId).matches());
-            if (clientParameters.hackStack != null) {
+            if (tileRender.hackStack != null) {
                 final Set<String> tileIdsToKeep = new HashSet<>(tileIds);
                 for (final ResolvedTileSpecCollection resolvedTiles : zToResolvedTiles.values()) {
                     resolvedTiles.retainTileSpecs(tileIdsToKeep);
@@ -356,22 +230,22 @@ public class RenderTilesClient {
     private void renderTiles()
             throws IOException {
 
-        if (clientParameters.hackStack != null) {
-            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(clientParameters.stack);
-            renderDataClient.setupDerivedStack(stackMetaData, clientParameters.hackStack);
-            renderDataClient.deleteMipmapPathBuilder(clientParameters.hackStack);
+        if (tileRender.hackStack != null) {
+            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stack);
+            renderDataClient.setupDerivedStack(stackMetaData, tileRender.hackStack);
+            renderDataClient.deleteMipmapPathBuilder(tileRender.hackStack);
         }
 
         for (final String tileId : tileIds) {
             renderTile(tileId);
         }
 
-        if (clientParameters.hackStack != null) {
+        if (tileRender.hackStack != null) {
             for (final Double z : zToResolvedTiles.keySet().stream().sorted().collect(Collectors.toList())) {
-                renderDataClient.saveResolvedTiles(zToResolvedTiles.get(z), clientParameters.hackStack, z);
+                renderDataClient.saveResolvedTiles(zToResolvedTiles.get(z), tileRender.hackStack, z);
             }
-            if (clientParameters.completeHackStack) {
-                renderDataClient.setStackState(clientParameters.hackStack, StackMetaData.StackState.COMPLETE);
+            if (tileRender.completeHackStack) {
+                renderDataClient.setStackState(tileRender.hackStack, StackMetaData.StackState.COMPLETE);
             }
         }
     }
@@ -380,13 +254,13 @@ public class RenderTilesClient {
             throws IOException {
 
         final RenderWebServiceUrls urls = renderDataClient.getUrls();
-        final String parametersUrl = urls.getTileUrlString(clientParameters.stack, tileId) + "/render-parameters" +
+        final String parametersUrl = urls.getTileUrlString(stack, tileId) + "/render-parameters" +
                                      renderParametersQueryString;
 
         final RenderParameters renderParameters = RenderParameters.loadFromUrl(parametersUrl);
         final TileSpec tileSpec = renderParameters.getTileSpecs().get(0);
 
-        if (clientParameters.renderMaskOnly) {
+        if (tileRender.renderMaskOnly) {
 
             // this hack conversion is needed to simplify working with channel specs below
             final String firstChannelName = tileSpec.getFirstChannelName();
@@ -406,9 +280,9 @@ public class RenderTilesClient {
 
         }
 
-        if (clientParameters.hackStack != null) {
-            if (clientParameters.hackTransformCount != null) {
-                for (int i = 0; i < clientParameters.hackTransformCount; i++) {
+        if (tileRender.hackStack != null) {
+            if (tileRender.hackTransformCount != null) {
+                for (int i = 0; i < tileRender.hackTransformCount; i++) {
                     tileSpec.removeLastTransformSpec();
                 }
             }
@@ -424,30 +298,30 @@ public class RenderTilesClient {
                 Renderer.renderImageProcessorWithMasks(renderParameters, imageProcessorCache, null);
 
         // Get URI for the tile file and convert to File for backwards compatibility
-        final String format = clientParameters.format.toLowerCase();
+        final String format = tileRender.format.toLowerCase();
         final List<String> imagePathSegments = getImagePathSegments(tileSpec, format);
         final URI imageUri = storageBackend.resolvePath(imagePathSegments);
 
         final BufferedImage bufferedImage;
-        if ((clientParameters.renderType == RenderType.ARGB) || (! clientParameters.excludeMask)) {
+        if ((tileRender.renderType == TileRenderParameters.RenderType.ARGB) || (! tileRender.excludeMask)) {
             // this incorporates the mask if it exists into the rendered image
             bufferedImage = ArgbRenderer.CONVERTER.convertProcessorWithMasksToImage(renderParameters,
                                                                                     imageProcessorWithMasks);
-        } else if (clientParameters.renderType == RenderType.EIGHT_BIT) {
+        } else if (tileRender.renderType == TileRenderParameters.RenderType.EIGHT_BIT) {
             // this only converts the image processor and ignores the mask
             bufferedImage = ByteRenderer.CONVERTER.convertProcessorWithMasksToImage(renderParameters,
                                                                                     imageProcessorWithMasks);
-        } else if (clientParameters.renderType == RenderType.SIXTEEN_BIT) {
+        } else if (tileRender.renderType == TileRenderParameters.RenderType.SIXTEEN_BIT) {
             // this only converts the image processor and ignores the mask
             bufferedImage = ShortRenderer.CONVERTER.convertProcessorWithMasksToImage(renderParameters,
                                                                                      imageProcessorWithMasks);
         } else {
-            throw new IllegalArgumentException("unsupported render type: " + clientParameters.renderType);
+            throw new IllegalArgumentException("unsupported render type: " + tileRender.renderType);
         }
 
         final String imageUrl = storageBackend.writeImage(bufferedImage, imageUri, format, renderParameters);
 
-        if (clientParameters.hackStack != null) {
+        if (tileRender.hackStack != null) {
             final ResolvedTileSpecCollection resolvedTiles = zToResolvedTiles.get(tileSpec.getZ());
             final TileSpec hackedTileSpec = resolvedTiles.getTileSpec(tileId);
             final double preHackMinX = hackedTileSpec.getMinX();
@@ -496,12 +370,12 @@ public class RenderTilesClient {
             hackedTileSpec.setWidth((double) imageProcessorWithMasks.ip.getWidth());
             hackedTileSpec.setHeight((double) imageProcessorWithMasks.ip.getHeight());
 
-            if (clientParameters.hackTransformCount != null) {
+            if (tileRender.hackTransformCount != null) {
                 // set hacked tile transforms
                 final Deque<TransformSpec> transformStack = new ArrayDeque<>();
                 final ListTransformSpec flattenedList = new ListTransformSpec();
                 hackedTileSpec.getTransforms().flatten(flattenedList);
-                for (int i = 0; i < clientParameters.hackTransformCount; i++) {
+                for (int i = 0; i < tileRender.hackTransformCount; i++) {
                     transformStack.push(flattenedList.getLastSpec());
                     flattenedList.removeLastSpec();
                 }

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
@@ -99,13 +99,21 @@ public class RenderTilesClient {
                 for (final StackWithZValues stackWithZValues : stackWithZValuesList) {
 
                     final StackId stackId = stackWithZValues.getStackId();
-                    final RenderDataClient projectClient =
+                    final RenderDataClient projectDataClient =
                             multiProjectDataClient.buildClientForProject(stackId.getProject());
 
-                    final RenderTilesClient client = new RenderTilesClient(projectClient,
+                    final RenderTilesClient client = new RenderTilesClient(projectDataClient,
                                                                            stackId.getStack(),
                                                                            parameters.tileRender);
+                    setupHackStackAsNeeded(projectDataClient,
+                                           stackId.getStack(),
+                                           parameters.tileRender.hackStack);
+
                     client.collectTileInfoAndRenderTiles(stackWithZValues.getzValues());
+
+                    completeHackStackAsNeeded(projectDataClient,
+                                              parameters.tileRender.hackStack,
+                                              parameters.tileRender.completeHackStack);
                 }
             }
         };
@@ -228,12 +236,6 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("There are no tiles to render!");
         }
 
-        if (tileRender.hackStack != null) {
-            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stack);
-            renderDataClient.setupDerivedStack(stackMetaData, tileRender.hackStack);
-            renderDataClient.deleteMipmapPathBuilder(tileRender.hackStack);
-        }
-
         for (final String tileId : tileIds) {
             renderTile(tileId);
         }
@@ -242,9 +244,26 @@ public class RenderTilesClient {
             for (final Double z : zToResolvedTiles.keySet().stream().sorted().collect(Collectors.toList())) {
                 renderDataClient.saveResolvedTiles(zToResolvedTiles.get(z), tileRender.hackStack, z);
             }
-            if (tileRender.completeHackStack) {
-                renderDataClient.setStackState(tileRender.hackStack, StackMetaData.StackState.COMPLETE);
-            }
+        }
+    }
+
+    public static void setupHackStackAsNeeded(final RenderDataClient renderDataClient,
+                                              final String stackName,
+                                              final String hackStackName)
+            throws IOException {
+        if (hackStackName != null) {
+            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stackName);
+            renderDataClient.setupDerivedStack(stackMetaData, hackStackName);
+            renderDataClient.deleteMipmapPathBuilder(hackStackName);
+        }
+    }
+
+    public static void completeHackStackAsNeeded(final RenderDataClient renderDataClient,
+                                                 final String hackStackName,
+                                                 final boolean completeHackStack)
+            throws IOException {
+        if (completeHackStack && (hackStackName != null)){
+            renderDataClient.setStackState(hackStackName, StackMetaData.StackState.COMPLETE);
         }
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
@@ -61,6 +61,8 @@ import org.janelia.saalfeldlab.n5.googlecloud.GoogleCloudStorageKeyValueAccess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.annotation.Nonnull;
+
 
 /**
  * Java client for rendering individual tiles.  Images are placed in:
@@ -105,15 +107,9 @@ public class RenderTilesClient {
                     final RenderTilesClient client = new RenderTilesClient(projectDataClient,
                                                                            stackId.getStack(),
                                                                            parameters.tileRender);
-                    setupHackStackAsNeeded(projectDataClient,
-                                           stackId.getStack(),
-                                           parameters.tileRender.hackStack);
-
-                    client.collectTileInfoAndRenderTiles(stackWithZValues.getzValues());
-
-                    completeHackStackAsNeeded(projectDataClient,
-                                              parameters.tileRender.hackStack,
-                                              parameters.tileRender.completeHackStack);
+                    client.setupHackStackAsNeeded();
+                    client.renderTiles(stackWithZValues.getzValues());
+                    client.completeHackStackAsNeeded();
                 }
             }
         };
@@ -123,9 +119,7 @@ public class RenderTilesClient {
     private final String stack;
     private final TileRenderParameters tileRender;
 
-    private final ImageProcessorCache imageProcessorCache;
     private final RenderDataClient renderDataClient;
-    private final List<String> tileIds;
     private final String renderParametersQueryString;
     private final Map<Double, ResolvedTileSpecCollection> zToResolvedTiles;
     private final StorageBackend storageBackend;
@@ -152,15 +146,7 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("Invalid root directory URI: " + tileRender.rootDirectory, e);
         }
 
-        // set cache size to 50MB so that masks get cached but most RAM is left for target images
-        final int maxCachedPixels = 50 * 1000000;
-        this.imageProcessorCache = new ImageProcessorCache(maxCachedPixels,
-                                                           false,
-                                                           false);
-
         this.renderDataClient = projectDataClient;
-
-        this.tileIds = new ArrayList<>();
 
         final StringBuilder queryParameters = new StringBuilder();
         queryParameters.append("?scale=").append(tileRender.scale);
@@ -197,19 +183,43 @@ public class RenderTilesClient {
         this.zToResolvedTiles = new HashMap<>();
     }
 
-    public void collectTileInfoAndRenderTiles(final List<Double> zValues)
+    public void renderTiles(final List<Double> zValues)
             throws IOException {
+
+        // set cache size to 50MB so that masks get cached but most RAM is left for target images
+        final int maxCachedPixels = 50 * 1000000;
+        final ImageProcessorCache imageProcessorCache = new ImageProcessorCache(maxCachedPixels,
+                                                                                false,
+                                                                                false);
+
+        final List<String> tileIds = buildTileIdsList(zValues);
+        for (final String tileId : tileIds) {
+            renderTile(tileId, imageProcessorCache);
+        }
+
+        if (tileRender.hackStack != null) {
+            for (final Double z : zValues) {
+                renderDataClient.saveResolvedTiles(zToResolvedTiles.get(z), tileRender.hackStack, z);
+            }
+        }
+    }
+
+    @Nonnull
+    private List<String> buildTileIdsList(final List<Double> zValues)
+            throws IOException {
+
+        final List<String> tileIds = new ArrayList<>();
 
         if (zValues != null) {
             for (final Double z : zValues) {
                 if (tileRender.hackStack == null) {
                     final List<TileBounds> tileBoundsList = renderDataClient.getTileBounds(stack, z);
-                    tileBoundsList.forEach(tileBounds -> this.tileIds.add(tileBounds.getTileId()));
+                    tileBoundsList.forEach(tileBounds -> tileIds.add(tileBounds.getTileId()));
                 } else {
                     final ResolvedTileSpecCollection resolvedTiles =
                             renderDataClient.getResolvedTiles(stack, z);
                     zToResolvedTiles.put(z, resolvedTiles);
-                    resolvedTiles.getTileSpecs().forEach(tileSpec -> this.tileIds.add(tileSpec.getTileId()));
+                    resolvedTiles.getTileSpecs().forEach(tileSpec -> tileIds.add(tileSpec.getTileId()));
                 }
             }
         }
@@ -236,38 +246,27 @@ public class RenderTilesClient {
             throw new IllegalArgumentException("There are no tiles to render!");
         }
 
-        for (final String tileId : tileIds) {
-            renderTile(tileId);
-        }
+        return tileIds;
+    }
 
+    public void setupHackStackAsNeeded()
+            throws IOException {
         if (tileRender.hackStack != null) {
-            for (final Double z : zToResolvedTiles.keySet().stream().sorted().collect(Collectors.toList())) {
-                renderDataClient.saveResolvedTiles(zToResolvedTiles.get(z), tileRender.hackStack, z);
-            }
+            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stack);
+            renderDataClient.setupDerivedStack(stackMetaData, tileRender.hackStack);
+            renderDataClient.deleteMipmapPathBuilder(tileRender.hackStack);
         }
     }
 
-    public static void setupHackStackAsNeeded(final RenderDataClient renderDataClient,
-                                              final String stackName,
-                                              final String hackStackName)
+    public void completeHackStackAsNeeded()
             throws IOException {
-        if (hackStackName != null) {
-            final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stackName);
-            renderDataClient.setupDerivedStack(stackMetaData, hackStackName);
-            renderDataClient.deleteMipmapPathBuilder(hackStackName);
+        if (tileRender.completeHackStack && (tileRender.hackStack != null)){
+            renderDataClient.setStackState(tileRender.hackStack, StackMetaData.StackState.COMPLETE);
         }
     }
 
-    public static void completeHackStackAsNeeded(final RenderDataClient renderDataClient,
-                                                 final String hackStackName,
-                                                 final boolean completeHackStack)
-            throws IOException {
-        if (completeHackStack && (hackStackName != null)){
-            renderDataClient.setStackState(hackStackName, StackMetaData.StackState.COMPLETE);
-        }
-    }
-
-    private void renderTile(final String tileId)
+    private void renderTile(final String tileId,
+                            final ImageProcessorCache imageProcessorCache)
             throws IOException {
 
         final RenderWebServiceUrls urls = renderDataClient.getUrls();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client;
+package org.janelia.render.client.tile;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
@@ -47,6 +47,8 @@ import org.janelia.alignment.spec.stack.StackMetaData;
 import org.janelia.alignment.util.FileUtil;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.alignment.util.RenderWebServiceUrls;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/tile/RenderTilesClient.java
@@ -1,6 +1,5 @@
 package org.janelia.render.client.tile;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 
 import java.awt.image.BufferedImage;
@@ -43,14 +42,16 @@ import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileBounds;
 import org.janelia.alignment.spec.TileSpec;
 import org.janelia.alignment.spec.TransformSpec;
+import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackMetaData;
+import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.alignment.util.FileUtil;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.alignment.util.RenderWebServiceUrls;
 import org.janelia.render.client.ClientRunner;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
-import org.janelia.render.client.parameter.RenderWebServiceParameters;
+import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.TileRenderParameters;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
@@ -74,13 +75,7 @@ public class RenderTilesClient {
     public static class Parameters extends CommandLineParameters {
 
         @ParametersDelegate
-        public RenderWebServiceParameters renderWeb = new RenderWebServiceParameters();
-
-        @Parameter(
-                names = "--stack",
-                description = "Stack name",
-                required = true)
-        public String stack;
+        public MultiProjectParameters multiProject = new MultiProjectParameters();
 
         @ParametersDelegate
         public TileRenderParameters tileRender = new TileRenderParameters();
@@ -99,11 +94,19 @@ public class RenderTilesClient {
 
                 LOG.info("runClient: entry, parameters={}", parameters);
 
-                final RenderTilesClient client = new RenderTilesClient(parameters.renderWeb,
-                                                                       parameters.stack,
-                                                                       parameters.tileRender);
-                client.collectTileInfo();
-                client.renderTiles();
+                final RenderDataClient multiProjectDataClient = parameters.multiProject.getDataClient();
+                final List<StackWithZValues> stackWithZValuesList = parameters.multiProject.buildListOfStackWithAllZ();
+                for (final StackWithZValues stackWithZValues : stackWithZValuesList) {
+
+                    final StackId stackId = stackWithZValues.getStackId();
+                    final RenderDataClient projectClient =
+                            multiProjectDataClient.buildClientForProject(stackId.getProject());
+
+                    final RenderTilesClient client = new RenderTilesClient(projectClient,
+                                                                           stackId.getStack(),
+                                                                           parameters.tileRender);
+                    client.collectTileInfoAndRenderTiles(stackWithZValues.getzValues());
+                }
             }
         };
         clientRunner.run();
@@ -119,7 +122,7 @@ public class RenderTilesClient {
     private final Map<Double, ResolvedTileSpecCollection> zToResolvedTiles;
     private final StorageBackend storageBackend;
 
-    public RenderTilesClient(final RenderWebServiceParameters renderWeb,
+    public RenderTilesClient(final RenderDataClient projectDataClient,
                              final String stack,
                              final TileRenderParameters tileRender) {
 
@@ -129,7 +132,7 @@ public class RenderTilesClient {
         try {
             final URIBuilder uriBuilder = new URIBuilder(tileRender.rootDirectory);
             final List<String> pathSegments = uriBuilder.getPathSegments();
-            pathSegments.add(renderWeb.project);
+            pathSegments.add(projectDataClient.getProject());
             pathSegments.add(stack);
             pathSegments.add(tileRender.getRunTimestamp());
 
@@ -147,7 +150,7 @@ public class RenderTilesClient {
                                                            false,
                                                            false);
 
-        this.renderDataClient = renderWeb.getDataClient();
+        this.renderDataClient = projectDataClient;
 
         this.tileIds = new ArrayList<>();
 
@@ -186,11 +189,11 @@ public class RenderTilesClient {
         this.zToResolvedTiles = new HashMap<>();
     }
 
-    private void collectTileInfo()
+    public void collectTileInfoAndRenderTiles(final List<Double> zValues)
             throws IOException {
 
-        if (tileRender.zValues != null) {
-            for (final Double z : tileRender.zValues) {
+        if (zValues != null) {
+            for (final Double z : zValues) {
                 if (tileRender.hackStack == null) {
                     final List<TileBounds> tileBoundsList = renderDataClient.getTileBounds(stack, z);
                     tileBoundsList.forEach(tileBounds -> this.tileIds.add(tileBounds.getTileId()));
@@ -224,11 +227,6 @@ public class RenderTilesClient {
         if (tileIds.isEmpty()) {
             throw new IllegalArgumentException("There are no tiles to render!");
         }
-
-    }
-
-    private void renderTiles()
-            throws IOException {
 
         if (tileRender.hackStack != null) {
             final StackMetaData stackMetaData = renderDataClient.getStackMetaData(stack);

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/tile/RenderTilesClientTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/tile/RenderTilesClientTest.java
@@ -1,4 +1,4 @@
-package org.janelia.render.client;
+package org.janelia.render.client.tile;
 
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.junit.Test;
@@ -23,20 +23,22 @@ public class RenderTilesClientTest {
         try {
             final String[] testArgs = {
                     "--baseDataUrl", "http://em-services-1.int.janelia.org:8080/render-ws/v1",
-                    "--owner", "fibsem",
-                    "--project", "jrc_mpi_psc120_1a1",
-                    "--stack", "v2_acquire_align_16bit",
-                    "--rootDirectory", "/Users/trautmane/Desktop/tiles_destreak",
-                    "--runTimestamp", "20241123_160000",
+                    "--owner", "hess_wafers_60_61",
+                    "--project", "w60_serial_360_to_369",
+                    "--stack", "w60_s360_r00_gc_mt5",
+                    "--rootDirectory", "/Users/trautmane/Desktop/tiles_test",
+//                    "--rootDirectory", "gs://storage.googleapis.com/janelia-spark-test/test_upload_ett/mfov_as_tile",
+//                    "--runTimestamp", "20241123_160000",
                     "--scale", "1.0",
                     "--format", "png",
                     "--excludeMask",
                     "--excludeAllTransforms",
-                    "--filterListName", "jrc_mpi_psc120_1a1-destreak-16bit",
+//                    "--filterListName", "jrc_mpi_psc120_1a1-destreak-16bit",
 //                    "--hackStack", "v3_acquire_align_16bit_destreak_test",
-                    "--renderType", "SIXTEEN_BIT",
+                    "--renderType", "EIGHT_BIT",
 //                    "--completeHackStack",
-                    "--z", "78.0"
+                    "--z", "1",
+                    "--tileIdPattern", ".*_m005."
             };
 
             RenderTilesClient.main(testArgs);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -23,6 +23,7 @@ import org.janelia.render.client.parameter.MipmapParameters;
 import org.janelia.render.client.parameter.MultiProjectParameters;
 import org.janelia.render.client.parameter.ScapeParameters;
 import org.janelia.render.client.parameter.TileClusterParameters;
+import org.janelia.render.client.parameter.TileRenderParameters;
 import org.janelia.render.client.parameter.UnconnectedCrossMFOVParameters;
 import org.janelia.render.client.parameter.ZSpacingParameters;
 
@@ -51,10 +52,12 @@ public class AlignmentPipelineParameters
     private final ZSpacingParameters zSpacing;
     private final MaskHackParameters maskHack;
     private final ScapeParameters scape;
+    private final TileRenderParameters tileRender;
 
     @SuppressWarnings("unused")
     public AlignmentPipelineParameters() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -83,7 +86,8 @@ public class AlignmentPipelineParameters
                                        final IntensityCorrectionSetup intensityCorrectionSetup,
                                        final ZSpacingParameters zSpacing,
                                        final MaskHackParameters maskHack,
-                                       final ScapeParameters scape) {
+                                       final ScapeParameters scape,
+                                       final TileRenderParameters tileRender) {
         this.multiProject = multiProject;
         this.pipelineStackGroups = pipelineStackGroups;
         this.pipelineSteps = pipelineSteps;
@@ -98,6 +102,7 @@ public class AlignmentPipelineParameters
         this.zSpacing = zSpacing;
         this.maskHack = maskHack;
         this.scape = scape;
+        this.tileRender = tileRender;
     }
 
     public MultiProjectParameters getMultiProject(final StackIdNamingGroup withNamingGroup) {
@@ -168,6 +173,10 @@ public class AlignmentPipelineParameters
 
     public ScapeParameters getScape() {
         return scape;
+    }
+
+    public TileRenderParameters getTileRender() {
+        return tileRender;
     }
 
     /**

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
@@ -12,6 +12,7 @@ import org.janelia.render.client.spark.multisem.MFOVMontageMatchPatchClient;
 import org.janelia.render.client.spark.multisem.UnconnectedCrossMFOVClient;
 import org.janelia.render.client.spark.newsolver.DistributedAffineBlockSolverClient;
 import org.janelia.render.client.spark.newsolver.DistributedIntensityCorrectionBlockSolverClient;
+import org.janelia.render.client.spark.tile.RenderTilesClient;
 import org.janelia.render.client.spark.zspacing.ZPositionCorrectionClient;
 
 /**
@@ -31,7 +32,8 @@ public enum AlignmentPipelineStepId {
     CORRECT_Z_POSITIONS(ZPositionCorrectionClient::new),
     CORRECT_INTENSITY(DistributedIntensityCorrectionBlockSolverClient::new),
     HACK_MASK(MaskHackClient::new),
-    RENDER_SCAPE_IMAGES(ScapeClient::new);
+    RENDER_SCAPE_IMAGES(ScapeClient::new),
+    RENDER_TILES(RenderTilesClient::new);
 
     private final Supplier<AlignmentPipelineStep> stepClientSupplier;
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
@@ -4,8 +4,8 @@ import com.beust.jcommander.ParametersDelegate;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
@@ -24,9 +24,6 @@ import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.janelia.render.client.tile.RenderTilesClient.completeHackStackAsNeeded;
-import static org.janelia.render.client.tile.RenderTilesClient.setupHackStackAsNeeded;
 
 /**
  * Spark client for rendering individual tiles.  Images are placed in:
@@ -119,18 +116,25 @@ public class RenderTilesClient
         // build a list of stacks with batched Z values since each z layer can be rendered in parallel
         final List<StackWithZValues> stackWithZValuesList = multiProjectParameters.buildListOfStackWithBatchedZ();
 
-        // if hack stacks are requested, set them up before rendering
-        final List<StackId> distinctStackIds = stackWithZValuesList.stream()
-                .map(StackWithZValues::getStackId).distinct().sorted().collect(Collectors.toList());
+        // build a java client for each stack before distributing the rendering tasks just to validate parameters
+        final List<org.janelia.render.client.tile.RenderTilesClient> javaStackSetupClients = new ArrayList<>();
+        stackWithZValuesList.stream()
+                .map(StackWithZValues::getStackId)
+                .distinct()
+                .sorted()
+                .forEach(stackId -> {
+                    final org.janelia.render.client.tile.RenderTilesClient jClient =
+                            buildJavaRenderTilesClient(baseDataUrl,
+                                                       stackId,
+                                                       tileRenderParameters);
+                    javaStackSetupClients.add(jClient);
+                });
+
+        // if hack stacks are requested, set them up before rendering using the javaStackSetupClients
         if (tileRenderParameters.hackStack != null) {
-           for(final StackId stackId : distinctStackIds) {
-               final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
-                                                                               stackId.getOwner(),
-                                                                               stackId.getProject());
-               setupHackStackAsNeeded(projectDataClient,
-                                      stackId.getStack(),
-                                      tileRenderParameters.hackStack);
-           }
+            for (final org.janelia.render.client.tile.RenderTilesClient jClient : javaStackSetupClients) {
+                jClient.setupHackStackAsNeeded();
+            }
         }
 
         final JavaRDD<StackWithZValues> rddStackWithZValues = sparkContext.parallelize(stackWithZValuesList);
@@ -140,15 +144,10 @@ public class RenderTilesClient
             LogUtilities.setupExecutorLog4j(stackWithZ.toString());
 
             final StackId stackId = stackWithZ.getStackId();
-            final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
-                                                                           stackId.getOwner(),
-                                                                           stackId.getProject());
-
-            final org.janelia.render.client.tile.RenderTilesClient jClient =
-                    new org.janelia.render.client.tile.RenderTilesClient(projectDataClient,
-                                                                         stackId.getStack(),
-                                                                         tileRenderParameters);
-            jClient.collectTileInfoAndRenderTiles(stackWithZ.getzValues());
+            final org.janelia.render.client.tile.RenderTilesClient jClient = buildJavaRenderTilesClient(baseDataUrl,
+                                                                                                        stackId,
+                                                                                                        tileRenderParameters);
+            jClient.renderTiles(stackWithZ.getzValues());
 
             return 1;
         };
@@ -159,19 +158,25 @@ public class RenderTilesClient
 
         LOG.info("renderTiles: completed rendering for {} stacks", resultList.size());
 
-        // if hack stacks are requested, complete them after rendering
+        // if hack stacks and completion are requested, complete them after rendering
         if ((tileRenderParameters.hackStack != null) && tileRenderParameters.completeHackStack) {
-            for(final StackId stackId : distinctStackIds) {
-                final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
-                                                                                stackId.getOwner(),
-                                                                                stackId.getProject());
-                completeHackStackAsNeeded(projectDataClient,
-                                          tileRenderParameters.hackStack,
-                                          tileRenderParameters.completeHackStack);
+            for (final org.janelia.render.client.tile.RenderTilesClient jClient : javaStackSetupClients) {
+                jClient.completeHackStackAsNeeded();
             }
         }
 
         LOG.info("renderTiles: exit");
+    }
+
+    private static org.janelia.render.client.tile.RenderTilesClient buildJavaRenderTilesClient(final String baseDataUrl,
+                                                                                               final StackId stackId,
+                                                                                               final TileRenderParameters tileRenderParameters) {
+        final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
+                                                                        stackId.getOwner(),
+                                                                        stackId.getProject());
+        return new org.janelia.render.client.tile.RenderTilesClient(projectDataClient,
+                                                                    stackId.getStack(),
+                                                                    tileRenderParameters);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(RenderTilesClient.class);

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
@@ -1,0 +1,148 @@
+package org.janelia.render.client.spark.tile;
+
+import com.beust.jcommander.ParametersDelegate;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackWithZValues;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.MultiProjectParameters;
+import org.janelia.render.client.parameter.TileRenderParameters;
+import org.janelia.render.client.spark.LogUtilities;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spark client for rendering individual tiles.  Images are placed in:
+ * <pre>
+ *   [rootDirectory]/[project]/[stack]/[runTimestamp]/[z-thousands]/[z-hundreds]/[z]/[tileId].[format]
+ * </pre>
+ */
+public class RenderTilesClient
+        implements Serializable, AlignmentPipelineStep {
+
+    public static class Parameters extends CommandLineParameters {
+        @ParametersDelegate
+        public MultiProjectParameters multiProject = new MultiProjectParameters();
+
+        @ParametersDelegate
+        public TileRenderParameters tileRender = new TileRenderParameters();
+
+        public Parameters() {
+        }
+
+        public Parameters(final MultiProjectParameters multiProject,
+                          final TileRenderParameters tileRender) {
+            this.multiProject = multiProject;
+            this.tileRender = tileRender;
+        }
+    }
+
+    /** Run the client with command line parameters. */
+    public static void main(final String[] args) {
+        final ClientRunner clientRunner = new ClientRunner(args) {
+            @Override
+            public void runClient(final String[] args) throws Exception {
+                final Parameters parameters = new Parameters();
+                parameters.parse(args);
+                final RenderTilesClient client = new RenderTilesClient();
+                client.createContextAndRun(parameters);
+            }
+        };
+        clientRunner.run();
+    }
+
+    /** Empty constructor required for alignment pipeline steps. */
+    public RenderTilesClient() {
+    }
+
+    /** Create a spark context and run the client with the specified parameters. */
+    public void createContextAndRun(final Parameters clientParameters) throws IOException {
+        final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
+        try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+            LOG.info("run: appId is {}", sparkContext.getConf().getAppId());
+            renderTiles(sparkContext, clientParameters);
+        }
+    }
+
+    /** Validates the specified pipeline parameters are sufficient. */
+    @Override
+    public void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException {
+        AlignmentPipelineParameters.validateRequiredElementExists("tileCluster",
+                                                                  pipelineParameters.getTileCluster());
+    }
+
+    /** Run the client as part of an alignment pipeline. */
+    public void runPipelineStep(final JavaSparkContext sparkContext,
+                                final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException, IOException {
+
+        final Parameters clientParameters = new Parameters();
+        clientParameters.multiProject = pipelineParameters.getMultiProject(pipelineParameters.getRawNamingGroup());
+        clientParameters.tileRender = pipelineParameters.getTileRender();
+
+        renderTiles(sparkContext, clientParameters);
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.RENDER_TILES;
+    }
+
+    private void renderTiles(final JavaSparkContext sparkContext,
+                             final Parameters clientParameters)
+            throws IOException {
+
+        LOG.info("renderTiles: entry, clientParameters={}", clientParameters);
+
+        final MultiProjectParameters multiProjectParameters = clientParameters.multiProject;
+        final String baseDataUrl = multiProjectParameters.getBaseDataUrl();
+        final List<StackWithZValues> stackWithZValuesList = multiProjectParameters.buildListOfStackWithAllZ();
+
+        // TODO: parallelize for each stack z instead of for each stack
+
+        final JavaRDD<StackWithZValues> rddStackWithZValues = sparkContext.parallelize(stackWithZValuesList);
+
+        final Function<StackWithZValues, Integer> renderStackFunction = stackWithZ -> {
+
+            LogUtilities.setupExecutorLog4j(stackWithZ.toString());
+
+            final StackId stackId = stackWithZ.getStackId();
+            final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
+                                                                           stackId.getOwner(),
+                                                                           stackId.getProject());
+
+            final org.janelia.render.client.tile.RenderTilesClient jClient =
+                    new org.janelia.render.client.tile.RenderTilesClient(projectDataClient,
+                                                                         stackId.getStack(),
+                                                                         clientParameters.tileRender);
+
+            jClient.collectTileInfoAndRenderTiles(stackWithZ.getzValues());
+
+            return 1;
+        };
+
+        final JavaRDD<Integer> rddSummaries = rddStackWithZValues.map(renderStackFunction);
+        
+        final List<Integer> resultList = rddSummaries.collect();
+
+        LOG.info("renderTiles: completed rendering for {} stacks", resultList.size());
+
+        LOG.info("renderTiles: exit");
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(RenderTilesClient.class);
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/tile/RenderTilesClient.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.ParametersDelegate;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
@@ -23,6 +24,9 @@ import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
 import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.janelia.render.client.tile.RenderTilesClient.completeHackStackAsNeeded;
+import static org.janelia.render.client.tile.RenderTilesClient.setupHackStackAsNeeded;
 
 /**
  * Spark client for rendering individual tiles.  Images are placed in:
@@ -110,9 +114,24 @@ public class RenderTilesClient
 
         final MultiProjectParameters multiProjectParameters = clientParameters.multiProject;
         final String baseDataUrl = multiProjectParameters.getBaseDataUrl();
-        final List<StackWithZValues> stackWithZValuesList = multiProjectParameters.buildListOfStackWithAllZ();
+        final TileRenderParameters tileRenderParameters = clientParameters.tileRender;
 
-        // TODO: parallelize for each stack z instead of for each stack
+        // build a list of stacks with batched Z values since each z layer can be rendered in parallel
+        final List<StackWithZValues> stackWithZValuesList = multiProjectParameters.buildListOfStackWithBatchedZ();
+
+        // if hack stacks are requested, set them up before rendering
+        final List<StackId> distinctStackIds = stackWithZValuesList.stream()
+                .map(StackWithZValues::getStackId).distinct().sorted().collect(Collectors.toList());
+        if (tileRenderParameters.hackStack != null) {
+           for(final StackId stackId : distinctStackIds) {
+               final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
+                                                                               stackId.getOwner(),
+                                                                               stackId.getProject());
+               setupHackStackAsNeeded(projectDataClient,
+                                      stackId.getStack(),
+                                      tileRenderParameters.hackStack);
+           }
+        }
 
         final JavaRDD<StackWithZValues> rddStackWithZValues = sparkContext.parallelize(stackWithZValuesList);
 
@@ -128,8 +147,7 @@ public class RenderTilesClient
             final org.janelia.render.client.tile.RenderTilesClient jClient =
                     new org.janelia.render.client.tile.RenderTilesClient(projectDataClient,
                                                                          stackId.getStack(),
-                                                                         clientParameters.tileRender);
-
+                                                                         tileRenderParameters);
             jClient.collectTileInfoAndRenderTiles(stackWithZ.getzValues());
 
             return 1;
@@ -140,6 +158,18 @@ public class RenderTilesClient
         final List<Integer> resultList = rddSummaries.collect();
 
         LOG.info("renderTiles: completed rendering for {} stacks", resultList.size());
+
+        // if hack stacks are requested, complete them after rendering
+        if ((tileRenderParameters.hackStack != null) && tileRenderParameters.completeHackStack) {
+            for(final StackId stackId : distinctStackIds) {
+                final RenderDataClient projectDataClient = new RenderDataClient(baseDataUrl,
+                                                                                stackId.getOwner(),
+                                                                                stackId.getProject());
+                completeHackStackAsNeeded(projectDataClient,
+                                          tileRenderParameters.hackStack,
+                                          tileRenderParameters.completeHackStack);
+            }
+        }
 
         LOG.info("renderTiles: exit");
     }

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/tile/RenderTilesClientTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/tile/RenderTilesClientTest.java
@@ -1,0 +1,16 @@
+package org.janelia.render.client.spark.tile;
+
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.junit.Test;
+
+/**
+ * Tests the {@link RenderTilesClient} class.
+ */
+public class RenderTilesClientTest {
+
+    @Test
+    public void testParameterParsing() throws Exception {
+        CommandLineParameters.parseHelp(new RenderTilesClient.Parameters());
+    }
+
+}


### PR DESCRIPTION
This PR extends the `RenderTilesClient` to be able to store rendered tiles¹ to cloud storage².

¹ Only PNGs are tested so far. The actual writing is done using `ImageIO.write` to write to a `ByteArrayOutputStream`, which is subsequently uploaded. Every format that is supported by that workflow should work, but the parameters `--convertToGray` and `--quality` are ignored right now.

² Only GCS is supported so far. For AWS, the changes to GCS shouldn't be too dramatic (since the actual object access is implemented using N5's `KeyValueAccess`), but I haven't spent the time figuring out authentication details.

Further caveats:
- We currently use an old version of N5GoogleCloud (4.1.1), which has bugs in URI handling. The bugs should be fixed in version 5.X.X, but for now all URI handling is done using other tools.
- The `KeyValueAccess` interface does not allow for fine-grained control over the upload. This results in all images being tagged with type `application/octet-stream`. To preview the images directly in GCS, one has to manually set the type to `image/png`.

I've tested that
- File system paths are the same as before the refactoring.
- Writing both images and masks works.
- GCS paths are correct.
- The paths are correctly stored in the hack stack and work (see [here](http://renderer.int.janelia.org:8080/render-ws/view/point-match-explorer.html?renderDataHost=renderer.int.janelia.org%3A8080&dynamicRenderHost=renderer.int.janelia.org%3A8080&catmaidHost=renderer-catmaid.int.janelia.org%3A8000&ndvizHost=renderer.int.janelia.org%3A8080&renderStackOwner=hess_wafers_60_61&renderStackProject=w60_serial_360_to_369&renderStack=w60_s360_r00_gc_mt_mi_test&startZ=1&endZ=1)).

Let me know if that's what you intended, @trautmane!