### PR TITLE
MFOV prealign and intensity correction

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVAsTileStackClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVAsTileStackClient.java
@@ -91,6 +91,7 @@ public class MFOVAsTileStackClient {
             buildOneMFOVAsTileStack(stackWithZ,
                                     renderDataClient,
                                     parameters.mfovTileRenderScale,
+                                    "",
                                     parameters.mfovTileStackSuffix);
         }
     }
@@ -111,10 +112,11 @@ public class MFOVAsTileStackClient {
     public static StackId buildOneMFOVAsTileStack(final StackWithZValues stackWithZ,
                                                   final RenderDataClient renderDataClient,
                                                   final Double mfovTileRenderScale,
+                                                  final String sourceStackSuffix,
                                                   final String mfovTileStackSuffix)
             throws IOException, IllegalStateException {
 
-        final StackId sourceStackId = stackWithZ.getStackId();
+        final StackId sourceStackId = stackWithZ.getStackId().withStackSuffix(sourceStackSuffix);
         final String sourceStackName = sourceStackId.getStack();
         final StackId mfovAsTileStackId = stackWithZ.getStackId().withStackSuffix(mfovTileStackSuffix);
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
@@ -27,6 +27,7 @@ public class MFOVAsTileParameters
 
     private final Double mfovRenderScale;
     private final String mfovRootDirectory;
+    private final String prealignedMfovStackSuffix;
     private final String dynamicMfovStackSuffix;
     private final String renderedMfovStackSuffix;
     private final String alignedMfovStackSuffix;
@@ -38,7 +39,24 @@ public class MFOVAsTileParameters
              null,
              null,
              null,
+             null,
              null);
+    }
+
+    public MFOVAsTileParameters(final Double mfovRenderScale,
+                                final String mfovRootDirectory,
+                                final String prealignedMfovStackSuffix,
+                                final String dynamicMfovStackSuffix,
+                                final String renderedMfovStackSuffix,
+                                final String alignedMfovStackSuffix,
+                                final String roughSfovStackSuffix) {
+        this.mfovRenderScale = mfovRenderScale;
+        this.mfovRootDirectory = mfovRootDirectory;
+        this.prealignedMfovStackSuffix = prealignedMfovStackSuffix;
+        this.dynamicMfovStackSuffix = dynamicMfovStackSuffix;
+        this.renderedMfovStackSuffix = renderedMfovStackSuffix;
+        this.alignedMfovStackSuffix = alignedMfovStackSuffix;
+        this.roughSfovStackSuffix = roughSfovStackSuffix;
     }
 
     public MFOVAsTileParameters(final Double mfovRenderScale,
@@ -47,12 +65,13 @@ public class MFOVAsTileParameters
                                 final String renderedMfovStackSuffix,
                                 final String alignedMfovStackSuffix,
                                 final String roughSfovStackSuffix) {
-        this.mfovRenderScale = mfovRenderScale;
-        this.mfovRootDirectory = mfovRootDirectory;
-        this.dynamicMfovStackSuffix = dynamicMfovStackSuffix;
-        this.renderedMfovStackSuffix = renderedMfovStackSuffix;
-        this.alignedMfovStackSuffix = alignedMfovStackSuffix;
-        this.roughSfovStackSuffix = roughSfovStackSuffix;
+        this(mfovRenderScale,
+             mfovRootDirectory,
+             null,
+             dynamicMfovStackSuffix,
+             renderedMfovStackSuffix,
+             alignedMfovStackSuffix,
+             roughSfovStackSuffix);
     }
 
     public Double getMfovRenderScale() {
@@ -61,6 +80,10 @@ public class MFOVAsTileParameters
 
     public String getMfovRootDirectory() {
         return mfovRootDirectory;
+    }
+
+    public String getPrealignedMfovStackSuffix() {
+        return prealignedMfovStackSuffix;
     }
 
     public String getDynamicMfovStackSuffix() {
@@ -97,6 +120,10 @@ public class MFOVAsTileParameters
 
     public StackId getRoughSfovStackId(final StackId rawSfovStackId) {
         return rawSfovStackId.withStackSuffix(roughSfovStackSuffix);
+    }
+
+    public boolean doPrealign() {
+        return prealignedMfovStackSuffix != null;
     }
 
     public List<MatchRunParameters> buildMfovMatchRunList() {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
@@ -197,7 +197,7 @@ public class MFOVAsTileParameters
         return setup;
     }
 
-    private static MatchRunParameters buildMontageMatchRunParameters() {
+    public static MatchRunParameters buildMontageMatchRunParameters() {
         final List<MatchStageParameters> matchStageParametersList =
                 List.of(new MatchStageParameters("montageMfovAsTilePass1",
                                                  buildFeatureRenderParameters(0.4), // 11 secs for 15 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
@@ -277,7 +277,7 @@ public class MFOVAsTileParameters
         return featureRender;
     }
 
-    private static FeatureExtractionParameters buildFeatureExtractionParameters() {
+    public static FeatureExtractionParameters buildFeatureExtractionParameters() {
         final FeatureExtractionParameters featureExtraction = new FeatureExtractionParameters();
         featureExtraction.fdSize = 4;
         featureExtraction.maxScale = 1.0;
@@ -286,7 +286,7 @@ public class MFOVAsTileParameters
         return featureExtraction;
     }
 
-    private static MatchDerivationParameters buildFeatureMatchDerivation(final int matchMinNumInliers) {
+    public static MatchDerivationParameters buildFeatureMatchDerivation(final int matchMinNumInliers) {
         final MatchDerivationParameters featureMatchDerivation = new MatchDerivationParameters();
         featureMatchDerivation.matchFilter = MatchFilter.FilterType.SINGLE_SET;
         featureMatchDerivation.matchFullScaleCoverageRadius = 10.0;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
@@ -197,7 +197,7 @@ public class MFOVAsTileParameters
         return setup;
     }
 
-    public static MatchRunParameters buildMontageMatchRunParameters() {
+    private static MatchRunParameters buildMontageMatchRunParameters() {
         final List<MatchStageParameters> matchStageParametersList =
                 List.of(new MatchStageParameters("montageMfovAsTilePass1",
                                                  buildFeatureRenderParameters(0.4), // 11 secs for 15 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
@@ -277,7 +277,7 @@ public class MFOVAsTileParameters
         return featureRender;
     }
 
-    public static FeatureExtractionParameters buildFeatureExtractionParameters() {
+    private static FeatureExtractionParameters buildFeatureExtractionParameters() {
         final FeatureExtractionParameters featureExtraction = new FeatureExtractionParameters();
         featureExtraction.fdSize = 4;
         featureExtraction.maxScale = 1.0;
@@ -286,7 +286,7 @@ public class MFOVAsTileParameters
         return featureExtraction;
     }
 
-    public static MatchDerivationParameters buildFeatureMatchDerivation(final int matchMinNumInliers) {
+    private static MatchDerivationParameters buildFeatureMatchDerivation(final int matchMinNumInliers) {
         final MatchDerivationParameters featureMatchDerivation = new MatchDerivationParameters();
         featureMatchDerivation.matchFilter = MatchFilter.FilterType.SINGLE_SET;
         featureMatchDerivation.matchFullScaleCoverageRadius = 10.0;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
@@ -198,8 +198,7 @@ public class MFOVASTileClient
                     mfovTasks.add(new MfovPrealignTask(baseDataUrl,
                                                         rawSfovStackId,
                                                         prealignedStackId,
-                                                        new LayerMFOV(z, mfovName),
-                                                        mfovAsTile)
+                                                        new LayerMFOV(z, mfovName))
                     );
                 }
             }
@@ -212,7 +211,7 @@ public class MFOVASTileClient
             // Parallelize MFOV alignment tasks
             LOG.info("alignAndIntensityCorrectMfovAsTileStacks: aligning {} MFOVs", mfovTasks.size());
             final JavaRDD<MfovPrealignTask> rddMfovTasks = sparkContext.parallelize(mfovTasks);
-            rddMfovTasks.foreach(MfovPrealignTask::alignMfov);
+            rddMfovTasks.foreach(MfovPrealignTask::run);
 
             // Complete all prealigned stacks
             for (final StackId prealignedStackId : prealignedStackIds) {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
@@ -158,8 +158,74 @@ public class MFOVASTileClient
     }
 
     private static void alignAndIntensityCorrectMfovAsTileStacks(final JavaSparkContext sparkContext,
-                                                                 final MFOVAsTileStackLists mfovAsTileStackLists) {
-        // TODO: implement pre-alignment of MFOV-as-tile stacks
+                                                                 final MFOVAsTileStackLists mfovAsTileStackLists)
+            throws IOException {
+        LOG.info("alignAndIntensityCorrectMfovAsTileStacks: entry");
+
+        final String baseDataUrl = mfovAsTileStackLists.getBaseDataUrl();
+        final MFOVAsTileParameters mfovAsTile = mfovAsTileStackLists.getMfovAsTile();
+        final List<StackWithZValues> rawSfovStacksWithAllZ = mfovAsTileStackLists.getRawSfovStacksWithAllZ();
+
+        // Collect all MFOV processing tasks
+        final List<MfovPrealignTask> mfovTasks = new ArrayList<>();
+        final List<StackId> prealignedStackIds = new ArrayList<>();
+
+        for (final StackWithZValues rawSfovStackWithZ : rawSfovStacksWithAllZ) {
+            final StackId rawSfovStackId = rawSfovStackWithZ.getStackId();
+            final StackId prealignedStackId = rawSfovStackId.withStackSuffix(mfovAsTile.getPrealignedMfovStackSuffix());
+
+            // Skip if prealigned stack already exists
+            if (mfovAsTileStackLists.isExistingStack(prealignedStackId)) {
+                LOG.info("alignAndIntensityCorrectMfovAsTileStacks: skipping {} because it already exists",
+                         prealignedStackId.toDevString());
+//                continue;
+            }
+
+            // Create prealigned stack
+            final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                     rawSfovStackId.getOwner(),
+                                                                     rawSfovStackId.getProject());
+            final StackMetaData rawStackMetaData = dataClient.getStackMetaData(rawSfovStackId.getStack());
+            dataClient.setupDerivedStack(rawStackMetaData, prealignedStackId.getStack());
+            prealignedStackIds.add(prealignedStackId);
+
+            // Collect MFOV tasks for each layer
+            for (final Double z : rawSfovStackWithZ.getzValues()) {
+                final List<String> mfovNames = MultiProjectParameters.getSortedMFOVNamesForOneLayer(dataClient,
+                                                                                                    rawSfovStackId.getStack(),
+                                                                                                    z);
+                for (final String mfovName : mfovNames) {
+                    mfovTasks.add(new MfovPrealignTask(baseDataUrl,
+                                                        rawSfovStackId,
+                                                        prealignedStackId,
+                                                        new LayerMFOV(z, mfovName),
+                                                        mfovAsTile)
+                    );
+                }
+            }
+        }
+
+        if (!mfovTasks.isEmpty()) {
+            LOG.info("alignAndIntensityCorrectMfovAsTileStacks: distributing alignment of {} MFOV tasks across {} stacks",
+                     mfovTasks.size(), prealignedStackIds.size());
+
+            // Parallelize MFOV alignment tasks
+            LOG.info("alignAndIntensityCorrectMfovAsTileStacks: aligning {} MFOVs", mfovTasks.size());
+            final JavaRDD<MfovPrealignTask> rddMfovTasks = sparkContext.parallelize(mfovTasks);
+            rddMfovTasks.foreach(MfovPrealignTask::alignMfov);
+
+            // Complete all prealigned stacks
+            for (final StackId prealignedStackId : prealignedStackIds) {
+                final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                         prealignedStackId.getOwner(),
+                                                                         prealignedStackId.getProject());
+                LOG.info("alignAndIntensityCorrectMfovAsTileStacks: completing stack {}",
+                         prealignedStackId.toDevString());
+                dataClient.setStackState(prealignedStackId.getStack(), StackMetaData.StackState.COMPLETE);
+            }
+        }
+
+        LOG.info("alignAndIntensityCorrectMfovAsTileStacks: exit");
     }
 
     private static void buildDynamicMfovAsTileStacks(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
@@ -234,6 +234,7 @@ public class MFOVASTileClient
         final MFOVAsTileParameters mfovAsTile = mfovAsTileStackLists.getMfovAsTile();
         final double mfovRenderScale = mfovAsTile.getMfovRenderScale();
         final String dynamicMfovStackSuffix = mfovAsTile.getDynamicMfovStackSuffix();
+        final String prealignedStackSuffix = mfovAsTile.getPrealignedMfovStackSuffix();
 
         final List<StackWithZValues> rawSfovStacksWithAllZ = mfovAsTileStackLists.getRawSfovStacksWithAllZ();
 
@@ -261,6 +262,7 @@ public class MFOVASTileClient
                 builtStackId = MFOVAsTileStackClient.buildOneMFOVAsTileStack(stackWithAllZ,
                                                                              dataClient,
                                                                              mfovRenderScale,
+                                                                             prealignedStackSuffix,
                                                                              dynamicMfovStackSuffix);
             }
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
@@ -138,6 +138,10 @@ public class MFOVASTileClient
         final MFOVAsTileStackLists mfovAsTileStackLists = new MFOVAsTileStackLists(baseDataUrl,
                                                                                    clientParameters.multiProject,
                                                                                    clientParameters.mfovAsTile);
+        if (clientParameters.mfovAsTile.doPrealign()) {
+            alignAndIntensityCorrectMfovAsTileStacks(sparkContext, mfovAsTileStackLists);
+        }
+
         buildDynamicMfovAsTileStacks(sparkContext, mfovAsTileStackLists);
 
         buildRenderedMfovAsTileStacks(sparkContext, mfovAsTileStackLists);
@@ -151,6 +155,11 @@ public class MFOVASTileClient
         buildRoughSfovStacks(sparkContext, mfovAsTileStackLists);
 
         LOG.info("run: exit");
+    }
+
+    private static void alignAndIntensityCorrectMfovAsTileStacks(final JavaSparkContext sparkContext,
+                                                                 final MFOVAsTileStackLists mfovAsTileStackLists) {
+        // TODO: implement pre-alignment of MFOV-as-tile stacks
     }
 
     private static void buildDynamicMfovAsTileStacks(final JavaSparkContext sparkContext,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -341,21 +341,6 @@ public class MfovPrealignTask implements Serializable {
 	}
 
     /**
-     * Optimize tile transformations using the derived matches.
-     */
-    private ResolvedTileSpecCollection optimizeTileTransformations(final ResolvedTileSpecCollection mfovTiles,
-                                                                  final List<CanvasMatches> matches) {
-        LOG.info("optimizeTileTransformations: applying basic local optimization for {} tiles with {} matches",
-                 mfovTiles.getTileCount(), matches.size());
-
-        // For now, return the original tiles without optimization
-        // This is a placeholder - you can implement actual tile optimization here
-        // using the Tile<TranslationModel2D> objects created in performSiftMatching
-
-        return mfovTiles;
-    }
-
-    /**
      * Save the aligned tiles to the prealigned stack.
      */
     private int saveMfovTiles(final RenderDataClient dataClient,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -20,9 +20,11 @@ import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import mpicbg.models.TileConfiguration;
+import mpicbg.models.TranslationModel1D;
 import mpicbg.models.TranslationModel2D;
 
 import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.filter.FilterSpec;
 import org.janelia.alignment.match.CanvasFeatureExtractor;
 import org.janelia.alignment.match.CanvasFeatureMatcher;
 import org.janelia.alignment.match.CanvasId;
@@ -54,7 +56,6 @@ public class MfovPrealignTask implements Serializable {
 	private final StackId rawSfovStackId;
 	private final StackId prealignedStackId;
 	private final LayerMFOV layerMfov;
-	private final ImageProcessorCache cache;
 
 	private static final FeatureExtractionParameters FEATURE_EXTRACTION_PARAMETERS = new FeatureExtractionParameters();
 	private static final MatchDerivationParameters MATCH_DERIVATION_PARAMETERS = new MatchDerivationParameters();
@@ -71,8 +72,6 @@ public class MfovPrealignTask implements Serializable {
 		this.prealignedStackId = prealignedStackId;
 		this.layerMfov = layerMfov;
 
-		// Initialize the image processor cache with ~1Gb size to hold all tiles in memory
-		this.cache = new ImageProcessorCache(1_000_000_000L, false, false);
 
 		FEATURE_EXTRACTION_PARAMETERS.fdSize = 4;
 		FEATURE_EXTRACTION_PARAMETERS.maxScale = 1.0;
@@ -125,11 +124,14 @@ public class MfovPrealignTask implements Serializable {
 			}
 			LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
 
+			// Initialize the image processor cache with ~1Gb size to hold all tiles in memory
+			final ImageProcessorCache cache = new ImageProcessorCache(1_000_000_000L, false, false);
+
 			// 3. Align tiles within this MFOV
-			final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles, tilePairs);
+			final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles, tilePairs, cache);
 
 			// 4. Perform intensity correction
-			final ResolvedTileSpecCollection alignedIcTiles = intensityCorrectTiles(alignedTiles, tilePairs);
+			final ResolvedTileSpecCollection alignedIcTiles = intensityCorrectTiles(alignedTiles, tilePairs, cache);
 
 			// 5. Push the aligned tile specs to the prealigned stack
 			final int savedTileCount = saveMfovTiles(dataClient, alignedIcTiles);
@@ -190,7 +192,8 @@ public class MfovPrealignTask implements Serializable {
 	 */
 	private ResolvedTileSpecCollection alignTiles(
 			final ResolvedTileSpecCollection tiles,
-			final List<OrderedCanvasIdPair> tilePairs
+			final List<OrderedCanvasIdPair> tilePairs,
+			final ImageProcessorCache cache
 	) {
 		// Extract features from all mfov tiles
 		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(FEATURE_EXTRACTION_PARAMETERS);
@@ -240,7 +243,7 @@ public class MfovPrealignTask implements Serializable {
 
 		try {
 			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
-			tc.optimizeSilently(errorStatistic, 0.5, 5000, 1000);
+			tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
 		} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
 			throw new RuntimeException("Failed to optimize tile transformations", e);
 		}
@@ -341,16 +344,103 @@ public class MfovPrealignTask implements Serializable {
 	 */
 	private ResolvedTileSpecCollection intensityCorrectTiles(
 			final ResolvedTileSpecCollection tiles,
-			final List<OrderedCanvasIdPair> tilePairs
+			final List<OrderedCanvasIdPair> tilePairs,
+			final ImageProcessorCache cache
 	) {
 		LOG.info("intensityCorrectTiles: entry, tile count={}", tiles.getTileCount());
+		final Map<String, Tile<TranslationModel1D>> modelTiles = new HashMap<>();
 
+		// Initialize models for each tile spec
+		for (final TileSpec tileSpec : tiles.getTileSpecs()) {
+			// Create a model tile for each tile spec
+			final Tile<TranslationModel1D> modelTile = new Tile<>(new TranslationModel1D());
+			modelTiles.put(tileSpec.getTileId(), modelTile);
+		}
+
+		// Compute intensity differences between tile pairs
 		for (final OrderedCanvasIdPair pair : tilePairs) {
-			// TODO
+			// Get the tile specs for the pair
+			final String tileIdI = pair.getP().getId();
+			final String tileIdJ = pair.getQ().getId();
+			final TileSpec tileSpecI = tiles.getTileSpec(tileIdI);
+			final TileSpec tileSpecJ = tiles.getTileSpec(tileIdJ);
+
+			// Update the bounding boxes, since we just moved the tiles
+			tileSpecI.deriveBoundingBox(tileSpecI.getMeshCellSize(), true);
+			tileSpecJ.deriveBoundingBox(tileSpecJ.getMeshCellSize(), true);
+
+			// Compute means on the overlap
+			final Rectangle2D rectI = new Rectangle2D.Double(tileSpecI.getMinX(), tileSpecI.getMinY(), tileSpecI.getWidth(), tileSpecI.getHeight());
+			final Rectangle2D rectJ = new Rectangle2D.Double(tileSpecJ.getMinX(), tileSpecJ.getMinY(), tileSpecJ.getWidth(), tileSpecJ.getHeight());
+			final Rectangle2D overlap = rectI.createIntersection(rectJ);
+
+			final double meanI = computeMeanIntensity(tileSpecI, overlap, cache);
+			final double meanJ = computeMeanIntensity(tileSpecJ, overlap, cache);
+
+			// Add point match
+			final PointMatch pointMatch = new PointMatch(
+					new Point(new double[] {meanI}),
+					new Point(new double[] {meanJ})
+			);
+			final Tile<TranslationModel1D> modelTileI = modelTiles.get(tileIdI);
+			final Tile<TranslationModel1D> modelTileJ = modelTiles.get(tileIdJ);
+			modelTileI.connect(modelTileJ, Collections.singletonList(pointMatch));
+		}
+
+		// Optimize the translation models for intensity correction
+		final TileConfiguration tc = new TileConfiguration();
+		tc.addTiles(modelTiles.values());
+		tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
+
+		try {
+			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
+			tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
+		} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
+			throw new RuntimeException("Failed to optimize intensity correction", e);
+		}
+
+		// Apply the intensity shift to the tiles
+		final double[] translation = new double[2];
+		for (final Map.Entry<String, Tile<TranslationModel1D>> entry : modelTiles.entrySet()) {
+			final String tileId = entry.getKey();
+			final TranslationModel1D model = entry.getValue().getModel();
+			final TileSpec tileSpec = tiles.getTileSpec(tileId);
+
+			model.toArray(translation);
+			final FilterSpec filterSpec = new FilterSpec(
+					"org.janelia.alignment.filter.AffineIntensityFilter",
+					Map.of("a", String.valueOf(translation[0]), "b", String.valueOf(translation[1]))
+			);
+			tileSpec.setFilterSpec(filterSpec);
 		}
 
 		LOG.info("intensityCorrectTiles: exit");
 		return tiles;
+	}
+
+	private double computeMeanIntensity(
+			final TileSpec tileSpec,
+			final Rectangle2D roi,
+			final ImageProcessorCache cache
+	) {
+		// Get the pixels within the overlap region
+		final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
+		final int roiMinX = (int) (roi.getMinX() - tileSpec.getMinX());
+		final int roiMinY = (int) (roi.getMinY() - tileSpec.getMinY());
+		ip.setRoi(roiMinX, roiMinY, (int) roi.getWidth(), (int) roi.getHeight());
+		final ImageProcessor roiIp = ip.crop();
+
+		// Compute the mean intensity in the ROI
+		double sum = 0.0;
+		int count = 0;
+		for (int y = 0; y < roiIp.getHeight(); y++) {
+			for (int x = 0; x < roiIp.getWidth(); x++) {
+				sum += roiIp.getf(x, y);
+				count++;
+			}
+		}
+
+		return count > 0 ? sum / count : 0.0;
 	}
 
 	/**

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -4,6 +4,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,18 +14,24 @@ import java.util.stream.Collectors;
 import ij.process.ImageProcessor;
 import mpicbg.imagefeatures.Feature;
 import mpicbg.models.ErrorStatistic;
+import mpicbg.models.IllDefinedDataPointsException;
+import mpicbg.models.NotEnoughDataPointsException;
+import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import mpicbg.models.TileConfiguration;
 import mpicbg.models.TileUtil;
 import mpicbg.models.TranslationModel2D;
 
+import net.imglib2.img.io.Load;
 import org.janelia.alignment.ImageAndMask;
 import org.janelia.alignment.match.CanvasFeatureExtractor;
 import org.janelia.alignment.match.CanvasFeatureMatcher;
 import org.janelia.alignment.match.CanvasId;
 import org.janelia.alignment.match.CanvasMatchResult;
 import org.janelia.alignment.match.CanvasMatches;
+import org.janelia.alignment.match.MatchFilter;
+import org.janelia.alignment.match.ModelType;
 import org.janelia.alignment.match.OrderedCanvasIdPair;
 import org.janelia.alignment.match.parameters.FeatureExtractionParameters;
 import org.janelia.alignment.match.parameters.MatchDerivationParameters;
@@ -56,6 +63,10 @@ public class MfovPrealignTask implements Serializable {
     private final LayerMFOV layerMfov;
     private final MFOVAsTileParameters mfovAsTile;
 
+	private static final FeatureExtractionParameters FEATURE_EXTRACTION_PARAMETERS = new FeatureExtractionParameters();
+	private static final MatchDerivationParameters MATCH_DERIVATION_PARAMETERS = new MatchDerivationParameters();
+	private static final int CLIP_SIZE = 150;
+
     public MfovPrealignTask(final String baseDataUrl,
                             final StackId rawSfovStackId,
                             final StackId prealignedStackId,
@@ -66,6 +77,22 @@ public class MfovPrealignTask implements Serializable {
         this.prealignedStackId = prealignedStackId;
         this.layerMfov = layerMfov;
         this.mfovAsTile = mfovAsTile;
+
+		FEATURE_EXTRACTION_PARAMETERS.fdSize = 4;
+		FEATURE_EXTRACTION_PARAMETERS.maxScale = 1.0;
+		FEATURE_EXTRACTION_PARAMETERS.minScale = 0.25;
+		FEATURE_EXTRACTION_PARAMETERS.steps = 5;
+
+		MATCH_DERIVATION_PARAMETERS.matchFilter = MatchFilter.FilterType.SINGLE_SET;
+		MATCH_DERIVATION_PARAMETERS.matchFullScaleCoverageRadius = 300.0;
+		MATCH_DERIVATION_PARAMETERS.matchIterations = 1000;
+		MATCH_DERIVATION_PARAMETERS.matchMaxEpsilonFullScale = 5.0f;
+		MATCH_DERIVATION_PARAMETERS.matchMaxTrust = 4.0;
+		MATCH_DERIVATION_PARAMETERS.matchMinCoveragePercentage = 0.0;
+		MATCH_DERIVATION_PARAMETERS.matchMinInlierRatio = 0.0f;
+		MATCH_DERIVATION_PARAMETERS.matchMinNumInliers = 10;
+		MATCH_DERIVATION_PARAMETERS.matchModelType = ModelType.TRANSLATION;
+		MATCH_DERIVATION_PARAMETERS.matchRod = 0.92f;
     }
 
     /**
@@ -155,8 +182,9 @@ public class MfovPrealignTask implements Serializable {
 
             for (int j = i + 1; j < tileList.size(); j++) {
                 final TileSpec tj = tileList.get(j);
-                final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMaxY(), tj.getWidth(), tj.getHeight());
+                final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMinY(), tj.getWidth(), tj.getHeight());
 
+				final boolean intersects = rectI.intersects(rectJ);
                 if (rectI.intersects(rectJ)) {
                     final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
                     final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
@@ -171,47 +199,50 @@ public class MfovPrealignTask implements Serializable {
     /**
      * Perform SIFT feature matching on the tile pairs.
      */
-	private ResolvedTileSpecCollection performSiftAlignment(final ResolvedTileSpecCollection mfovTiles,
-															final List<OrderedCanvasIdPair> tilePairs) {
+	private ResolvedTileSpecCollection performSiftAlignment(
+			final ResolvedTileSpecCollection mfovTiles,
+			final List<OrderedCanvasIdPair> tilePairs
+	) {
+		// Set cache size to ~1GB, so that all mfov tiles can be kept in memory
+		final ImageProcessorCache ipCache = new ImageProcessorCache(1_000_000_000L, false, false);
 
 		// Extract features from all mfov tiles
-		final FeatureExtractionParameters featureExtractionParameters = MFOVAsTileParameters.buildFeatureExtractionParameters();
-		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(featureExtractionParameters);
-		final Map<CanvasId, List<Feature>> mfovFeatures = new HashMap<>(mfovTiles.getTileCount());
-		final Map<CanvasId, Tile<TranslationModel2D>> tiles = new HashMap<>();
+		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(FEATURE_EXTRACTION_PARAMETERS);
+		final Map<String, List<Feature>> mfovFeatures = new HashMap<>(mfovTiles.getTileCount());
+		final Map<String, Tile<TranslationModel2D>> tiles = new HashMap<>();
 
 		for (final TileSpec tileSpec : mfovTiles.getTileSpecs()) {
-			// Set cache size to ~1GB, so that all mfov tiles can be kept in memory
-			final ImageProcessorCache ipCache = new ImageProcessorCache(1_000_000_000L, false, false);
-			final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
-			final ImageAndMask image = firstChannel.getMipmap(0);
-			final ImageProcessor ip = ipCache.get(image.getImageUrl(), 0, false, false, image.getImageLoaderType(), null);
-			final List<Feature> tileFeatures = featureExtractor.extractFeaturesFromImageAndMask(ip, null);
+			final List<Feature> tileFeatures = extractBoundaryFeatures(ipCache, tileSpec, featureExtractor);
 
-			final CanvasId canvasId = new CanvasId(tileSpec.getGroupId(), tileSpec.getTileId());
-			mfovFeatures.put(canvasId, tileFeatures);
-			tiles.put(canvasId, new Tile<>(new TranslationModel2D()));
+			mfovFeatures.put(tileSpec.getTileId(), tileFeatures);
+			tiles.put(tileSpec.getTileId(), new Tile<>(new TranslationModel2D()));
 		}
 
 		// Match features between tile pairs
-		final MatchDerivationParameters matchDerivationParameters = MFOVAsTileParameters.buildFeatureMatchDerivation(10);
-		final CanvasFeatureMatcher featureMatcher = new CanvasFeatureMatcher(matchDerivationParameters, 1.0);
+		final CanvasFeatureMatcher featureMatcher = new CanvasFeatureMatcher(MATCH_DERIVATION_PARAMETERS, 1.0);
 
 		for (final OrderedCanvasIdPair pair : tilePairs) {
-			final CanvasId canvasIdI = pair.getP();
-			final CanvasId canvasIdJ = pair.getQ();
+			final String tileIdI = pair.getP().getId();
+			final String tileIdJ = pair.getQ().getId();
 
+			LOG.info("performSiftAlignment: matching features for canvas pair {} <-> {}", tileIdI, tileIdJ);
 			final CanvasMatchResult matchResult = featureMatcher.deriveMatchResult(
-					mfovFeatures.get(canvasIdI),
-					mfovFeatures.get(canvasIdJ)
+					mfovFeatures.get(tileIdI),
+					mfovFeatures.get(tileIdJ)
 			);
 
-			// Connect tiles for optimization using point matches
-			if (matchResult != null && matchResult.getTotalNumberOfInliers() > 0) {
+			// Connect tiles for optimization...
+			final Tile<TranslationModel2D> tileI = tiles.get(tileIdI);
+			final Tile<TranslationModel2D> tileJ = tiles.get(tileIdJ);
+			if (matchResult == null || matchResult.getTotalNumberOfInliers() == 0) {
+				// ... with fake matches if no inliers found
+				final PointMatch fakeMatch = new PointMatch(
+						new Point(new double[] {0.0, 0.0}), new Point(new double[] {0.0, 0.0}), 1e-4
+				);
+				tileI.connect(tileJ, Collections.singletonList(fakeMatch));
+			} else {
+				// ... with real matches if inliers found
 				final List<PointMatch> pointMatches = matchResult.getInlierPointMatchList();
-				final Tile<TranslationModel2D> tileI = tiles.get(canvasIdI);
-				final Tile<TranslationModel2D> tileJ = tiles.get(canvasIdJ);
-
 				tileI.connect(tileJ, pointMatches);
 			}
 		}
@@ -221,32 +252,27 @@ public class MfovPrealignTask implements Serializable {
 		tc.addTiles(tiles.values());
 		tc.fixTile(tiles.values().stream().findFirst().orElseThrow());
 
-		TileUtil.optimizeConcurrently(
-				new ErrorStatistic(1000),
-				0.5,
-				5000,
-				1000,
-				0.0f,
-				tc,
-				tc.getTiles(),
-				tc.getFixedTiles(),
-				1,
-				false
-		);
+		try {
+			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
+			tc.optimizeSilently(errorStatistic, 0.5, 5000, 1000);
+		} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
+			throw new RuntimeException("Failed to optimize tile transformations", e);
+		}
+
 
 		// Add the transformations to the tiles
-		for (final Map.Entry<CanvasId, Tile<TranslationModel2D>> entry : tiles.entrySet()) {
-			final String tileId = entry.getKey().getId();
+		final double[] translation = new double[6];
+		for (final Map.Entry<String, Tile<TranslationModel2D>> entry : tiles.entrySet()) {
+			final String tileId = entry.getKey();
 			final TranslationModel2D model = entry.getValue().getModel();
 
 			// Combine the translation from the model with the previous translation
-			final double[] translation = new double[2];
 			model.toArray(translation);
 			final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) mfovTiles.getTileSpec(tileId).getLastTransform();
 
 			final String[] previousCoefficients = previousTransformSpec.getDataString().split(" ");
-			final double x = Double.parseDouble(previousCoefficients[4]) + translation[0];
-			final double y = Double.parseDouble(previousCoefficients[5]) + translation[1];
+			final double x = Double.parseDouble(previousCoefficients[4]) + translation[4];
+			final double y = Double.parseDouble(previousCoefficients[5]) + translation[5];
 			final LeafTransformSpec newTransformSpec =  new LeafTransformSpec(
 					"mpicbg.trakem2.transform.AffineModel2D",
 					"1 0 0 1 " + x + " " + y
@@ -258,6 +284,62 @@ public class MfovPrealignTask implements Serializable {
 
 		return mfovTiles;
     }
+
+	/**
+	 * Extract features from boundary regions.
+	 */
+	private static List<Feature> extractBoundaryFeatures(
+			final ImageProcessorCache cache,
+			final TileSpec tileSpec,
+			final CanvasFeatureExtractor featureExtractor
+	) {
+		// Load an image processor for the given tile.
+		final int downSampleLevel = 0;
+		final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
+		final ImageAndMask image = firstChannel.getMipmap(downSampleLevel);
+		final ImageProcessor ip = cache.get(image.getImageUrl(), downSampleLevel, false, false, image.getImageLoaderType(), 0);
+		final int width = ip.getWidth();
+		final int height = ip.getHeight();
+
+		// Left
+		ip.setRoi(0, 0, CLIP_SIZE, height);
+		final List<Feature> features = new ArrayList<>(extractFeaturesFromRoi(featureExtractor, ip, 0, 0));
+		// Right
+		ip.setRoi(width - CLIP_SIZE, 0, CLIP_SIZE, height);
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, width - CLIP_SIZE, 0));
+		// Top
+		ip.setRoi(CLIP_SIZE, 0, width - 2 * CLIP_SIZE, CLIP_SIZE);
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, 0));
+		// Bottom
+		ip.setRoi(CLIP_SIZE, height - CLIP_SIZE, width - 2 * CLIP_SIZE, CLIP_SIZE);
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, height));
+
+		// Move the features to the global coordinate system
+		for (final Feature feature : features) {
+			feature.location[0] += tileSpec.getMinX();
+			feature.location[1] += tileSpec.getMinY();
+		}
+
+		return features;
+	}
+
+	/**
+	 * Extract features from ROI and shift them
+	 */
+	private static List<Feature> extractFeaturesFromRoi(
+			final CanvasFeatureExtractor featureExtractor,
+			final ImageProcessor ip,
+			final int xShift,
+			final int yShift
+	) {
+		final ImageProcessor roiIp = ip.crop();
+		final List<Feature> features = featureExtractor.extractFeaturesFromImageAndMask(roiIp, null);
+		for (final Feature feature : features) {
+			feature.location[0] += xShift;
+			feature.location[1] += yShift;
+		}
+		return features;
+	}
 
     /**
      * Optimize tile transformations using the derived matches.

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -1,0 +1,296 @@
+package org.janelia.render.client.spark.multisem;
+
+import java.awt.geom.Rectangle2D;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import ij.process.ImageProcessor;
+import mpicbg.imagefeatures.Feature;
+import mpicbg.models.ErrorStatistic;
+import mpicbg.models.PointMatch;
+import mpicbg.models.Tile;
+import mpicbg.models.TileConfiguration;
+import mpicbg.models.TileUtil;
+import mpicbg.models.TranslationModel2D;
+
+import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.match.CanvasFeatureExtractor;
+import org.janelia.alignment.match.CanvasFeatureMatcher;
+import org.janelia.alignment.match.CanvasId;
+import org.janelia.alignment.match.CanvasMatchResult;
+import org.janelia.alignment.match.CanvasMatches;
+import org.janelia.alignment.match.OrderedCanvasIdPair;
+import org.janelia.alignment.match.parameters.FeatureExtractionParameters;
+import org.janelia.alignment.match.parameters.MatchDerivationParameters;
+import org.janelia.alignment.multisem.LayerMFOV;
+import org.janelia.alignment.spec.ChannelSpec;
+import org.janelia.alignment.spec.LeafTransformSpec;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.TransformSpec;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.util.ImageProcessorCache;
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.parameter.MFOVAsTileParameters;
+import org.janelia.render.client.spark.LogUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.crypto.dsig.Transform;
+
+/**
+ * Serializable task for aligning SFOVs within a single MFOV.
+ * This task handles fetching tile specs, deriving matches, optimizing tiles, and saving results.
+ */
+public class MfovPrealignTask implements Serializable {
+
+    private final String baseDataUrl;
+    private final StackId rawSfovStackId;
+    private final StackId prealignedStackId;
+    private final LayerMFOV layerMfov;
+    private final MFOVAsTileParameters mfovAsTile;
+
+    public MfovPrealignTask(final String baseDataUrl,
+                            final StackId rawSfovStackId,
+                            final StackId prealignedStackId,
+                            final LayerMFOV layerMfov,
+                            final MFOVAsTileParameters mfovAsTile) {
+        this.baseDataUrl = baseDataUrl;
+        this.rawSfovStackId = rawSfovStackId;
+        this.prealignedStackId = prealignedStackId;
+        this.layerMfov = layerMfov;
+        this.mfovAsTile = mfovAsTile;
+    }
+
+    /**
+     * Align all SFOVs within this MFOV and save the aligned tile specs to the prealigned stack.
+     *
+     * @throws RuntimeException if alignment fails
+     */
+    public void alignMfov() {
+        try {
+            LogUtilities.setupExecutorLog4j(prealignedStackId.toDevString() + "_" + layerMfov);
+
+            LOG.info("alignMfov: entry");
+
+            final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                     rawSfovStackId.getOwner(),
+                                                                     rawSfovStackId.getProject());
+
+            // 1. Fetch tile specs for all SFOVs in this MFOV
+            final ResolvedTileSpecCollection mfovTiles = fetchMfovTileSpecs(dataClient);
+
+            if (mfovTiles.getTileCount() == 0) {
+                LOG.warn("alignMfov: no tiles found");
+            } else {
+                LOG.info("alignMfov: fetched {} tiles", mfovTiles.getTileCount());
+            }
+
+            // 2. Align tiles within this MFOV
+            final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles);
+
+            // 4. Push the aligned tile specs to the prealigned stack
+            final int savedTileCount = saveMfovTiles(dataClient, alignedTiles);
+
+            LOG.info("alignMfov: exit, aligned and saved {} tiles", savedTileCount);
+
+        } catch (final Exception e) {
+            LOG.error("alignMfov: failed", e);
+            throw new RuntimeException("Failed to align MFOV " + layerMfov, e);
+        }
+    }
+
+    /**
+     * Fetch tile specs for all SFOVs belonging to this MFOV at the specified z layer.
+     */
+    private ResolvedTileSpecCollection fetchMfovTileSpecs(final RenderDataClient dataClient) throws IOException {
+        final ResolvedTileSpecCollection mfovTiles = dataClient.getResolvedTiles(rawSfovStackId.getStack(), layerMfov.getZ());
+
+        // Filter tiles that belong to this MFOV and add them to the collection
+        final Set<String> tileIdsToKeep = mfovTiles.getTileSpecs().stream()
+                .map(TileSpec::getTileId)
+                .filter(tileId -> tileId.contains("_" + layerMfov.getSimpleMfovName() + "_"))
+                .collect(Collectors.toSet());
+        mfovTiles.retainTileSpecs(tileIdsToKeep);
+
+        return mfovTiles;
+    }
+
+    /**
+     * Derive matches between neighboring SFOVs within this MFOV.
+     */
+    private ResolvedTileSpecCollection alignTiles(final ResolvedTileSpecCollection mfovTiles) {
+		// 1. Generate tile pairs for matching
+		final List<OrderedCanvasIdPair> tilePairs = generateTilePairs(mfovTiles);
+
+		if (tilePairs.isEmpty()) {
+			LOG.warn("alignTiles: no tile pairs generated");
+			return mfovTiles;
+		}
+		LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
+
+		// 2. Perform SIFT feature matching on tile pairs
+		final ResolvedTileSpecCollection optimizedTiles = performSiftAlignment(mfovTiles, tilePairs);
+		LOG.info("alignTiles: exit");
+		return optimizedTiles;
+    }
+
+    /**
+     * Generate tile pairs for matching based on spatial proximity within the MFOV.
+     */
+    private List<OrderedCanvasIdPair> generateTilePairs(final ResolvedTileSpecCollection mfovTiles) {
+        final List<OrderedCanvasIdPair> pairs = new ArrayList<>();
+        final List<TileSpec> tileList = new ArrayList<>(mfovTiles.getTileSpecs());
+
+        // Generate intersecting tile pairs
+        for (int i = 0; i < tileList.size(); i++) {
+            final TileSpec ti = tileList.get(i);
+            final Rectangle2D rectI = new Rectangle2D.Double(ti.getMinX(), ti.getMinY(), ti.getWidth(), ti.getHeight());
+
+            for (int j = i + 1; j < tileList.size(); j++) {
+                final TileSpec tj = tileList.get(j);
+                final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMaxY(), tj.getWidth(), tj.getHeight());
+
+                if (rectI.intersects(rectJ)) {
+                    final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
+                    final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
+                    pairs.add(new OrderedCanvasIdPair(canvasIdI, canvasIdJ, 0.0));
+                }
+            }
+        }
+
+        return pairs;
+    }
+
+    /**
+     * Perform SIFT feature matching on the tile pairs.
+     */
+	private ResolvedTileSpecCollection performSiftAlignment(final ResolvedTileSpecCollection mfovTiles,
+															final List<OrderedCanvasIdPair> tilePairs) {
+
+		// Extract features from all mfov tiles
+		final FeatureExtractionParameters featureExtractionParameters = MFOVAsTileParameters.buildFeatureExtractionParameters();
+		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(featureExtractionParameters);
+		final Map<CanvasId, List<Feature>> mfovFeatures = new HashMap<>(mfovTiles.getTileCount());
+		final Map<CanvasId, Tile<TranslationModel2D>> tiles = new HashMap<>();
+
+		for (final TileSpec tileSpec : mfovTiles.getTileSpecs()) {
+			// Set cache size to ~1GB, so that all mfov tiles can be kept in memory
+			final ImageProcessorCache ipCache = new ImageProcessorCache(1_000_000_000L, false, false);
+			final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
+			final ImageAndMask image = firstChannel.getMipmap(0);
+			final ImageProcessor ip = ipCache.get(image.getImageUrl(), 0, false, false, image.getImageLoaderType(), null);
+			final List<Feature> tileFeatures = featureExtractor.extractFeaturesFromImageAndMask(ip, null);
+
+			final CanvasId canvasId = new CanvasId(tileSpec.getGroupId(), tileSpec.getTileId());
+			mfovFeatures.put(canvasId, tileFeatures);
+			tiles.put(canvasId, new Tile<>(new TranslationModel2D()));
+		}
+
+		// Match features between tile pairs
+		final MatchDerivationParameters matchDerivationParameters = MFOVAsTileParameters.buildFeatureMatchDerivation(10);
+		final CanvasFeatureMatcher featureMatcher = new CanvasFeatureMatcher(matchDerivationParameters, 1.0);
+
+		for (final OrderedCanvasIdPair pair : tilePairs) {
+			final CanvasId canvasIdI = pair.getP();
+			final CanvasId canvasIdJ = pair.getQ();
+
+			final CanvasMatchResult matchResult = featureMatcher.deriveMatchResult(
+					mfovFeatures.get(canvasIdI),
+					mfovFeatures.get(canvasIdJ)
+			);
+
+			// Connect tiles for optimization using point matches
+			if (matchResult != null && matchResult.getTotalNumberOfInliers() > 0) {
+				final List<PointMatch> pointMatches = matchResult.getInlierPointMatchList();
+				final Tile<TranslationModel2D> tileI = tiles.get(canvasIdI);
+				final Tile<TranslationModel2D> tileJ = tiles.get(canvasIdJ);
+
+				tileI.connect(tileJ, pointMatches);
+			}
+		}
+
+		// Optimize the tiles
+		final TileConfiguration tc = new TileConfiguration();
+		tc.addTiles(tiles.values());
+		tc.fixTile(tiles.values().stream().findFirst().orElseThrow());
+
+		TileUtil.optimizeConcurrently(
+				new ErrorStatistic(1000),
+				0.5,
+				5000,
+				1000,
+				0.0f,
+				tc,
+				tc.getTiles(),
+				tc.getFixedTiles(),
+				1,
+				false
+		);
+
+		// Add the transformations to the tiles
+		for (final Map.Entry<CanvasId, Tile<TranslationModel2D>> entry : tiles.entrySet()) {
+			final String tileId = entry.getKey().getId();
+			final TranslationModel2D model = entry.getValue().getModel();
+
+			// Combine the translation from the model with the previous translation
+			final double[] translation = new double[2];
+			model.toArray(translation);
+			final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) mfovTiles.getTileSpec(tileId).getLastTransform();
+
+			final String[] previousCoefficients = previousTransformSpec.getDataString().split(" ");
+			final double x = Double.parseDouble(previousCoefficients[4]) + translation[0];
+			final double y = Double.parseDouble(previousCoefficients[5]) + translation[1];
+			final LeafTransformSpec newTransformSpec =  new LeafTransformSpec(
+					"mpicbg.trakem2.transform.AffineModel2D",
+					"1 0 0 1 " + x + " " + y
+			);
+
+			// Set the transformation model to the tile spec
+			mfovTiles.addTransformSpecToTile(tileId, newTransformSpec, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
+		}
+
+		return mfovTiles;
+    }
+
+    /**
+     * Optimize tile transformations using the derived matches.
+     */
+    private ResolvedTileSpecCollection optimizeTileTransformations(final ResolvedTileSpecCollection mfovTiles,
+                                                                  final List<CanvasMatches> matches) {
+        LOG.info("optimizeTileTransformations: applying basic local optimization for {} tiles with {} matches",
+                 mfovTiles.getTileCount(), matches.size());
+
+        // For now, return the original tiles without optimization
+        // This is a placeholder - you can implement actual tile optimization here
+        // using the Tile<TranslationModel2D> objects created in performSiftMatching
+
+        return mfovTiles;
+    }
+
+    /**
+     * Save the aligned tiles to the prealigned stack.
+     */
+    private int saveMfovTiles(final RenderDataClient dataClient,
+                             final ResolvedTileSpecCollection alignedTiles) throws IOException {
+
+        if (alignedTiles.getTileCount() == 0) {
+            LOG.warn("saveMfovTiles: no aligned tiles to save for mfov={}, z={}",
+                     layerMfov.getName(), layerMfov.getZ());
+            return 0;
+        }
+
+        // Save tiles to the prealigned stack
+        dataClient.saveResolvedTiles(alignedTiles, prealignedStackId.getStack(), layerMfov.getZ());
+
+        return alignedTiles.getTileCount();
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(MfovPrealignTask.class);
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -301,18 +301,11 @@ public class MfovPrealignTask implements Serializable {
 		final int width = ip.getWidth();
 		final int height = ip.getHeight();
 
-		// Left
-		ip.setRoi(0, 0, CLIP_SIZE, height);
-		final List<Feature> features = new ArrayList<>(extractFeaturesFromRoi(featureExtractor, ip, 0, 0));
-		// Right
-		ip.setRoi(width - CLIP_SIZE, 0, CLIP_SIZE, height);
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, width - CLIP_SIZE, 0));
-		// Top
-		ip.setRoi(CLIP_SIZE, 0, width - 2 * CLIP_SIZE, CLIP_SIZE);
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, 0));
-		// Bottom
-		ip.setRoi(CLIP_SIZE, height - CLIP_SIZE, width - 2 * CLIP_SIZE, CLIP_SIZE);
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, height));
+		// Left, right, top, and bottom boundaries
+		final List<Feature> features = new ArrayList<>(extractFeaturesFromRoi(featureExtractor, ip, 0, 0, CLIP_SIZE, height));
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, width - CLIP_SIZE, 0, CLIP_SIZE, height));
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, 0, width - 2 * CLIP_SIZE, CLIP_SIZE));
+		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, height - CLIP_SIZE, width - 2 * CLIP_SIZE, CLIP_SIZE));
 
 		// Move the features to the global coordinate system
 		for (final Feature feature : features) {
@@ -330,9 +323,15 @@ public class MfovPrealignTask implements Serializable {
 			final CanvasFeatureExtractor featureExtractor,
 			final ImageProcessor ip,
 			final int xShift,
-			final int yShift
+			final int yShift,
+			final int w,
+			final int h
 	) {
+		// Extract the specified ROI from the image processor
+		ip.setRoi(xShift, yShift, w, h);
 		final ImageProcessor roiIp = ip.crop();
+
+		// Extract features from the ROI and place them in the tile coordinate system
 		final List<Feature> features = featureExtractor.extractFeaturesFromImageAndMask(roiIp, null);
 		for (final Feature feature : features) {
 			feature.location[0] += xShift;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -52,414 +52,414 @@ import org.slf4j.LoggerFactory;
  */
 public class MfovPrealignTask implements Serializable {
 
-	private final String baseDataUrl;
-	private final StackId rawSfovStackId;
-	private final StackId prealignedStackId;
-	private final LayerMFOV layerMfov;
-
-	private static final FeatureExtractionParameters FEATURE_EXTRACTION_PARAMETERS = new FeatureExtractionParameters();
-	private static final MatchDerivationParameters MATCH_DERIVATION_PARAMETERS = new MatchDerivationParameters();
-	private static final int CLIP_SIZE = 150;
-
-	public MfovPrealignTask(
-			final String baseDataUrl,
-			final StackId rawSfovStackId,
-			final StackId prealignedStackId,
-			final LayerMFOV layerMfov
-	) {
-		this.baseDataUrl = baseDataUrl;
-		this.rawSfovStackId = rawSfovStackId;
-		this.prealignedStackId = prealignedStackId;
-		this.layerMfov = layerMfov;
-
-
-		FEATURE_EXTRACTION_PARAMETERS.fdSize = 4;
-		FEATURE_EXTRACTION_PARAMETERS.maxScale = 1.0;
-		FEATURE_EXTRACTION_PARAMETERS.minScale = 0.25;
-		FEATURE_EXTRACTION_PARAMETERS.steps = 5;
-
-		MATCH_DERIVATION_PARAMETERS.matchFilter = MatchFilter.FilterType.SINGLE_SET;
-		MATCH_DERIVATION_PARAMETERS.matchFullScaleCoverageRadius = 300.0;
-		MATCH_DERIVATION_PARAMETERS.matchIterations = 1000;
-		MATCH_DERIVATION_PARAMETERS.matchMaxEpsilonFullScale = 5.0f;
-		MATCH_DERIVATION_PARAMETERS.matchMaxTrust = 4.0;
-		MATCH_DERIVATION_PARAMETERS.matchMinCoveragePercentage = 0.0;
-		MATCH_DERIVATION_PARAMETERS.matchMinInlierRatio = 0.0f;
-		MATCH_DERIVATION_PARAMETERS.matchMinNumInliers = 10;
-		MATCH_DERIVATION_PARAMETERS.matchModelType = ModelType.TRANSLATION;
-		MATCH_DERIVATION_PARAMETERS.matchRod = 0.92f;
-	}
-
-	/**
-	 * Align and intensity correct all SFOVs within this MFOV and save the aligned tile specs to the prealigned stack.
-	 * Both alignment and intensity correction are performed by simple translation models.
-	 *
-	 * @throws RuntimeException if alignment fails
-	 */
-	public void run() {
-		try {
-			LogUtilities.setupExecutorLog4j(prealignedStackId.toDevString() + "_" + layerMfov);
-
-			LOG.info("alignMfov: entry");
-
-			final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
-																	 rawSfovStackId.getOwner(),
-																	 rawSfovStackId.getProject());
-
-			// 1. Fetch tile specs for all SFOVs in this MFOV
-			final ResolvedTileSpecCollection mfovTiles = fetchMfovTileSpecs(dataClient);
-
-			if (mfovTiles.getTileCount() == 0) {
-				LOG.warn("alignMfov: no tiles found");
-			} else {
-				LOG.info("alignMfov: fetched {} tiles", mfovTiles.getTileCount());
-			}
-
-			// 2. Generate tile pairs for matching
-			final List<OrderedCanvasIdPair> tilePairs = generateTilePairs(mfovTiles);
-
-			if (tilePairs.isEmpty()) {
-				LOG.warn("alignTiles: no tile pairs generated");
-				return;
-			}
-			LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
-
-			// Initialize the image processor cache with ~1Gb size to hold all tiles in memory
-			final ImageProcessorCache cache = new ImageProcessorCache(1_000_000_000L, false, false);
-
-			// 3. Align tiles within this MFOV
-			final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles, tilePairs, cache);
-
-			// 4. Perform intensity correction
-			final ResolvedTileSpecCollection alignedIcTiles = intensityCorrectTiles(alignedTiles, tilePairs, cache);
-
-			// 5. Push the aligned tile specs to the prealigned stack
-			final int savedTileCount = saveMfovTiles(dataClient, alignedIcTiles);
-
-			LOG.info("alignMfov: exit, aligned and saved {} tiles", savedTileCount);
-
-		} catch (final Exception e) {
-			LOG.error("alignMfov: failed", e);
-			throw new RuntimeException("Failed to align MFOV " + layerMfov, e);
-		}
-	}
-
-	/**
-	 * Fetch tile specs for all SFOVs belonging to this MFOV at the specified z layer.
-	 */
-	private ResolvedTileSpecCollection fetchMfovTileSpecs(final RenderDataClient dataClient) throws IOException {
-		final ResolvedTileSpecCollection mfovTiles = dataClient.getResolvedTiles(rawSfovStackId.getStack(), layerMfov.getZ());
-
-		// Filter tiles that belong to this MFOV and add them to the collection
-		final Set<String> tileIdsToKeep = mfovTiles.getTileSpecs().stream()
-				.map(TileSpec::getTileId)
-				.filter(tileId -> tileId.contains("_" + layerMfov.getSimpleMfovName() + "_"))
-				.collect(Collectors.toSet());
-		mfovTiles.retainTileSpecs(tileIdsToKeep);
-
-		return mfovTiles;
-	}
-
-	/**
-	 * Generate tile pairs for matching based on spatial proximity within the MFOV.
-	 */
-	private List<OrderedCanvasIdPair> generateTilePairs(final ResolvedTileSpecCollection mfovTiles) {
-		final List<OrderedCanvasIdPair> pairs = new ArrayList<>();
-		final List<TileSpec> tileList = new ArrayList<>(mfovTiles.getTileSpecs());
-
-		// Generate intersecting tile pairs
-		for (int i = 0; i < tileList.size(); i++) {
-			final TileSpec ti = tileList.get(i);
-			final Rectangle2D rectI = new Rectangle2D.Double(ti.getMinX(), ti.getMinY(), ti.getWidth(), ti.getHeight());
-
-			for (int j = i + 1; j < tileList.size(); j++) {
-				final TileSpec tj = tileList.get(j);
-				final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMinY(), tj.getWidth(), tj.getHeight());
-
-				if (rectI.intersects(rectJ)) {
-					final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
-					final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
-					pairs.add(new OrderedCanvasIdPair(canvasIdI, canvasIdJ, 0.0));
-				}
-			}
-		}
-
-		return pairs;
-	}
-
-	/**
-	 * Perform SIFT feature matching on the tile pairs.
-	 */
-	private ResolvedTileSpecCollection alignTiles(
-			final ResolvedTileSpecCollection tiles,
-			final List<OrderedCanvasIdPair> tilePairs,
-			final ImageProcessorCache cache
-	) {
-		// Extract features from all mfov tiles
-		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(FEATURE_EXTRACTION_PARAMETERS);
-		final Map<String, List<Feature>> mfovFeatures = new HashMap<>(tiles.getTileCount());
-		final Map<String, Tile<TranslationModel2D>> modelTiles = new HashMap<>();
-
-		for (final TileSpec tileSpec : tiles.getTileSpecs()) {
-			final List<Feature> tileFeatures = extractBoundaryFeatures(cache, tileSpec, featureExtractor);
-
-			mfovFeatures.put(tileSpec.getTileId(), tileFeatures);
-			modelTiles.put(tileSpec.getTileId(), new Tile<>(new TranslationModel2D()));
-		}
-
-		// Match features between tile pairs
-		final CanvasFeatureMatcher featureMatcher = new CanvasFeatureMatcher(MATCH_DERIVATION_PARAMETERS, 1.0);
-
-		for (final OrderedCanvasIdPair pair : tilePairs) {
-			final String tileIdI = pair.getP().getId();
-			final String tileIdJ = pair.getQ().getId();
-
-			LOG.info("performSiftAlignment: matching features for canvas pair {} <-> {}", tileIdI, tileIdJ);
-			final CanvasMatchResult matchResult = featureMatcher.deriveMatchResult(
-					mfovFeatures.get(tileIdI),
-					mfovFeatures.get(tileIdJ)
-			);
-
-			// Connect tiles for optimization...
-			final Tile<TranslationModel2D> modelTileI = modelTiles.get(tileIdI);
-			final Tile<TranslationModel2D> modelTileJ = modelTiles.get(tileIdJ);
-			if (matchResult == null || matchResult.getTotalNumberOfInliers() == 0) {
-				// ... with fake matches if no inliers found
-				final PointMatch fakeMatch = new PointMatch(
-						new Point(new double[] {0.0, 0.0}), new Point(new double[] {0.0, 0.0}), 1e-4
-				);
-				modelTileI.connect(modelTileJ, Collections.singletonList(fakeMatch));
-			} else {
-				// ... with real matches if inliers found
-				final List<PointMatch> pointMatches = matchResult.getInlierPointMatchList();
-				modelTileI.connect(modelTileJ, pointMatches);
-			}
-		}
-
-		// Optimize the tiles
-		final TileConfiguration tc = new TileConfiguration();
-		tc.addTiles(modelTiles.values());
-		tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
-
-		try {
-			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
-			tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
-		} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
-			throw new RuntimeException("Failed to optimize tile transformations", e);
-		}
-
-
-		// Add the transformations to the tiles
-		final double[] translation = new double[6];
-		for (final Map.Entry<String, Tile<TranslationModel2D>> entry : modelTiles.entrySet()) {
-			final String tileId = entry.getKey();
-			final TranslationModel2D model = entry.getValue().getModel();
-
-			// Combine the translation from the model with the previous translation
-			model.toArray(translation);
-			final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) tiles.getTileSpec(tileId).getLastTransform();
-
-			final String[] previousCoefficients = previousTransformSpec.getDataString().split(" ");
-			final double x = Double.parseDouble(previousCoefficients[4]) + translation[4];
-			final double y = Double.parseDouble(previousCoefficients[5]) + translation[5];
-			final LeafTransformSpec newTransformSpec =  new LeafTransformSpec(
-					"mpicbg.trakem2.transform.AffineModel2D",
-					"1 0 0 1 " + x + " " + y
-			);
-
-			// Set the transformation model to the tile spec
-			tiles.addTransformSpecToTile(tileId, newTransformSpec, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
-		}
-
-		return tiles;
-	}
-
-	/**
-	 * Extract features from boundary regions.
-	 */
-	private static List<Feature> extractBoundaryFeatures(
-			final ImageProcessorCache cache,
-			final TileSpec tileSpec,
-			final CanvasFeatureExtractor featureExtractor
-	) {
-		// Load an image processor for the given tile.
-		final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
-		final int width = ip.getWidth();
-		final int height = ip.getHeight();
-
-		// Left, right, top, and bottom boundaries
-		final List<Feature> features = new ArrayList<>(extractFeaturesFromRoi(featureExtractor, ip, 0, 0, CLIP_SIZE, height));
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, width - CLIP_SIZE, 0, CLIP_SIZE, height));
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, 0, width - 2 * CLIP_SIZE, CLIP_SIZE));
-		features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, height - CLIP_SIZE, width - 2 * CLIP_SIZE, CLIP_SIZE));
-
-		// Move the features to the global coordinate system
-		for (final Feature feature : features) {
-			feature.location[0] += tileSpec.getMinX();
-			feature.location[1] += tileSpec.getMinY();
-		}
-
-		return features;
-	}
-
-	private static ImageProcessor loadImageProcessor(
-			final ImageProcessorCache cache,
-			final TileSpec tileSpec
-	) {
-		final int downSampleLevel = 0;
-		final boolean isMask = false;
-		final boolean convertTo16Bit = false;
-		final int slice = 0;
-		final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
-		final ImageAndMask image = firstChannel.getMipmap(downSampleLevel);
-		return cache.get(image.getImageUrl(), downSampleLevel, isMask, convertTo16Bit, image.getImageLoaderType(), slice);
-	}
-
-	/**
-	 * Extract features from ROI and shift them
-	 */
-	private static List<Feature> extractFeaturesFromRoi(
-			final CanvasFeatureExtractor featureExtractor,
-			final ImageProcessor ip,
-			final int xShift,
-			final int yShift,
-			final int w,
-			final int h
-	) {
-		// Extract the specified ROI from the image processor
-		ip.setRoi(xShift, yShift, w, h);
-		final ImageProcessor roiIp = ip.crop();
-
-		// Extract features from the ROI and place them in the tile coordinate system
-		final List<Feature> features = featureExtractor.extractFeaturesFromImageAndMask(roiIp, null);
-		for (final Feature feature : features) {
-			feature.location[0] += xShift;
-			feature.location[1] += yShift;
-		}
-		return features;
-	}
-
-	/**
-	 * Perform intensity correction on the aligned tiles.
-	 */
-	private ResolvedTileSpecCollection intensityCorrectTiles(
-			final ResolvedTileSpecCollection tiles,
-			final List<OrderedCanvasIdPair> tilePairs,
-			final ImageProcessorCache cache
-	) {
-		LOG.info("intensityCorrectTiles: entry, tile count={}", tiles.getTileCount());
-		final Map<String, Tile<TranslationModel1D>> modelTiles = new HashMap<>();
-
-		// Initialize models for each tile spec
-		for (final TileSpec tileSpec : tiles.getTileSpecs()) {
-			// Create a model tile for each tile spec
-			final Tile<TranslationModel1D> modelTile = new Tile<>(new TranslationModel1D());
-			modelTiles.put(tileSpec.getTileId(), modelTile);
-		}
-
-		// Compute intensity differences between tile pairs
-		for (final OrderedCanvasIdPair pair : tilePairs) {
-			// Get the tile specs for the pair
-			final String tileIdI = pair.getP().getId();
-			final String tileIdJ = pair.getQ().getId();
-			final TileSpec tileSpecI = tiles.getTileSpec(tileIdI);
-			final TileSpec tileSpecJ = tiles.getTileSpec(tileIdJ);
-
-			// Update the bounding boxes, since we just moved the tiles
-			tileSpecI.deriveBoundingBox(tileSpecI.getMeshCellSize(), true);
-			tileSpecJ.deriveBoundingBox(tileSpecJ.getMeshCellSize(), true);
-
-			// Compute means on the overlap
-			final Rectangle2D rectI = new Rectangle2D.Double(tileSpecI.getMinX(), tileSpecI.getMinY(), tileSpecI.getWidth(), tileSpecI.getHeight());
-			final Rectangle2D rectJ = new Rectangle2D.Double(tileSpecJ.getMinX(), tileSpecJ.getMinY(), tileSpecJ.getWidth(), tileSpecJ.getHeight());
-			final Rectangle2D overlap = rectI.createIntersection(rectJ);
-
-			final double meanI = computeMeanIntensity(tileSpecI, overlap, cache);
-			final double meanJ = computeMeanIntensity(tileSpecJ, overlap, cache);
-
-			// Add point match
-			final PointMatch pointMatch = new PointMatch(
-					new Point(new double[] {meanI}),
-					new Point(new double[] {meanJ})
-			);
-			final Tile<TranslationModel1D> modelTileI = modelTiles.get(tileIdI);
-			final Tile<TranslationModel1D> modelTileJ = modelTiles.get(tileIdJ);
-			modelTileI.connect(modelTileJ, Collections.singletonList(pointMatch));
-		}
-
-		// Optimize the translation models for intensity correction
-		final TileConfiguration tc = new TileConfiguration();
-		tc.addTiles(modelTiles.values());
-		tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
-
-		try {
-			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
-			tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
-		} catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
-			throw new RuntimeException("Failed to optimize intensity correction", e);
-		}
-
-		// Apply the intensity shift to the tiles
-		final double[] translation = new double[2];
-		for (final Map.Entry<String, Tile<TranslationModel1D>> entry : modelTiles.entrySet()) {
-			final String tileId = entry.getKey();
-			final TranslationModel1D model = entry.getValue().getModel();
-			final TileSpec tileSpec = tiles.getTileSpec(tileId);
-
-			model.toArray(translation);
-			final FilterSpec filterSpec = new FilterSpec(
-					"org.janelia.alignment.filter.AffineIntensityFilter",
-					Map.of("a", String.valueOf(translation[0]), "b", String.valueOf(translation[1]))
-			);
-			tileSpec.setFilterSpec(filterSpec);
-		}
-
-		LOG.info("intensityCorrectTiles: exit");
-		return tiles;
-	}
-
-	private double computeMeanIntensity(
-			final TileSpec tileSpec,
-			final Rectangle2D roi,
-			final ImageProcessorCache cache
-	) {
-		// Get the pixels within the overlap region
-		final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
-		final int roiMinX = (int) (roi.getMinX() - tileSpec.getMinX());
-		final int roiMinY = (int) (roi.getMinY() - tileSpec.getMinY());
-		ip.setRoi(roiMinX, roiMinY, (int) roi.getWidth(), (int) roi.getHeight());
-		final ImageProcessor roiIp = ip.crop();
-
-		// Compute the mean intensity in the ROI
-		double sum = 0.0;
-		int count = 0;
-		for (int y = 0; y < roiIp.getHeight(); y++) {
-			for (int x = 0; x < roiIp.getWidth(); x++) {
-				sum += roiIp.getf(x, y);
-				count++;
-			}
-		}
-
-		return count > 0 ? sum / count : 0.0;
-	}
-
-	/**
-	 * Save the aligned tiles to the prealigned stack.
-	 */
-	private int saveMfovTiles(final RenderDataClient dataClient,
-							  final ResolvedTileSpecCollection alignedTiles) throws IOException {
-
-		if (alignedTiles.getTileCount() == 0) {
-			LOG.warn("saveMfovTiles: no aligned tiles to save for mfov={}, z={}",
-					 layerMfov.getName(), layerMfov.getZ());
-			return 0;
-		}
-
-		// Save tiles to the prealigned stack
-		dataClient.saveResolvedTiles(alignedTiles, prealignedStackId.getStack(), layerMfov.getZ());
-
-		return alignedTiles.getTileCount();
-	}
-
-	private static final Logger LOG = LoggerFactory.getLogger(MfovPrealignTask.class);
+    private final String baseDataUrl;
+    private final StackId rawSfovStackId;
+    private final StackId prealignedStackId;
+    private final LayerMFOV layerMfov;
+
+    private static final FeatureExtractionParameters FEATURE_EXTRACTION_PARAMETERS = new FeatureExtractionParameters();
+    private static final MatchDerivationParameters MATCH_DERIVATION_PARAMETERS = new MatchDerivationParameters();
+    private static final int CLIP_SIZE = 150;
+
+    public MfovPrealignTask(
+            final String baseDataUrl,
+            final StackId rawSfovStackId,
+            final StackId prealignedStackId,
+            final LayerMFOV layerMfov
+    ) {
+        this.baseDataUrl = baseDataUrl;
+        this.rawSfovStackId = rawSfovStackId;
+        this.prealignedStackId = prealignedStackId;
+        this.layerMfov = layerMfov;
+
+
+        FEATURE_EXTRACTION_PARAMETERS.fdSize = 4;
+        FEATURE_EXTRACTION_PARAMETERS.maxScale = 1.0;
+        FEATURE_EXTRACTION_PARAMETERS.minScale = 0.25;
+        FEATURE_EXTRACTION_PARAMETERS.steps = 5;
+
+        MATCH_DERIVATION_PARAMETERS.matchFilter = MatchFilter.FilterType.SINGLE_SET;
+        MATCH_DERIVATION_PARAMETERS.matchFullScaleCoverageRadius = 300.0;
+        MATCH_DERIVATION_PARAMETERS.matchIterations = 1000;
+        MATCH_DERIVATION_PARAMETERS.matchMaxEpsilonFullScale = 5.0f;
+        MATCH_DERIVATION_PARAMETERS.matchMaxTrust = 4.0;
+        MATCH_DERIVATION_PARAMETERS.matchMinCoveragePercentage = 0.0;
+        MATCH_DERIVATION_PARAMETERS.matchMinInlierRatio = 0.0f;
+        MATCH_DERIVATION_PARAMETERS.matchMinNumInliers = 10;
+        MATCH_DERIVATION_PARAMETERS.matchModelType = ModelType.TRANSLATION;
+        MATCH_DERIVATION_PARAMETERS.matchRod = 0.92f;
+    }
+
+    /**
+     * Align and intensity correct all SFOVs within this MFOV and save the aligned tile specs to the prealigned stack.
+     * Both alignment and intensity correction are performed by simple translation models.
+     *
+     * @throws RuntimeException if alignment fails
+     */
+    public void run() {
+        try {
+            LogUtilities.setupExecutorLog4j(prealignedStackId.toDevString() + "_" + layerMfov);
+
+            LOG.info("alignMfov: entry");
+
+            final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                     rawSfovStackId.getOwner(),
+                                                                     rawSfovStackId.getProject());
+
+            // 1. Fetch tile specs for all SFOVs in this MFOV
+            final ResolvedTileSpecCollection mfovTiles = fetchMfovTileSpecs(dataClient);
+
+            if (mfovTiles.getTileCount() == 0) {
+                LOG.warn("alignMfov: no tiles found");
+            } else {
+                LOG.info("alignMfov: fetched {} tiles", mfovTiles.getTileCount());
+            }
+
+            // 2. Generate tile pairs for matching
+            final List<OrderedCanvasIdPair> tilePairs = generateTilePairs(mfovTiles);
+
+            if (tilePairs.isEmpty()) {
+                LOG.warn("alignTiles: no tile pairs generated");
+                return;
+            }
+            LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
+
+            // Initialize the image processor cache with ~1Gb size to hold all tiles in memory
+            final ImageProcessorCache cache = new ImageProcessorCache(1_000_000_000L, false, false);
+
+            // 3. Align tiles within this MFOV
+            final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles, tilePairs, cache);
+
+            // 4. Perform intensity correction
+            final ResolvedTileSpecCollection alignedIcTiles = intensityCorrectTiles(alignedTiles, tilePairs, cache);
+
+            // 5. Push the aligned tile specs to the prealigned stack
+            final int savedTileCount = saveMfovTiles(dataClient, alignedIcTiles);
+
+            LOG.info("alignMfov: exit, aligned and saved {} tiles", savedTileCount);
+
+        } catch (final Exception e) {
+            LOG.error("alignMfov: failed", e);
+            throw new RuntimeException("Failed to align MFOV " + layerMfov, e);
+        }
+    }
+
+    /**
+     * Fetch tile specs for all SFOVs belonging to this MFOV at the specified z layer.
+     */
+    private ResolvedTileSpecCollection fetchMfovTileSpecs(final RenderDataClient dataClient) throws IOException {
+        final ResolvedTileSpecCollection mfovTiles = dataClient.getResolvedTiles(rawSfovStackId.getStack(), layerMfov.getZ());
+
+        // Filter tiles that belong to this MFOV and add them to the collection
+        final Set<String> tileIdsToKeep = mfovTiles.getTileSpecs().stream()
+                .map(TileSpec::getTileId)
+                .filter(tileId -> tileId.contains("_" + layerMfov.getSimpleMfovName() + "_"))
+                .collect(Collectors.toSet());
+        mfovTiles.retainTileSpecs(tileIdsToKeep);
+
+        return mfovTiles;
+    }
+
+    /**
+     * Generate tile pairs for matching based on spatial proximity within the MFOV.
+     */
+    private List<OrderedCanvasIdPair> generateTilePairs(final ResolvedTileSpecCollection mfovTiles) {
+        final List<OrderedCanvasIdPair> pairs = new ArrayList<>();
+        final List<TileSpec> tileList = new ArrayList<>(mfovTiles.getTileSpecs());
+
+        // Generate intersecting tile pairs
+        for (int i = 0; i < tileList.size(); i++) {
+            final TileSpec ti = tileList.get(i);
+            final Rectangle2D rectI = new Rectangle2D.Double(ti.getMinX(), ti.getMinY(), ti.getWidth(), ti.getHeight());
+
+            for (int j = i + 1; j < tileList.size(); j++) {
+                final TileSpec tj = tileList.get(j);
+                final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMinY(), tj.getWidth(), tj.getHeight());
+
+                if (rectI.intersects(rectJ)) {
+                    final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
+                    final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
+                    pairs.add(new OrderedCanvasIdPair(canvasIdI, canvasIdJ, 0.0));
+                }
+            }
+        }
+
+        return pairs;
+    }
+
+    /**
+     * Perform SIFT feature matching on the tile pairs.
+     */
+    private ResolvedTileSpecCollection alignTiles(
+            final ResolvedTileSpecCollection tiles,
+            final List<OrderedCanvasIdPair> tilePairs,
+            final ImageProcessorCache cache
+    ) {
+        // Extract features from all mfov tiles
+        final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(FEATURE_EXTRACTION_PARAMETERS);
+        final Map<String, List<Feature>> mfovFeatures = new HashMap<>(tiles.getTileCount());
+        final Map<String, Tile<TranslationModel2D>> modelTiles = new HashMap<>();
+
+        for (final TileSpec tileSpec : tiles.getTileSpecs()) {
+            final List<Feature> tileFeatures = extractBoundaryFeatures(cache, tileSpec, featureExtractor);
+
+            mfovFeatures.put(tileSpec.getTileId(), tileFeatures);
+            modelTiles.put(tileSpec.getTileId(), new Tile<>(new TranslationModel2D()));
+        }
+
+        // Match features between tile pairs
+        final CanvasFeatureMatcher featureMatcher = new CanvasFeatureMatcher(MATCH_DERIVATION_PARAMETERS, 1.0);
+
+        for (final OrderedCanvasIdPair pair : tilePairs) {
+            final String tileIdI = pair.getP().getId();
+            final String tileIdJ = pair.getQ().getId();
+
+            LOG.info("performSiftAlignment: matching features for canvas pair {} <-> {}", tileIdI, tileIdJ);
+            final CanvasMatchResult matchResult = featureMatcher.deriveMatchResult(
+                    mfovFeatures.get(tileIdI),
+                    mfovFeatures.get(tileIdJ)
+            );
+
+            // Connect tiles for optimization...
+            final Tile<TranslationModel2D> modelTileI = modelTiles.get(tileIdI);
+            final Tile<TranslationModel2D> modelTileJ = modelTiles.get(tileIdJ);
+            if (matchResult == null || matchResult.getTotalNumberOfInliers() == 0) {
+                // ... with fake matches if no inliers found
+                final PointMatch fakeMatch = new PointMatch(
+                        new Point(new double[] {0.0, 0.0}), new Point(new double[] {0.0, 0.0}), 1e-4
+                );
+                modelTileI.connect(modelTileJ, Collections.singletonList(fakeMatch));
+            } else {
+                // ... with real matches if inliers found
+                final List<PointMatch> pointMatches = matchResult.getInlierPointMatchList();
+                modelTileI.connect(modelTileJ, pointMatches);
+            }
+        }
+
+        // Optimize the tiles
+        final TileConfiguration tc = new TileConfiguration();
+        tc.addTiles(modelTiles.values());
+        tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
+
+        try {
+            final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
+            tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
+        } catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
+            throw new RuntimeException("Failed to optimize tile transformations", e);
+        }
+
+
+        // Add the transformations to the tiles
+        final double[] translation = new double[6];
+        for (final Map.Entry<String, Tile<TranslationModel2D>> entry : modelTiles.entrySet()) {
+            final String tileId = entry.getKey();
+            final TranslationModel2D model = entry.getValue().getModel();
+
+            // Combine the translation from the model with the previous translation
+            model.toArray(translation);
+            final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) tiles.getTileSpec(tileId).getLastTransform();
+
+            final String[] previousCoefficients = previousTransformSpec.getDataString().split(" ");
+            final double x = Double.parseDouble(previousCoefficients[4]) + translation[4];
+            final double y = Double.parseDouble(previousCoefficients[5]) + translation[5];
+            final LeafTransformSpec newTransformSpec =  new LeafTransformSpec(
+                    "mpicbg.trakem2.transform.AffineModel2D",
+                    "1 0 0 1 " + x + " " + y
+            );
+
+            // Set the transformation model to the tile spec
+            tiles.addTransformSpecToTile(tileId, newTransformSpec, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
+        }
+
+        return tiles;
+    }
+
+    /**
+     * Extract features from boundary regions.
+     */
+    private static List<Feature> extractBoundaryFeatures(
+            final ImageProcessorCache cache,
+            final TileSpec tileSpec,
+            final CanvasFeatureExtractor featureExtractor
+    ) {
+        // Load an image processor for the given tile.
+        final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
+        final int width = ip.getWidth();
+        final int height = ip.getHeight();
+
+        // Left, right, top, and bottom boundaries
+        final List<Feature> features = new ArrayList<>(extractFeaturesFromRoi(featureExtractor, ip, 0, 0, CLIP_SIZE, height));
+        features.addAll(extractFeaturesFromRoi(featureExtractor, ip, width - CLIP_SIZE, 0, CLIP_SIZE, height));
+        features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, 0, width - 2 * CLIP_SIZE, CLIP_SIZE));
+        features.addAll(extractFeaturesFromRoi(featureExtractor, ip, CLIP_SIZE, height - CLIP_SIZE, width - 2 * CLIP_SIZE, CLIP_SIZE));
+
+        // Move the features to the global coordinate system
+        for (final Feature feature : features) {
+            feature.location[0] += tileSpec.getMinX();
+            feature.location[1] += tileSpec.getMinY();
+        }
+
+        return features;
+    }
+
+    private static ImageProcessor loadImageProcessor(
+            final ImageProcessorCache cache,
+            final TileSpec tileSpec
+    ) {
+        final int downSampleLevel = 0;
+        final boolean isMask = false;
+        final boolean convertTo16Bit = false;
+        final int slice = 0;
+        final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
+        final ImageAndMask image = firstChannel.getMipmap(downSampleLevel);
+        return cache.get(image.getImageUrl(), downSampleLevel, isMask, convertTo16Bit, image.getImageLoaderType(), slice);
+    }
+
+    /**
+     * Extract features from ROI and shift them
+     */
+    private static List<Feature> extractFeaturesFromRoi(
+            final CanvasFeatureExtractor featureExtractor,
+            final ImageProcessor ip,
+            final int xShift,
+            final int yShift,
+            final int w,
+            final int h
+    ) {
+        // Extract the specified ROI from the image processor
+        ip.setRoi(xShift, yShift, w, h);
+        final ImageProcessor roiIp = ip.crop();
+
+        // Extract features from the ROI and place them in the tile coordinate system
+        final List<Feature> features = featureExtractor.extractFeaturesFromImageAndMask(roiIp, null);
+        for (final Feature feature : features) {
+            feature.location[0] += xShift;
+            feature.location[1] += yShift;
+        }
+        return features;
+    }
+
+    /**
+     * Perform intensity correction on the aligned tiles.
+     */
+    private ResolvedTileSpecCollection intensityCorrectTiles(
+            final ResolvedTileSpecCollection tiles,
+            final List<OrderedCanvasIdPair> tilePairs,
+            final ImageProcessorCache cache
+    ) {
+        LOG.info("intensityCorrectTiles: entry, tile count={}", tiles.getTileCount());
+        final Map<String, Tile<TranslationModel1D>> modelTiles = new HashMap<>();
+
+        // Initialize models for each tile spec
+        for (final TileSpec tileSpec : tiles.getTileSpecs()) {
+            // Create a model tile for each tile spec
+            final Tile<TranslationModel1D> modelTile = new Tile<>(new TranslationModel1D());
+            modelTiles.put(tileSpec.getTileId(), modelTile);
+        }
+
+        // Compute intensity differences between tile pairs
+        for (final OrderedCanvasIdPair pair : tilePairs) {
+            // Get the tile specs for the pair
+            final String tileIdI = pair.getP().getId();
+            final String tileIdJ = pair.getQ().getId();
+            final TileSpec tileSpecI = tiles.getTileSpec(tileIdI);
+            final TileSpec tileSpecJ = tiles.getTileSpec(tileIdJ);
+
+            // Update the bounding boxes, since we just moved the tiles
+            tileSpecI.deriveBoundingBox(tileSpecI.getMeshCellSize(), true);
+            tileSpecJ.deriveBoundingBox(tileSpecJ.getMeshCellSize(), true);
+
+            // Compute means on the overlap
+            final Rectangle2D rectI = new Rectangle2D.Double(tileSpecI.getMinX(), tileSpecI.getMinY(), tileSpecI.getWidth(), tileSpecI.getHeight());
+            final Rectangle2D rectJ = new Rectangle2D.Double(tileSpecJ.getMinX(), tileSpecJ.getMinY(), tileSpecJ.getWidth(), tileSpecJ.getHeight());
+            final Rectangle2D overlap = rectI.createIntersection(rectJ);
+
+            final double meanI = computeMeanIntensity(tileSpecI, overlap, cache);
+            final double meanJ = computeMeanIntensity(tileSpecJ, overlap, cache);
+
+            // Add point match
+            final PointMatch pointMatch = new PointMatch(
+                    new Point(new double[] {meanI}),
+                    new Point(new double[] {meanJ})
+            );
+            final Tile<TranslationModel1D> modelTileI = modelTiles.get(tileIdI);
+            final Tile<TranslationModel1D> modelTileJ = modelTiles.get(tileIdJ);
+            modelTileI.connect(modelTileJ, Collections.singletonList(pointMatch));
+        }
+
+        // Optimize the translation models for intensity correction
+        final TileConfiguration tc = new TileConfiguration();
+        tc.addTiles(modelTiles.values());
+        tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
+
+        try {
+            final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
+            tc.optimizeSilently(errorStatistic, 0.5, 1000, 100);
+        } catch (final NotEnoughDataPointsException | IllDefinedDataPointsException e) {
+            throw new RuntimeException("Failed to optimize intensity correction", e);
+        }
+
+        // Apply the intensity shift to the tiles
+        final double[] translation = new double[2];
+        for (final Map.Entry<String, Tile<TranslationModel1D>> entry : modelTiles.entrySet()) {
+            final String tileId = entry.getKey();
+            final TranslationModel1D model = entry.getValue().getModel();
+            final TileSpec tileSpec = tiles.getTileSpec(tileId);
+
+            model.toArray(translation);
+            final FilterSpec filterSpec = new FilterSpec(
+                    "org.janelia.alignment.filter.AffineIntensityFilter",
+                    Map.of("a", String.valueOf(translation[0]), "b", String.valueOf(translation[1]))
+            );
+            tileSpec.setFilterSpec(filterSpec);
+        }
+
+        LOG.info("intensityCorrectTiles: exit");
+        return tiles;
+    }
+
+    private double computeMeanIntensity(
+            final TileSpec tileSpec,
+            final Rectangle2D roi,
+            final ImageProcessorCache cache
+    ) {
+        // Get the pixels within the overlap region
+        final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
+        final int roiMinX = (int) (roi.getMinX() - tileSpec.getMinX());
+        final int roiMinY = (int) (roi.getMinY() - tileSpec.getMinY());
+        ip.setRoi(roiMinX, roiMinY, (int) roi.getWidth(), (int) roi.getHeight());
+        final ImageProcessor roiIp = ip.crop();
+
+        // Compute the mean intensity in the ROI
+        double sum = 0.0;
+        int count = 0;
+        for (int y = 0; y < roiIp.getHeight(); y++) {
+            for (int x = 0; x < roiIp.getWidth(); x++) {
+                sum += roiIp.getf(x, y);
+                count++;
+            }
+        }
+
+        return count > 0 ? sum / count : 0.0;
+    }
+
+    /**
+     * Save the aligned tiles to the prealigned stack.
+     */
+    private int saveMfovTiles(final RenderDataClient dataClient,
+                              final ResolvedTileSpecCollection alignedTiles) throws IOException {
+
+        if (alignedTiles.getTileCount() == 0) {
+            LOG.warn("saveMfovTiles: no aligned tiles to save for mfov={}, z={}",
+                     layerMfov.getName(), layerMfov.getZ());
+            return 0;
+        }
+
+        // Save tiles to the prealigned stack
+        dataClient.saveResolvedTiles(alignedTiles, prealignedStackId.getStack(), layerMfov.getZ());
+
+        return alignedTiles.getTileCount();
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(MfovPrealignTask.class);
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MfovPrealignTask.java
@@ -20,16 +20,13 @@ import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
 import mpicbg.models.Tile;
 import mpicbg.models.TileConfiguration;
-import mpicbg.models.TileUtil;
 import mpicbg.models.TranslationModel2D;
 
-import net.imglib2.img.io.Load;
 import org.janelia.alignment.ImageAndMask;
 import org.janelia.alignment.match.CanvasFeatureExtractor;
 import org.janelia.alignment.match.CanvasFeatureMatcher;
 import org.janelia.alignment.match.CanvasId;
 import org.janelia.alignment.match.CanvasMatchResult;
-import org.janelia.alignment.match.CanvasMatches;
 import org.janelia.alignment.match.MatchFilter;
 import org.janelia.alignment.match.ModelType;
 import org.janelia.alignment.match.OrderedCanvasIdPair;
@@ -40,16 +37,12 @@ import org.janelia.alignment.spec.ChannelSpec;
 import org.janelia.alignment.spec.LeafTransformSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
-import org.janelia.alignment.spec.TransformSpec;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.RenderDataClient;
-import org.janelia.render.client.parameter.MFOVAsTileParameters;
 import org.janelia.render.client.spark.LogUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.crypto.dsig.Transform;
 
 /**
  * Serializable task for aligning SFOVs within a single MFOV.
@@ -57,26 +50,29 @@ import javax.xml.crypto.dsig.Transform;
  */
 public class MfovPrealignTask implements Serializable {
 
-    private final String baseDataUrl;
-    private final StackId rawSfovStackId;
-    private final StackId prealignedStackId;
-    private final LayerMFOV layerMfov;
-    private final MFOVAsTileParameters mfovAsTile;
+	private final String baseDataUrl;
+	private final StackId rawSfovStackId;
+	private final StackId prealignedStackId;
+	private final LayerMFOV layerMfov;
+	private final ImageProcessorCache cache;
 
 	private static final FeatureExtractionParameters FEATURE_EXTRACTION_PARAMETERS = new FeatureExtractionParameters();
 	private static final MatchDerivationParameters MATCH_DERIVATION_PARAMETERS = new MatchDerivationParameters();
 	private static final int CLIP_SIZE = 150;
 
-    public MfovPrealignTask(final String baseDataUrl,
-                            final StackId rawSfovStackId,
-                            final StackId prealignedStackId,
-                            final LayerMFOV layerMfov,
-                            final MFOVAsTileParameters mfovAsTile) {
-        this.baseDataUrl = baseDataUrl;
-        this.rawSfovStackId = rawSfovStackId;
-        this.prealignedStackId = prealignedStackId;
-        this.layerMfov = layerMfov;
-        this.mfovAsTile = mfovAsTile;
+	public MfovPrealignTask(
+			final String baseDataUrl,
+			final StackId rawSfovStackId,
+			final StackId prealignedStackId,
+			final LayerMFOV layerMfov
+	) {
+		this.baseDataUrl = baseDataUrl;
+		this.rawSfovStackId = rawSfovStackId;
+		this.prealignedStackId = prealignedStackId;
+		this.layerMfov = layerMfov;
+
+		// Initialize the image processor cache with ~1Gb size to hold all tiles in memory
+		this.cache = new ImageProcessorCache(1_000_000_000L, false, false);
 
 		FEATURE_EXTRACTION_PARAMETERS.fdSize = 4;
 		FEATURE_EXTRACTION_PARAMETERS.maxScale = 1.0;
@@ -93,129 +89,119 @@ public class MfovPrealignTask implements Serializable {
 		MATCH_DERIVATION_PARAMETERS.matchMinNumInliers = 10;
 		MATCH_DERIVATION_PARAMETERS.matchModelType = ModelType.TRANSLATION;
 		MATCH_DERIVATION_PARAMETERS.matchRod = 0.92f;
-    }
+	}
 
-    /**
-     * Align all SFOVs within this MFOV and save the aligned tile specs to the prealigned stack.
-     *
-     * @throws RuntimeException if alignment fails
-     */
-    public void alignMfov() {
-        try {
-            LogUtilities.setupExecutorLog4j(prealignedStackId.toDevString() + "_" + layerMfov);
+	/**
+	 * Align and intensity correct all SFOVs within this MFOV and save the aligned tile specs to the prealigned stack.
+	 * Both alignment and intensity correction are performed by simple translation models.
+	 *
+	 * @throws RuntimeException if alignment fails
+	 */
+	public void run() {
+		try {
+			LogUtilities.setupExecutorLog4j(prealignedStackId.toDevString() + "_" + layerMfov);
 
-            LOG.info("alignMfov: entry");
+			LOG.info("alignMfov: entry");
 
-            final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
-                                                                     rawSfovStackId.getOwner(),
-                                                                     rawSfovStackId.getProject());
+			final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+																	 rawSfovStackId.getOwner(),
+																	 rawSfovStackId.getProject());
 
-            // 1. Fetch tile specs for all SFOVs in this MFOV
-            final ResolvedTileSpecCollection mfovTiles = fetchMfovTileSpecs(dataClient);
+			// 1. Fetch tile specs for all SFOVs in this MFOV
+			final ResolvedTileSpecCollection mfovTiles = fetchMfovTileSpecs(dataClient);
 
-            if (mfovTiles.getTileCount() == 0) {
-                LOG.warn("alignMfov: no tiles found");
-            } else {
-                LOG.info("alignMfov: fetched {} tiles", mfovTiles.getTileCount());
-            }
+			if (mfovTiles.getTileCount() == 0) {
+				LOG.warn("alignMfov: no tiles found");
+			} else {
+				LOG.info("alignMfov: fetched {} tiles", mfovTiles.getTileCount());
+			}
 
-            // 2. Align tiles within this MFOV
-            final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles);
+			// 2. Generate tile pairs for matching
+			final List<OrderedCanvasIdPair> tilePairs = generateTilePairs(mfovTiles);
 
-            // 4. Push the aligned tile specs to the prealigned stack
-            final int savedTileCount = saveMfovTiles(dataClient, alignedTiles);
+			if (tilePairs.isEmpty()) {
+				LOG.warn("alignTiles: no tile pairs generated");
+				return;
+			}
+			LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
 
-            LOG.info("alignMfov: exit, aligned and saved {} tiles", savedTileCount);
+			// 3. Align tiles within this MFOV
+			final ResolvedTileSpecCollection alignedTiles = alignTiles(mfovTiles, tilePairs);
 
-        } catch (final Exception e) {
-            LOG.error("alignMfov: failed", e);
-            throw new RuntimeException("Failed to align MFOV " + layerMfov, e);
-        }
-    }
+			// 4. Perform intensity correction
+			final ResolvedTileSpecCollection alignedIcTiles = intensityCorrectTiles(alignedTiles, tilePairs);
 
-    /**
-     * Fetch tile specs for all SFOVs belonging to this MFOV at the specified z layer.
-     */
-    private ResolvedTileSpecCollection fetchMfovTileSpecs(final RenderDataClient dataClient) throws IOException {
-        final ResolvedTileSpecCollection mfovTiles = dataClient.getResolvedTiles(rawSfovStackId.getStack(), layerMfov.getZ());
+			// 5. Push the aligned tile specs to the prealigned stack
+			final int savedTileCount = saveMfovTiles(dataClient, alignedIcTiles);
 
-        // Filter tiles that belong to this MFOV and add them to the collection
-        final Set<String> tileIdsToKeep = mfovTiles.getTileSpecs().stream()
-                .map(TileSpec::getTileId)
-                .filter(tileId -> tileId.contains("_" + layerMfov.getSimpleMfovName() + "_"))
-                .collect(Collectors.toSet());
-        mfovTiles.retainTileSpecs(tileIdsToKeep);
+			LOG.info("alignMfov: exit, aligned and saved {} tiles", savedTileCount);
 
-        return mfovTiles;
-    }
-
-    /**
-     * Derive matches between neighboring SFOVs within this MFOV.
-     */
-    private ResolvedTileSpecCollection alignTiles(final ResolvedTileSpecCollection mfovTiles) {
-		// 1. Generate tile pairs for matching
-		final List<OrderedCanvasIdPair> tilePairs = generateTilePairs(mfovTiles);
-
-		if (tilePairs.isEmpty()) {
-			LOG.warn("alignTiles: no tile pairs generated");
-			return mfovTiles;
+		} catch (final Exception e) {
+			LOG.error("alignMfov: failed", e);
+			throw new RuntimeException("Failed to align MFOV " + layerMfov, e);
 		}
-		LOG.info("alignTiles: generated {} tile pairs", tilePairs.size());
+	}
 
-		// 2. Perform SIFT feature matching on tile pairs
-		final ResolvedTileSpecCollection optimizedTiles = performSiftAlignment(mfovTiles, tilePairs);
-		LOG.info("alignTiles: exit");
-		return optimizedTiles;
-    }
+	/**
+	 * Fetch tile specs for all SFOVs belonging to this MFOV at the specified z layer.
+	 */
+	private ResolvedTileSpecCollection fetchMfovTileSpecs(final RenderDataClient dataClient) throws IOException {
+		final ResolvedTileSpecCollection mfovTiles = dataClient.getResolvedTiles(rawSfovStackId.getStack(), layerMfov.getZ());
 
-    /**
-     * Generate tile pairs for matching based on spatial proximity within the MFOV.
-     */
-    private List<OrderedCanvasIdPair> generateTilePairs(final ResolvedTileSpecCollection mfovTiles) {
-        final List<OrderedCanvasIdPair> pairs = new ArrayList<>();
-        final List<TileSpec> tileList = new ArrayList<>(mfovTiles.getTileSpecs());
+		// Filter tiles that belong to this MFOV and add them to the collection
+		final Set<String> tileIdsToKeep = mfovTiles.getTileSpecs().stream()
+				.map(TileSpec::getTileId)
+				.filter(tileId -> tileId.contains("_" + layerMfov.getSimpleMfovName() + "_"))
+				.collect(Collectors.toSet());
+		mfovTiles.retainTileSpecs(tileIdsToKeep);
 
-        // Generate intersecting tile pairs
-        for (int i = 0; i < tileList.size(); i++) {
-            final TileSpec ti = tileList.get(i);
-            final Rectangle2D rectI = new Rectangle2D.Double(ti.getMinX(), ti.getMinY(), ti.getWidth(), ti.getHeight());
+		return mfovTiles;
+	}
 
-            for (int j = i + 1; j < tileList.size(); j++) {
-                final TileSpec tj = tileList.get(j);
-                final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMinY(), tj.getWidth(), tj.getHeight());
+	/**
+	 * Generate tile pairs for matching based on spatial proximity within the MFOV.
+	 */
+	private List<OrderedCanvasIdPair> generateTilePairs(final ResolvedTileSpecCollection mfovTiles) {
+		final List<OrderedCanvasIdPair> pairs = new ArrayList<>();
+		final List<TileSpec> tileList = new ArrayList<>(mfovTiles.getTileSpecs());
 
-				final boolean intersects = rectI.intersects(rectJ);
-                if (rectI.intersects(rectJ)) {
-                    final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
-                    final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
-                    pairs.add(new OrderedCanvasIdPair(canvasIdI, canvasIdJ, 0.0));
-                }
-            }
-        }
+		// Generate intersecting tile pairs
+		for (int i = 0; i < tileList.size(); i++) {
+			final TileSpec ti = tileList.get(i);
+			final Rectangle2D rectI = new Rectangle2D.Double(ti.getMinX(), ti.getMinY(), ti.getWidth(), ti.getHeight());
 
-        return pairs;
-    }
+			for (int j = i + 1; j < tileList.size(); j++) {
+				final TileSpec tj = tileList.get(j);
+				final Rectangle2D rectJ = new Rectangle2D.Double(tj.getMinX(), tj.getMinY(), tj.getWidth(), tj.getHeight());
 
-    /**
-     * Perform SIFT feature matching on the tile pairs.
-     */
-	private ResolvedTileSpecCollection performSiftAlignment(
-			final ResolvedTileSpecCollection mfovTiles,
+				if (rectI.intersects(rectJ)) {
+					final CanvasId canvasIdI = new CanvasId(ti.getGroupId(), ti.getTileId());
+					final CanvasId canvasIdJ = new CanvasId(tj.getGroupId(), tj.getTileId());
+					pairs.add(new OrderedCanvasIdPair(canvasIdI, canvasIdJ, 0.0));
+				}
+			}
+		}
+
+		return pairs;
+	}
+
+	/**
+	 * Perform SIFT feature matching on the tile pairs.
+	 */
+	private ResolvedTileSpecCollection alignTiles(
+			final ResolvedTileSpecCollection tiles,
 			final List<OrderedCanvasIdPair> tilePairs
 	) {
-		// Set cache size to ~1GB, so that all mfov tiles can be kept in memory
-		final ImageProcessorCache ipCache = new ImageProcessorCache(1_000_000_000L, false, false);
-
 		// Extract features from all mfov tiles
 		final CanvasFeatureExtractor featureExtractor = CanvasFeatureExtractor.build(FEATURE_EXTRACTION_PARAMETERS);
-		final Map<String, List<Feature>> mfovFeatures = new HashMap<>(mfovTiles.getTileCount());
-		final Map<String, Tile<TranslationModel2D>> tiles = new HashMap<>();
+		final Map<String, List<Feature>> mfovFeatures = new HashMap<>(tiles.getTileCount());
+		final Map<String, Tile<TranslationModel2D>> modelTiles = new HashMap<>();
 
-		for (final TileSpec tileSpec : mfovTiles.getTileSpecs()) {
-			final List<Feature> tileFeatures = extractBoundaryFeatures(ipCache, tileSpec, featureExtractor);
+		for (final TileSpec tileSpec : tiles.getTileSpecs()) {
+			final List<Feature> tileFeatures = extractBoundaryFeatures(cache, tileSpec, featureExtractor);
 
 			mfovFeatures.put(tileSpec.getTileId(), tileFeatures);
-			tiles.put(tileSpec.getTileId(), new Tile<>(new TranslationModel2D()));
+			modelTiles.put(tileSpec.getTileId(), new Tile<>(new TranslationModel2D()));
 		}
 
 		// Match features between tile pairs
@@ -232,25 +218,25 @@ public class MfovPrealignTask implements Serializable {
 			);
 
 			// Connect tiles for optimization...
-			final Tile<TranslationModel2D> tileI = tiles.get(tileIdI);
-			final Tile<TranslationModel2D> tileJ = tiles.get(tileIdJ);
+			final Tile<TranslationModel2D> modelTileI = modelTiles.get(tileIdI);
+			final Tile<TranslationModel2D> modelTileJ = modelTiles.get(tileIdJ);
 			if (matchResult == null || matchResult.getTotalNumberOfInliers() == 0) {
 				// ... with fake matches if no inliers found
 				final PointMatch fakeMatch = new PointMatch(
 						new Point(new double[] {0.0, 0.0}), new Point(new double[] {0.0, 0.0}), 1e-4
 				);
-				tileI.connect(tileJ, Collections.singletonList(fakeMatch));
+				modelTileI.connect(modelTileJ, Collections.singletonList(fakeMatch));
 			} else {
 				// ... with real matches if inliers found
 				final List<PointMatch> pointMatches = matchResult.getInlierPointMatchList();
-				tileI.connect(tileJ, pointMatches);
+				modelTileI.connect(modelTileJ, pointMatches);
 			}
 		}
 
 		// Optimize the tiles
 		final TileConfiguration tc = new TileConfiguration();
-		tc.addTiles(tiles.values());
-		tc.fixTile(tiles.values().stream().findFirst().orElseThrow());
+		tc.addTiles(modelTiles.values());
+		tc.fixTile(modelTiles.values().stream().findFirst().orElseThrow());
 
 		try {
 			final ErrorStatistic errorStatistic = new ErrorStatistic(1001);
@@ -262,13 +248,13 @@ public class MfovPrealignTask implements Serializable {
 
 		// Add the transformations to the tiles
 		final double[] translation = new double[6];
-		for (final Map.Entry<String, Tile<TranslationModel2D>> entry : tiles.entrySet()) {
+		for (final Map.Entry<String, Tile<TranslationModel2D>> entry : modelTiles.entrySet()) {
 			final String tileId = entry.getKey();
 			final TranslationModel2D model = entry.getValue().getModel();
 
 			// Combine the translation from the model with the previous translation
 			model.toArray(translation);
-			final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) mfovTiles.getTileSpec(tileId).getLastTransform();
+			final LeafTransformSpec previousTransformSpec = (LeafTransformSpec) tiles.getTileSpec(tileId).getLastTransform();
 
 			final String[] previousCoefficients = previousTransformSpec.getDataString().split(" ");
 			final double x = Double.parseDouble(previousCoefficients[4]) + translation[4];
@@ -279,11 +265,11 @@ public class MfovPrealignTask implements Serializable {
 			);
 
 			// Set the transformation model to the tile spec
-			mfovTiles.addTransformSpecToTile(tileId, newTransformSpec, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
+			tiles.addTransformSpecToTile(tileId, newTransformSpec, ResolvedTileSpecCollection.TransformApplicationMethod.REPLACE_LAST);
 		}
 
-		return mfovTiles;
-    }
+		return tiles;
+	}
 
 	/**
 	 * Extract features from boundary regions.
@@ -294,10 +280,7 @@ public class MfovPrealignTask implements Serializable {
 			final CanvasFeatureExtractor featureExtractor
 	) {
 		// Load an image processor for the given tile.
-		final int downSampleLevel = 0;
-		final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
-		final ImageAndMask image = firstChannel.getMipmap(downSampleLevel);
-		final ImageProcessor ip = cache.get(image.getImageUrl(), downSampleLevel, false, false, image.getImageLoaderType(), 0);
+		final ImageProcessor ip = loadImageProcessor(cache, tileSpec);
 		final int width = ip.getWidth();
 		final int height = ip.getHeight();
 
@@ -314,6 +297,19 @@ public class MfovPrealignTask implements Serializable {
 		}
 
 		return features;
+	}
+
+	private static ImageProcessor loadImageProcessor(
+			final ImageProcessorCache cache,
+			final TileSpec tileSpec
+	) {
+		final int downSampleLevel = 0;
+		final boolean isMask = false;
+		final boolean convertTo16Bit = false;
+		final int slice = 0;
+		final ChannelSpec firstChannel = tileSpec.getAllChannels().get(0);
+		final ImageAndMask image = firstChannel.getMipmap(downSampleLevel);
+		return cache.get(image.getImageUrl(), downSampleLevel, isMask, convertTo16Bit, image.getImageLoaderType(), slice);
 	}
 
 	/**
@@ -340,23 +336,40 @@ public class MfovPrealignTask implements Serializable {
 		return features;
 	}
 
-    /**
-     * Save the aligned tiles to the prealigned stack.
-     */
-    private int saveMfovTiles(final RenderDataClient dataClient,
-                             final ResolvedTileSpecCollection alignedTiles) throws IOException {
+	/**
+	 * Perform intensity correction on the aligned tiles.
+	 */
+	private ResolvedTileSpecCollection intensityCorrectTiles(
+			final ResolvedTileSpecCollection tiles,
+			final List<OrderedCanvasIdPair> tilePairs
+	) {
+		LOG.info("intensityCorrectTiles: entry, tile count={}", tiles.getTileCount());
 
-        if (alignedTiles.getTileCount() == 0) {
-            LOG.warn("saveMfovTiles: no aligned tiles to save for mfov={}, z={}",
-                     layerMfov.getName(), layerMfov.getZ());
-            return 0;
-        }
+		for (final OrderedCanvasIdPair pair : tilePairs) {
+			// TODO
+		}
 
-        // Save tiles to the prealigned stack
-        dataClient.saveResolvedTiles(alignedTiles, prealignedStackId.getStack(), layerMfov.getZ());
+		LOG.info("intensityCorrectTiles: exit");
+		return tiles;
+	}
 
-        return alignedTiles.getTileCount();
-    }
+	/**
+	 * Save the aligned tiles to the prealigned stack.
+	 */
+	private int saveMfovTiles(final RenderDataClient dataClient,
+							  final ResolvedTileSpecCollection alignedTiles) throws IOException {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MfovPrealignTask.class);
+		if (alignedTiles.getTileCount() == 0) {
+			LOG.warn("saveMfovTiles: no aligned tiles to save for mfov={}, z={}",
+					 layerMfov.getName(), layerMfov.getZ());
+			return 0;
+		}
+
+		// Save tiles to the prealigned stack
+		dataClient.saveResolvedTiles(alignedTiles, prealignedStackId.getStack(), layerMfov.getZ());
+
+		return alignedTiles.getTileCount();
+	}
+
+	private static final Logger LOG = LoggerFactory.getLogger(MfovPrealignTask.class);
 }


### PR DESCRIPTION
This PR adds an mfov-wise prealign (translation-only) and intensity correction (shift-only).

The whole process runs in about 2min with a single core on my laptop for one mfov, and it's parallelized across mfovs. To test, I ran `MFOVASTileClient.java` with
```
final MultiProjectParameters projectParams = new MultiProjectParameters();
projectParams.baseDataUrl = "http://10.40.3.113:8080/render-ws/v1";
projectParams.owner = "hess_wafers_60_61";
projectParams.project = "w60_serial_360_to_369";
projectParams.stackIdWithZ.projectPattern = "^w60_serial_360_to_369$";
projectParams.stackIdWithZ.stackPattern = "^mi_mfov_align_ic_test$";
final MFOVAsTileParameters mfovAsTileParams = new MFOVAsTileParameters(
        0.2,
        "/Users/innerbergerm/Data/wafer-60-61/mfov-align-ic",
        "_prealign",
        "_mat",
        "_rend",
        "_align",
        "_rough"
);
final Parameters parameters = new Parameters(projectParams, mfovAsTileParams);
```

The preliminary results look pretty good:
- [old stack without prealing/intensity correction](http://renderer.int.janelia.org:8080/ng/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B103971.2578125%2C49522.16796875%2C19.5%5D%2C%22crossSectionScale%22:10.35623467324856%2C%22projectionScale%22:32768%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22render://http://renderer.int.janelia.org:8080/hess_wafers_60_61/w60_serial_360_to_369/mi_mfov_align_ic_test%22%2C%22subsources%22:%7B%22default%22:true%2C%22bounds%22:true%7D%2C%22enableDefaultSubsources%22:false%7D%2C%22tab%22:%22rendering%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B141%2C201%5D%7D%7D%2C%22name%22:%22mi_mfov_align_ic_test%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22mi_mfov_align_ic_test%22%7D%2C%22layout%22:%22xy%22%7D)
- [new stack with both](http://renderer.int.janelia.org:8080/ng/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B103523.3984375%2C49420.33984375%2C19.5%5D%2C%22crossSectionScale%22:8.187337244584688%2C%22projectionScale%22:32768%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%7B%22url%22:%22render://http://renderer.int.janelia.org:8080/hess_wafers_60_61/w60_serial_360_to_369/mi_mfov_align_ic_test_prealign?maxTileSpecsToRender=400%22%2C%22subsources%22:%7B%22default%22:true%2C%22bounds%22:true%7D%2C%22enableDefaultSubsources%22:false%7D%2C%22tab%22:%22rendering%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B134%2C206%5D%7D%7D%2C%22name%22:%22mi_mfov_align_ic_test_prealign%22%7D%5D%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22mi_mfov_align_ic_test_prealign%22%7D%2C%22layout%22:%22xy%22%7D)

However, this is only a draft insofar as there are still two things that I haven't fully tested:
- I only tested the prealign step separately from the rest of the pipeline. In [this commit](https://github.com/saalfeldlab/render/commit/a4afc7289168b3ac1c3c371b87fcb52bea9ae9aa), I hooked up the prealigned stack into the general pipeline, but didn't test it, yet. I doubt there will be large problems, but can you please have a quick look @trautmane if that's still compatible with your workflow?
- The feature extraction and matching parameters are taken from [our normal multi-sem pipeline](https://github.com/JaneliaSciComp/EM_recon_pipeline/blob/4ce381e25d5705e5bd5e58626f7524c7e87c1ff9/src/scripts/msem_60_61/pipeline_json/01_match/pipe.01.360.mip-match-patch-check.json#L89). However, they don't seem to work too well in practice as the current client still needs to connect some tiles with fake matches, even if there should be sufficient content. As I'm not super familiar with the matching parameters, could you please have a look, @StephanPreibisch?