### PR TITLE
Add support  writing to google cloud storage

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/util/NeuroglancerAttributes.java
+++ b/render-app/src/main/java/org/janelia/alignment/util/NeuroglancerAttributes.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,13 +134,13 @@ public class NeuroglancerAttributes {
     /**
      * Writes all attribute.json files required by neuroglancer to display the specified dataset.
      *
-     * @param  n5BasePath            base path for n5.
+     * @param  n5Writer              N5 writer to use for writing the attributes.
      * @param  fullScaleDatasetPath  path of the full scale data set.
      *
      * @throws IOException
      *   if the writes fail for any reason.
      */
-    public void write(final Path n5BasePath,
+    public void write(final N5Writer n5Writer,
                       final Path fullScaleDatasetPath)
             throws IOException {
 
@@ -150,10 +149,8 @@ public class NeuroglancerAttributes {
         final Path ngAttributesPath = isMultiScaleDataset ?
                                       fullScaleDatasetPath.getParent() : fullScaleDatasetPath;
 
-        LOG.info("write: entry, n5BasePath={}, fullScaleDatasetPath={}, ngAttributesPath={}",
-                 n5BasePath, fullScaleDatasetPath, ngAttributesPath);
-
-        final N5Writer n5Writer = new N5FSWriter(n5BasePath.toAbsolutePath().toString());
+        LOG.info("write: entry, n5Base={}, fullScaleDatasetPath={}, ngAttributesPath={}",
+                 n5Writer.getURI(), fullScaleDatasetPath, ngAttributesPath);
 
         // Neuroglancer recursively looks for attribute.json files from root path and stops at
         // the first subdirectory without an attributes.json file.
@@ -164,7 +161,7 @@ public class NeuroglancerAttributes {
         for (Path path = ngAttributesPath.getParent();
              (path != null) && (! path.endsWith("/"));
              path = path.getParent()) {
-            LOG.info("write: saving supported attribute to {}{}/attributes.json", n5BasePath, path);
+            LOG.info("write: saving supported attribute to {}{}/attributes.json", n5Writer.getURI(), path);
             n5Writer.setAttribute(path.toString(), SUPPORTED_KEY, true);
         }
 
@@ -180,7 +177,7 @@ public class NeuroglancerAttributes {
         attributes.put("pixelResolution", pixelResolution);
         attributes.put("translate", translate);
 
-        LOG.info("write: saving neuroglancer attributes to {}{}/attributes.json", n5BasePath, ngAttributesPath);
+        LOG.info("write: saving neuroglancer attributes to {}{}/attributes.json", n5Writer.getURI(), ngAttributesPath);
         n5Writer.setAttributes(ngAttributesPath.toString(), attributes);
 
         if (isMultiScaleDataset) {
@@ -188,7 +185,7 @@ public class NeuroglancerAttributes {
                 writeScaleLevelTransformAttributes(scaleLevel,
                                                    scales.get(scaleLevel),
                                                    n5Writer,
-                                                   n5BasePath,
+                                                   n5Writer.getURI().toString(),
                                                    ngAttributesPath);
             }
         }
@@ -197,16 +194,18 @@ public class NeuroglancerAttributes {
     private void writeScaleLevelTransformAttributes(final int scaleLevel,
                                                     final List<Integer> scaleLevelFactors,
                                                     final N5Writer n5Writer,
-                                                    final Path n5BasePath,
+                                                    final String n5Base,
                                                     final Path ngAttributesPath)
             throws IOException {
 
         final String scaleName = "s" + scaleLevel;
         final Path scaleAttributesPath = Paths.get(ngAttributesPath.toString(), scaleName);
 
-        final Path scaleLevelDirectoryPath = Paths.get(n5BasePath.toString(), ngAttributesPath.toString(), scaleName);
-        if (! scaleLevelDirectoryPath.toFile().exists()) {
-            throw new IOException(scaleLevelDirectoryPath.toAbsolutePath() + " does not exist");
+        if (n5Base.startsWith("/") || n5Base.startsWith("\\")) {
+            final Path scaleLevelDirectoryPath = Paths.get(n5Base, ngAttributesPath.toString(), scaleName);
+            if (! scaleLevelDirectoryPath.toFile().exists()) {
+                throw new IOException(scaleLevelDirectoryPath.toAbsolutePath() + " does not exist");
+            }
         }
 
         final Map<String, Object> transformAttributes = new HashMap<>();
@@ -232,7 +231,7 @@ public class NeuroglancerAttributes {
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put("transform", transformAttributes);
 
-        LOG.info("writeScaleLevelTransformAttributes: saving {}{}/attributes.json", n5BasePath, scaleAttributesPath);
+        LOG.info("writeScaleLevelTransformAttributes: saving {}{}/attributes.json", n5Base, scaleAttributesPath);
         n5Writer.setAttributes(scaleAttributesPath.toString(), attributes);
     }
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/n5/CrossCorrelationWithNextRegionalDataN5Writer.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/n5/CrossCorrelationWithNextRegionalDataN5Writer.java
@@ -132,7 +132,7 @@ public class CrossCorrelationWithNextRegionalDataN5Writer
                                                                       stackResolutionUnit,
                                                                       rowCount,
                                                                       columnCount);
-        ngAttributes.write(Paths.get(basePath), Paths.get(datasetName));
+        ngAttributes.write(n5Writer, Paths.get(datasetName));
 
         final String dataSetPath = attributesPath.getParent().toString();
         final Path ccDataPath = Paths.get(dataSetPath, "cc_regional_data.json.gz");
@@ -161,7 +161,7 @@ public class CrossCorrelationWithNextRegionalDataN5Writer
                 Files.write(ngUrlPath, ngUrlString.getBytes());
                 LOG.info("createDataSet: neuroglancer URL written to {}", ngUrlPath);
             } catch (final IOException e) {
-                LOG.warn("ignoring failure to write " + ngUrlPath, e);
+                LOG.warn("ignoring failure to write {}", ngUrlPath, e);
             }
         }
 
@@ -327,7 +327,7 @@ public class CrossCorrelationWithNextRegionalDataN5Writer
                              exportPrefix, renderExportProjectDir);
                 }
             } catch (final IOException e) {
-                LOG.warn("ignoring failure to list files in " + renderExportProjectDir, e);
+                LOG.warn("ignoring failure to list files in {}", renderExportProjectDir, e);
             }
         } else {
             LOG.warn("buildNgLayerStringForLatestRenderExport: failed to find render export directory {}",

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/ExportMichalSegmentationsClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/ExportMichalSegmentationsClient.java
@@ -242,6 +242,8 @@ public class ExportMichalSegmentationsClient implements Serializable {
                                            Arrays.asList(min[0], min[1], min[2]),
                                            NeuroglancerAttributes.NumpyContiguousOrdering.FORTRAN);
 
-        ngAttributes.write(Paths.get(parameters.targetN5Path), Paths.get(targetDataset, "s0"));
+        try (final N5Writer n5 = new N5FSWriter(parameters.targetN5Path)) {
+            ngAttributes.write(n5, Paths.get(targetDataset, "s0"));
+        }
     }
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/H5TileToN5PreviewClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/H5TileToN5PreviewClient.java
@@ -559,8 +559,7 @@ public class H5TileToN5PreviewClient {
                                            Arrays.asList(exportInfo.min[0], exportInfo.min[1], exportInfo.min[2]),
                                            NeuroglancerAttributes.NumpyContiguousOrdering.FORTRAN);
 
-        ngAttributes.write(Paths.get(exportInfo.n5PathString),
-                           Paths.get(exportInfo.fullScaleDatasetName));
+        ngAttributes.write(n5Supplier.get(), Paths.get(exportInfo.fullScaleDatasetName));
     }
 
     private static long findMinZToRender(final DatasetAttributes datasetAttributes,

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
@@ -336,13 +336,12 @@ public class N5Client {
         }
 
         int numberOfDownSampledDatasets = 0;
+        final N5WriterSupplier n5Supplier = new Util.N5PathSupplier(parameters.n5Path);
         if (downsampleStack) {
 
             LOG.info("run: downsample stack with factors {}", Arrays.toString(downsampleFactors));
 
             // Now that the full resolution image is saved into n5, generate the scale pyramid
-            final N5WriterSupplier n5Supplier = new Util.N5PathSupplier(parameters.n5Path);
-
             final List<String> downsampledDatasetPaths =
                     downsampleScalePyramid(sparkContext,
                                            n5Supplier,
@@ -362,8 +361,7 @@ public class N5Client {
                                            Arrays.asList(min[0], min[1], min[2]),
                                            NeuroglancerAttributes.NumpyContiguousOrdering.FORTRAN);
 
-        ngAttributes.write(Paths.get(parameters.n5Path),
-                           Paths.get(fullScaleDatasetName));
+        ngAttributes.write(n5Supplier.get(), Paths.get(fullScaleDatasetName));
 
         if (downsampleStackForReview) {
 
@@ -407,8 +405,7 @@ public class N5Client {
                                                Arrays.asList(min[0], min[1], min[2]),
                                                NeuroglancerAttributes.NumpyContiguousOrdering.FORTRAN);
 
-            reviewNgAttributes.write(Paths.get(parameters.n5Path),
-                                     Paths.get(fullScaleReviewDatasetName));
+            reviewNgAttributes.write(n5ReviewSupplier.get(), Paths.get(fullScaleReviewDatasetName));
         }
 
         sparkContext.close();

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/N5Client.java
@@ -38,10 +38,11 @@ import org.janelia.render.client.spark.LogUtilities;
 import org.janelia.render.client.zspacing.ThicknessCorrectionData;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
+import org.janelia.saalfeldlab.n5.universe.N5Factory.StorageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -475,7 +476,7 @@ public class N5Client {
                                               final int[] blockSize,
                                               final DataType dataType) {
 
-        try (final N5Writer n5 = new N5FSWriter(parameters.n5Path)) {
+        try (final N5Writer n5 = new N5Factory().openWriter(StorageFormat.N5, parameters.n5Path)) {
             n5.createDataset(fullScaleDatasetName,
                              dimensions,
                              blockSize,
@@ -494,7 +495,7 @@ public class N5Client {
 
         String exportAttributesDatasetName = fullScaleDatasetName;
 
-        try (final N5Writer n5 = new N5FSWriter(parameters.n5Path)) {
+        try (final N5Writer n5 = new N5Factory().openWriter(StorageFormat.N5, parameters.n5Path)) {
             final Map<String, Object> export_attributes = new HashMap<>();
             export_attributes.put("runTimestamp", new Date());
             export_attributes.put("runParameters", parameters);
@@ -661,8 +662,9 @@ public class N5Client {
                 }
             }
 
-            final N5Writer anotherN5Writer = new N5FSWriter(n5Path); // needed to prevent Spark serialization error
+            final N5Writer anotherN5Writer = new N5Factory().openWriter(StorageFormat.N5, n5Path); // needed to prevent Spark serialization error
             N5Utils.saveNonEmptyBlock(block, anotherN5Writer, datasetName, gridBlock.gridPosition, new UnsignedByteType(0));
+            anotherN5Writer.close();
         });
     }
 
@@ -722,8 +724,9 @@ public class N5Client {
                 out.next().set(in.next());
             }
 
-            final N5Writer anotherN5Writer = new N5FSWriter(n5Path); // needed to prevent Spark serialization error
+            final N5Writer anotherN5Writer = new N5Factory().openWriter(StorageFormat.N5, n5Path); // needed to prevent Spark serialization error
             N5Utils.saveNonEmptyBlock(block, anotherN5Writer, datasetName, gridBlock.gridPosition, new UnsignedByteType(0));
+            anotherN5Writer.close();
         });
 
         LOG.info("save2DRenderStack: exit");

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/Util.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/n5/Util.java
@@ -2,9 +2,9 @@ package org.janelia.render.client.spark.n5;
 
 import java.io.IOException;
 
-import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.spark.supplier.N5WriterSupplier;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
 
 /**
  * Utilities for N5 operations.
@@ -22,7 +22,7 @@ public class Util {
         @Override
         public N5Writer get()
                 throws IOException {
-            return new N5FSWriter(path);
+            return new N5Factory().openWriter(N5Factory.StorageFormat.N5, path);
         }
     }
 

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/n5/N5ClientTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/n5/N5ClientTest.java
@@ -150,13 +150,13 @@ public class N5ClientTest {
     @Test
     public void testNeuroglancerAttributes() throws Exception {
 
-        final Path n5Path = n5PathDirectory.toPath().toAbsolutePath();
+        final String n5Path = n5PathDirectory.getAbsolutePath();
         final Path fullScaleDatasetPath = Paths.get("/render/test_stack/one_more_nested_dir/s0");
         final String datasetName = fullScaleDatasetPath.toString();
 
         final long[] dimensions = { 100L, 200L, 300L };
         final int[] blockSize = { 10, 20, 30 };
-        try (final N5Writer n5Writer = new N5FSWriter(n5Path.toString())) {
+        try (final N5Writer n5Writer = new N5FSWriter(n5Path)) {
 
             final DatasetAttributes datasetAttributes = new DatasetAttributes(dimensions,
                                                                               blockSize,
@@ -164,7 +164,7 @@ public class N5ClientTest {
                                                                               new GzipCompression());
             n5Writer.createDataset(datasetName, datasetAttributes);
 
-            final N5Reader n5Reader = new N5FSReader(n5Path.toString());
+            final N5Reader n5Reader = new N5FSReader(n5Path);
             Assert.assertTrue("dataset " + datasetName + " is missing", n5Reader.datasetExists(datasetName));
 
             final Map<String, Object> originalDatasetAttributes = datasetAttributes.asMap();
@@ -198,7 +198,7 @@ public class N5ClientTest {
                                                Arrays.asList(5L, 25L, 125L),
                                                NeuroglancerAttributes.NumpyContiguousOrdering.C);
 
-            ngAttributes.write(n5Path, fullScaleDatasetPath);
+            ngAttributes.write(n5Writer, fullScaleDatasetPath);
 
             final String testStackDatasetName = fullScaleDatasetPath.getParent().toString();
 


### PR DESCRIPTION
This is a second attempt at #207. I used some of the commits from there as a starting point, which already enabled writing the N5 data to gcp.

In order to not pull N5-universe into render-app, I made `NeuroglancerAtrributes::write` take an `N5Writer` instead of a string/URI. Interestingly, this made it much more convenient to use the method in most occurrences, anyway.

I checked that writing everything works to the extent that the N5 on gcp can be pointed to and viewed from neuroglancer. Let me know what you think, @trautmane! (Also tagging @StephanPreibisch)