### PR TITLE
Fix gaps in mfov tiles

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/RenderTransformMeshMappingWithMasks.java
+++ b/render-app/src/main/java/org/janelia/alignment/RenderTransformMeshMappingWithMasks.java
@@ -150,6 +150,12 @@ public class RenderTransformMeshMappingWithMasks {
             return e;
         }
 
+        // Slightly shrink the rendering area to avoid artifacts at the edges. This only happens for axis-aligned
+        // images with integer origin coordinates, which is a valid use case (unaligned images).
+        final double eps = 1e-8;
+        affineTransform2D.scale(1.0 - eps);
+        affineTransform2D.translate(eps / 2, eps / 2);
+
         final LineMapper lineMapper = pixelMapper.createLineMapper();
         final double dx = affineTransform2D.d(0).getDoublePosition(0);
         final double dy = affineTransform2D.d(0).getDoublePosition(1);

--- a/render-app/src/main/java/org/janelia/alignment/RenderTransformMeshMappingWithMasks.java
+++ b/render-app/src/main/java/org/janelia/alignment/RenderTransformMeshMappingWithMasks.java
@@ -92,7 +92,7 @@ public class RenderTransformMeshMappingWithMasks {
         }
 
         @Override
-        final public void run() {
+        public void run() {
             int k = i.getAndIncrement();
             Exception lastIgnoredException = null;
             while (!isInterrupted() && k < triangles.size()) {
@@ -109,11 +109,11 @@ public class RenderTransformMeshMappingWithMasks {
      * Extract the inverse {@code model} transform
      * (mapping target to source coordinates).
      *
-     * @param model
+     * @param model the model to be inverted
      * @return the inverse model transform
-     * @throws NoninvertibleModelException
+     * @throws NoninvertibleModelException if the model is not invertible
      */
-    private static AffineTransform2D getTransformToSource(AffineModel2D model) throws NoninvertibleModelException {
+    private static AffineTransform2D getTransformToSource(final AffineModel2D model) throws NoninvertibleModelException {
         try {
             final AffineTransform2D transform = new AffineTransform2D();
             final double[] m = new double[6];
@@ -144,7 +144,7 @@ public class RenderTransformMeshMappingWithMasks {
         final int maxY = Math.min(pixelMapper.getTargetHeight() - 1, Util.roundPos(max[1]));
 
         final AffineTransform2D affineTransform2D;
-            try {
+        try {
             affineTransform2D = getTransformToSource(model);
         } catch (final NoninvertibleModelException e) {
             return e;

--- a/render-app/src/main/java/org/janelia/alignment/loader/MultiBoxDynamicMaskLoader.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/MultiBoxDynamicMaskLoader.java
@@ -108,8 +108,8 @@ public class MultiBoxDynamicMaskLoader
                 final int scaledY = (int) Math.floor(fullScaleY * renderScale);
 
                 // note that width and height need to be floored (not ceiled) to be in sync with the image
-                final int scaledBoundWidth = (int) Math.floor(fullScaleBound.getDeltaX() * renderScale);
-                final int scaledBoundHeight = (int) Math.floor(fullScaleBound.getDeltaY() * renderScale);
+                final int scaledBoundWidth = (int) Math.floor(fullScaleBound.getWidth() * renderScale);
+                final int scaledBoundHeight = (int) Math.floor(fullScaleBound.getHeight() * renderScale);
 
                 this.boxList.add(new Rectangle(scaledX, scaledY, scaledBoundWidth, scaledBoundHeight));
             }

--- a/render-app/src/main/java/org/janelia/alignment/loader/MultiBoxDynamicMaskLoader.java
+++ b/render-app/src/main/java/org/janelia/alignment/loader/MultiBoxDynamicMaskLoader.java
@@ -52,7 +52,8 @@ public class MultiBoxDynamicMaskLoader
 
         maskProcessor.setColor(255);
         for (final Rectangle box : description.boxList) {
-            maskProcessor.fillRect(box.x, box.y, box.width, box.height);
+            // TODO: this is an ad-hoc fix without strict justification; find out what's really causing the offset!
+            maskProcessor.fillRect(box.x + 1, box.y + 1, box.width, box.height);
         }
 
         final Matcher levelMatcher = LEVEL_PATTERN.matcher(urlString);


### PR DESCRIPTION
This PR aims to fix some gaps that occur in rendered mfov tiles for multi-sem. I found two causes of this:

- There seems to be an offset of about one pixel in both x and y direction of the content relative to the mask. This caused gaps at the boundary of the mfov. I couldn't find any plausible explanation why that might be, so I just hard-coded the offset into the mask loader for now.
- The general rendering code was susceptible to floating point fluctuations because the unaligned stacks have integer coordinates. This caused gaps between sfovs. I fixed this by shrinking the rendered area by a small amount (`1 - 1e-8`).

Because of the changes in the general rendering code, there are still some tests that are failing. Could you please tell me how to update the checksums in those tests, @trautmane ? Thanks!