### PR TITLE
first draft of layer-as-tile code

### DIFF
--- a/render-app/src/main/java/org/janelia/alignment/multisem/Layer.java
+++ b/render-app/src/main/java/org/janelia/alignment/multisem/Layer.java
@@ -59,8 +59,8 @@ public class Layer {
 
         final int numberOfTilesInZLayer = renderParameters.numberOfTileSpecs();
 
-        final int scaledImageWidth = (int) Math.floor(renderParameters.width * renderScale);
-        final int scaledImageHeight = (int) Math.floor(renderParameters.height * renderScale);
+        final double scaledImageWidth = Math.floor(renderParameters.width * renderScale);
+        final double scaledImageHeight = Math.floor(renderParameters.height * renderScale);
         final double x = renderParameters.x * renderScale;
         final double y = renderParameters.y * renderScale;
 
@@ -68,8 +68,8 @@ public class Layer {
 
         tileSpec.setTileId(toLayerAsTileName(stackId.getStack(), z.intValue()));
         tileSpec.setZ(z);
-        tileSpec.setWidth((double) scaledImageWidth);
-        tileSpec.setHeight((double) scaledImageHeight);
+        tileSpec.setWidth(scaledImageWidth);
+        tileSpec.setHeight(scaledImageHeight);
 
         final LayoutData layoutData = new LayoutData(z.toString(), null, null,
                                                      0, 0, x, y, null);

--- a/render-app/src/main/java/org/janelia/alignment/multisem/Layer.java
+++ b/render-app/src/main/java/org/janelia/alignment/multisem/Layer.java
@@ -1,0 +1,117 @@
+package org.janelia.alignment.multisem;
+
+import java.util.Collections;
+
+import mpicbg.trakem2.transform.TranslationModel2D;
+
+import org.janelia.alignment.ImageAndMask;
+import org.janelia.alignment.RenderParameters;
+import org.janelia.alignment.loader.ImageLoader;
+import org.janelia.alignment.spec.ChannelSpec;
+import org.janelia.alignment.spec.LayoutData;
+import org.janelia.alignment.spec.LeafTransformSpec;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.stack.StackId;
+
+/**
+ * Utilities for rendering a z-layer.
+ */
+public class Layer {
+
+
+    public static String toLayerAsTileName(final String stackName,
+                                           final int z) {
+        return String.format("%s_z%03d", stackName, z);
+    }
+
+    /**
+     * @param  baseDataUrl  the base URL for the render web service.
+     * @param  stackId      stack identifier.
+     * @param  z            layer z value.
+     * @param  renderScale  scale to apply to each SFOV within each MFOV when the MFOVs images are later rendered.
+     *
+     * @return a URL string to retrieve the render parameters for this MFOV.
+     */
+    public static String buildRenderParametersUrl(final String baseDataUrl,
+                                                  final StackId stackId,
+                                                  final Double z,
+                                                  final double renderScale) {
+        final String stackUrl = baseDataUrl + "/owner/" + stackId.getOwner() +
+                                "/project/" + stackId.getProject() + "/stack/" + stackId.getStack();
+        return stackUrl + "/z/" + z + "/render-parameters?scale=" + renderScale;
+    }
+
+    /**
+     * @param  baseDataUrl  the base URL for the render web service.
+     * @param  stackId      stack identifier.
+     * @param  z            layer z value.
+     * @param  renderScale  scale to apply to each SFOV within each MFOV when the MFOVs images are later rendered.
+     *
+     * @return a TileSpec for this z layer.
+     */
+    public static TileSpec buildTileSpec(final String baseDataUrl,
+                                         final StackId stackId,
+                                         final Double z,
+                                         final double renderScale) {
+
+        final String renderParametersUrl = buildRenderParametersUrl(baseDataUrl, stackId, z, renderScale);
+        final RenderParameters renderParameters = RenderParameters.loadFromUrl(renderParametersUrl);
+
+        final int numberOfTilesInZLayer = renderParameters.numberOfTileSpecs();
+
+        final int scaledImageWidth = (int) Math.floor(renderParameters.width * renderScale);
+        final int scaledImageHeight = (int) Math.floor(renderParameters.height * renderScale);
+        final double x = renderParameters.x * renderScale;
+        final double y = renderParameters.y * renderScale;
+
+        final TileSpec tileSpec = new TileSpec();
+
+        tileSpec.setTileId(toLayerAsTileName(stackId.getStack(), z.intValue()));
+        tileSpec.setZ(z);
+        tileSpec.setWidth((double) scaledImageWidth);
+        tileSpec.setHeight((double) scaledImageHeight);
+
+        final LayoutData layoutData = new LayoutData(z.toString(), null, null,
+                                                     0, 0, x, y, null);
+        tileSpec.setLayout(layoutData);
+
+        final ChannelSpec channelSpec = new ChannelSpec();
+        // Convert
+        //   http://.../stack/w60_s360_r00_gc/z/1.0/render-parameters?scale=0.1
+        // to:
+        //   http://.../stack/w60_s360_r00_gc/z/1.0/png-image?scale=0.1&maxTileSpecsToRender=1234
+        final String pngImageUrl = renderParametersUrl.replace("render-parameters", "png-image") +
+                                   "&maxTileSpecsToRender=" + numberOfTilesInZLayer;
+
+        final TileSpec firstSfovTileSpec = renderParameters.getTileSpecs().get(0);
+        final ImageAndMask firstSfovImageAndMask = firstSfovTileSpec.getFirstMipmapEntry().getValue();
+        final ImageLoader.LoaderType firstSfovImageLoaderType = firstSfovImageAndMask.getImageLoaderType();
+        ImageLoader.LoaderType loaderType = null;
+        if (ImageLoader.LoaderType.IMAGEJ_DEFAULT_W_TIMEOUT.equals(firstSfovImageLoaderType)) {
+            // If the first SFOV uses LoaderType.IMAGEJ_DEFAULT_W_TIMEOUT
+            // (e.g., when source images are stored in Google buckets),
+            // use the same loader type for the MFOV image.
+            loaderType = ImageLoader.LoaderType.IMAGEJ_DEFAULT_W_TIMEOUT;
+        }
+
+        channelSpec.putMipmap(0,
+                              new ImageAndMask(pngImageUrl,
+                                               loaderType,
+                                               null,
+                                               null,
+                                               null,
+                                               null));
+        tileSpec.addChannel(channelSpec);
+        tileSpec.convertSingleChannelSpecToLegacyForm();
+
+        final String translateDataString = (int) Math.floor(x) + " " + (int) Math.floor(y);
+        final LeafTransformSpec transformSpec = new LeafTransformSpec(TranslationModel2D.class.getName(),
+                                                                      translateDataString);
+        tileSpec.addTransformSpecs(Collections.singletonList(transformSpec));
+
+        tileSpec.deriveBoundingBox(tileSpec.getMeshCellSize(), true);
+
+        return tileSpec;
+    }
+
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVAsTileStackClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/multisem/MFOVAsTileStackClient.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.janelia.alignment.multisem.Layer;
 import org.janelia.alignment.multisem.MultiSemMfovColumn;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileBounds;
@@ -88,65 +89,76 @@ public class MFOVAsTileStackClient {
         final List<StackWithZValues> stackWithZList = parameters.multiProject.buildListOfStackWithAllZ();
 
         for (final StackWithZValues stackWithZ : stackWithZList) {
-            buildOneMFOVAsTileStack(stackWithZ,
-                                    renderDataClient,
-                                    parameters.mfovTileRenderScale,
-                                    parameters.mfovTileStackSuffix);
+            buildOneXAsTileStack(stackWithZ,
+                                 renderDataClient,
+                                 parameters.mfovTileRenderScale,
+                                 parameters.mfovTileStackSuffix,
+                                 true);
         }
     }
 
     /**
-     * Builds an MFOV as tile stack for the specified stack with Z values.
+     * Builds an MFOV-as-tile or layer-as-tile stack for the specified stack with Z values.
      *
      * @param  stackWithZ           identifies the source stack.
      * @param  renderDataClient     web service client for render stack data.
-     * @param  mfovTileRenderScale  scale for rendered SFOVs when creating the MFOV tiles.
-     * @param  mfovTileStackSuffix  suffix to append to the source stack name when creating the MFOV as tile stack name.
+     * @param  xAsTileRenderScale   scale for rendered SFOVs when creating the MFOV/layer tiles.
+     * @param  xAsTileStackSuffix   suffix to append to the source stack name when creating the MFOV/layer as tile stack name.
+     * @param  isMFOVAsTileStack    true means MFOV-as-tile stack, false means layer-as-tile stack
      *
-     * @return the identifier of the newly created MFOV as tile stack.
+     * @return the identifier of the newly created MFOV/layer as tile stack.
      *
      * @throws IOException
      *   if the build fails for any reason.
      */
-    public static StackId buildOneMFOVAsTileStack(final StackWithZValues stackWithZ,
-                                                  final RenderDataClient renderDataClient,
-                                                  final Double mfovTileRenderScale,
-                                                  final String mfovTileStackSuffix)
+    public static StackId buildOneXAsTileStack(final StackWithZValues stackWithZ,
+                                               final RenderDataClient renderDataClient,
+                                               final Double xAsTileRenderScale,
+                                               final String xAsTileStackSuffix,
+                                               final boolean isMFOVAsTileStack)
             throws IOException, IllegalStateException {
 
+        final String baseDataUrl = renderDataClient.getBaseDataUrl();
         final StackId sourceStackId = stackWithZ.getStackId();
         final String sourceStackName = sourceStackId.getStack();
-        final StackId mfovAsTileStackId = stackWithZ.getStackId().withStackSuffix(mfovTileStackSuffix);
+        final StackId xAsTileStackId = stackWithZ.getStackId().withStackSuffix(xAsTileStackSuffix);
 
         final StackMetaData stackMetaData = renderDataClient.getStackMetaData(sourceStackName);
-        final String mfovAsTileStackName = mfovAsTileStackId.getStack();
+        final String xAsTileStackName = xAsTileStackId.getStack();
 
-        // TODO: fix mfovAsTileStack metadata to reflect actual pixel resolution
+        // TODO: fix xAsTileStack metadata to reflect actual pixel resolution
         renderDataClient.setupDerivedStack(stackMetaData,
-                                           mfovAsTileStackName);
+                                           xAsTileStackName);
 
         for (final Double z : stackWithZ.getzValues()) {
 
             final List<TileBounds> sourceTileBoundsListForZLayer =
                     renderDataClient.getTileBounds(sourceStackId.getStack(), z);
 
-            final List<MultiSemMfovColumn> mfovColumnList =
-                    MultiSemMfovColumn.assembleColumnData(sourceStackId, z, sourceTileBoundsListForZLayer);
+            final List<TileSpec> xTileSpecs = new ArrayList<>();
+            if (isMFOVAsTileStack) {
+                final List<MultiSemMfovColumn> mfovColumnList =
+                        MultiSemMfovColumn.assembleColumnData(sourceStackId, z, sourceTileBoundsListForZLayer);
 
-            final List<TileSpec> mfovTileSpecs = new ArrayList<>();
-            for (final MultiSemMfovColumn mfovColumn : mfovColumnList) {
-                mfovTileSpecs.addAll(mfovColumn.buildMfovTileSpecs(renderDataClient.getBaseDataUrl(),
-                                                                   sourceStackId,
-                                                                   mfovTileRenderScale));
+                for (final MultiSemMfovColumn mfovColumn : mfovColumnList) {
+                    xTileSpecs.addAll(mfovColumn.buildMfovTileSpecs(baseDataUrl,
+                                                                    sourceStackId,
+                                                                    xAsTileRenderScale));
+                }
+            } else {
+                xTileSpecs.add(Layer.buildTileSpec(baseDataUrl,
+                                                   sourceStackId,
+                                                   z,
+                                                   xAsTileRenderScale));
             }
 
-            final ResolvedTileSpecCollection resolvedTiles = new ResolvedTileSpecCollection(mfovTileSpecs);
-            renderDataClient.saveResolvedTiles(resolvedTiles, mfovAsTileStackName, z);
+            final ResolvedTileSpecCollection resolvedTiles = new ResolvedTileSpecCollection(xTileSpecs);
+            renderDataClient.saveResolvedTiles(resolvedTiles, xAsTileStackName, z);
         }
 
-        renderDataClient.setStackState(mfovAsTileStackName, StackMetaData.StackState.COMPLETE);
+        renderDataClient.setStackState(xAsTileStackName, StackMetaData.StackState.COMPLETE);
 
-        return mfovAsTileStackId;
+        return xAsTileStackId;
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(MFOVAsTileStackClient.class);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileParameters.java
@@ -1,0 +1,203 @@
+package org.janelia.render.client.parameter;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.janelia.alignment.match.MatchFilter;
+import org.janelia.alignment.match.ModelType;
+import org.janelia.alignment.match.parameters.FeatureRenderClipParameters;
+import org.janelia.alignment.match.parameters.MatchRunParameters;
+import org.janelia.alignment.match.parameters.MatchStageParameters;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.render.client.newsolver.blocksolveparameters.FIBSEMAlignmentParameters;
+import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
+
+/**
+ * Parameters for building layer-as-tile images, matches, and stacks.
+ */
+public class LayerAsTileParameters
+        implements Serializable {
+
+    private final Double layerRenderScale;
+    private final String layerRootDirectory;
+    private final String dynamicLayerStackSuffix;
+    private final String renderedLayerStackSuffix;
+    private String renderedLayerRunTimestamp;
+    private final String alignedLayerStackSuffix;
+    private final String align3DSfovStackSuffix;
+
+    public LayerAsTileParameters() {
+        this(null,
+             null,
+             null,
+             null,
+             null,
+             null);
+    }
+
+    public LayerAsTileParameters(final Double layerRenderScale,
+                                 final String layerRootDirectory,
+                                 final String dynamicLayerStackSuffix,
+                                 final String renderedLayerStackSuffix,
+                                 final String alignedLayerStackSuffix,
+                                 final String align3DSfovStackSuffix) {
+        this(layerRenderScale,
+             layerRootDirectory,
+             dynamicLayerStackSuffix,
+             renderedLayerStackSuffix,
+             null,
+             alignedLayerStackSuffix,
+             align3DSfovStackSuffix);
+    }
+
+    public LayerAsTileParameters(final Double layerRenderScale,
+                                 final String layerRootDirectory,
+                                 final String dynamicLayerStackSuffix,
+                                 final String renderedLayerStackSuffix,
+                                 final String renderedLayerRunTimestamp,
+                                 final String alignedLayerStackSuffix,
+                                 final String align3DSfovStackSuffix) {
+        this.layerRenderScale = layerRenderScale;
+        this.layerRootDirectory = layerRootDirectory;
+        this.dynamicLayerStackSuffix = dynamicLayerStackSuffix;
+        this.renderedLayerStackSuffix = renderedLayerStackSuffix;
+        this.renderedLayerRunTimestamp = renderedLayerRunTimestamp;
+        this.alignedLayerStackSuffix = alignedLayerStackSuffix;
+        this.align3DSfovStackSuffix = align3DSfovStackSuffix;
+    }
+
+    public Double getLayerRenderScale() {
+        return layerRenderScale;
+    }
+
+    public String getLayerRootDirectory() {
+        return layerRootDirectory;
+    }
+
+    public String getDynamicLayerStackSuffix() {
+        return dynamicLayerStackSuffix;
+    }
+
+    public String getRenderedLayerStackSuffix() {
+        return renderedLayerStackSuffix;
+    }
+
+    public String getAlignedLayerStackSuffix() {
+        return alignedLayerStackSuffix;
+    }
+
+    public String getAlign3DSfovStackSuffix() {
+        return align3DSfovStackSuffix;
+    }
+
+    public String getDynamicLayerStackSuffixForRawSfovStack() {
+        return dynamicLayerStackSuffix;
+    }
+
+    public String getRenderedLayerStackSuffixForRawSfovStack() {
+        return getDynamicLayerStackSuffixForRawSfovStack() + renderedLayerStackSuffix;
+    }
+
+    public String getAlignedLayerStackSuffixForRawSfovStack() {
+        return getRenderedLayerStackSuffixForRawSfovStack() + alignedLayerStackSuffix;
+    }
+
+    public StackId getDynamicLayerStackId(final StackId rawSfovStackId) {
+        return rawSfovStackId.withStackSuffix(getDynamicLayerStackSuffixForRawSfovStack());
+    }
+
+    public StackId getRenderedLayerStackId(final StackId rawSfovStackId) {
+        return rawSfovStackId.withStackSuffix(getRenderedLayerStackSuffixForRawSfovStack());
+    }
+
+    public StackId getAlign3DSfovStackId(final StackId rawSfovStackId) {
+        return rawSfovStackId.withStackSuffix(align3DSfovStackSuffix);
+    }
+
+    public String getRenderedLayerRunTimestamp() {
+        if (this.renderedLayerRunTimestamp == null) {
+            final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+            this.renderedLayerRunTimestamp = sdf.format(new Date());
+        }
+        return this.renderedLayerRunTimestamp;
+    }
+
+    public List<MatchRunParameters> buildLayerMatchRunList() {
+        final List<MatchRunParameters> layerMatchRunList = new ArrayList<>();
+        layerMatchRunList.add(buildCrossMatchRunParameters());
+        return layerMatchRunList;
+    }
+
+    public AffineBlockSolverSetup buildLayerAffineBlockSolverSetup() {
+
+        final AffineBlockSolverSetup setup = new AffineBlockSolverSetup();
+
+        setup.preAlign = FIBSEMAlignmentParameters.PreAlign.NONE;
+
+        setup.distributedSolve.maxAllowedErrorGlobal = 10.0;
+        setup.distributedSolve.maxIterationsGlobal = 1000;
+        setup.distributedSolve.maxPlateauWidthGlobal = 200;
+        setup.distributedSolve.threadsWorker = 1;
+        setup.distributedSolve.threadsGlobal = 1;
+        setup.distributedSolve.deriveThreadsUsingSparkConfig = true;
+
+        setup.targetStack.stackSuffix = this.alignedLayerStackSuffix;
+        setup.targetStack.completeStack = true;
+
+        setup.blockPartition.sizeZ = 100; // must be greater than total number of layers in each layer-as-tile stack
+
+        setup.stitching.lambda = 0.0;
+        setup.stitching.maxAllowedError = 10.0;
+        setup.stitching.maxIterations = 5000;
+        setup.stitching.maxPlateauWidth = 1000;
+        setup.stitching.minInliers = 25;
+
+        setup.blockOptimizer.lambdasRigid = List.of(1.0, 1.0, 0.9, 0.3, 0.01);
+        // NOTE: lambda's translation means how much do you want to regularize with a translation model, thus 1.0 means 100% translation
+        setup.blockOptimizer.lambdasTranslation = MFOVAsTileParameters.SolveType.TRANSLATION.getLambdasTranslation();
+        setup.blockOptimizer.lambdasRegularization = List.of(0.0, 0.0, 0.0, 0.0, 0.0);
+
+        setup.blockOptimizer.iterations = List.of(1000, 1000, 500, 250, 250);
+        setup.blockOptimizer.maxPlateauWidth = List.of(250, 250, 150, 100, 100);
+        setup.blockOptimizer.maxAllowedError = 10.0;
+
+        setup.maxNumMatches = 0;
+
+        setup.alternatingRuns.nRuns = 1;
+        setup.alternatingRuns.keepIntermediateStacks = false;
+
+        return setup;
+    }
+
+    private static MatchRunParameters buildCrossMatchRunParameters() {
+
+        // renderWithFilter = true greatly improves results when no intensity correction has been run on SFOVs
+        final boolean renderWithFilter = true;
+
+        final List<MatchStageParameters> matchStageParametersList =
+                List.of(
+                        // pass 1 render scale 0.5 with AGGREGATED_CONSENSUS_SETS
+                        new MatchStageParameters("crossLayerAsTilePass1",
+                                                 MFOVAsTileParameters.buildFeatureRenderParameters(0.5,
+                                                                                                   renderWithFilter),
+                                                 new FeatureRenderClipParameters(),
+                                                 MFOVAsTileParameters.buildFeatureExtractionParameters(),
+                                                 MFOVAsTileParameters.buildFeatureMatchDerivation(MatchFilter.FilterType.AGGREGATED_CONSENSUS_SETS,
+                                                                                                  100,
+                                                                                                  ModelType.RIGID),
+                                                 MFOVAsTileParameters.buildDisabledGeometricDescriptorAndMatch(),
+                                                 null,
+                                                 null));
+        // zNeighborDistance = 3 improves results (over zNeighborDistance = 1)
+        final int zNeighborDistance = 3;
+        return new MatchRunParameters("crossLayerAsTileRun",
+                                      MFOVAsTileParameters.buildMatchCommonParameters(2),
+                                      MFOVAsTileParameters.buildTilePairDerivationParameters(0.1,
+                                                                                             zNeighborDistance,
+                                                                                             true),
+                                      matchStageParametersList);
+    }
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileParameters.java
@@ -157,7 +157,7 @@ public class LayerAsTileParameters
 
         setup.blockOptimizer.lambdasRigid = List.of(1.0, 1.0, 0.9, 0.3, 0.01);
         // NOTE: lambda's translation means how much do you want to regularize with a translation model, thus 1.0 means 100% translation
-        setup.blockOptimizer.lambdasTranslation = MFOVAsTileParameters.SolveType.TRANSLATION.getLambdasTranslation();
+        setup.blockOptimizer.lambdasTranslation = MFOVAsTileParameters.SolveType.AFFINE.getLambdasTranslation();
         setup.blockOptimizer.lambdasRegularization = List.of(0.0, 0.0, 0.0, 0.0, 0.0);
 
         setup.blockOptimizer.iterations = List.of(1000, 1000, 500, 250, 250);

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileStackLists.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/LayerAsTileStackLists.java
@@ -1,0 +1,113 @@
+package org.janelia.render.client.parameter;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackWithZValues;
+import org.janelia.render.client.RenderDataClient;
+
+/**
+ * Lists of stacks for layer-as-tile processing.
+ */
+public class LayerAsTileStackLists implements Serializable {
+
+    private final String baseDataUrl;
+    private final LayerAsTileParameters layerAsTile;
+
+    private final List<StackWithZValues> align2DSfovStacksWithAllZ;
+    private final List<StackWithZValues> renderedLayerStacksWithAllZ = new ArrayList<>();
+    private final List<StackWithZValues> align3DSfovStacksWithAllZ = new ArrayList<>();
+
+    private final Set<StackId> existingStacks = new HashSet<>();
+
+    public LayerAsTileStackLists(final String baseDataUrl,
+                                 final MultiProjectParameters multiProject,
+                                 final LayerAsTileParameters layerAsTile)
+            throws IOException {
+
+        this.baseDataUrl = baseDataUrl;
+        this.layerAsTile = layerAsTile;
+        this.align2DSfovStacksWithAllZ = multiProject.buildListOfStackWithAllZ();
+
+        final Map<String, Set<String>> ownerToProjectNames = new HashMap<>();
+        for (final StackWithZValues rawStackWithAllZ : this.align2DSfovStacksWithAllZ) {
+
+            final StackId rawSfovStackId = rawStackWithAllZ.getStackId();
+            final StackId renderedLayerStackId = layerAsTile.getRenderedLayerStackId(rawSfovStackId);
+            final StackId align3DSfovStackId = layerAsTile.getAlign3DSfovStackId(rawSfovStackId);
+
+            final List<Double> allZValues = rawStackWithAllZ.getzValues();
+            this.renderedLayerStacksWithAllZ.add(new StackWithZValues(renderedLayerStackId, allZValues));
+            this.align3DSfovStacksWithAllZ.add(new StackWithZValues(align3DSfovStackId, allZValues));
+
+            final Set<String> projectNames = ownerToProjectNames.computeIfAbsent(rawSfovStackId.getOwner(),
+                                                                                 k -> new HashSet<>());
+            projectNames.add(rawSfovStackId.getProject());
+        }
+
+        for (final String owner : ownerToProjectNames.keySet()) {
+            for (final String project : ownerToProjectNames.get(owner)) {
+                final RenderDataClient projectClient = new RenderDataClient(baseDataUrl, owner, project);
+                existingStacks.addAll(projectClient.getProjectStacks());
+            }
+        }
+    }
+
+    public String getBaseDataUrl() {
+        return baseDataUrl;
+    }
+
+    public LayerAsTileParameters getLayerAsTile() {
+        return layerAsTile;
+    }
+
+    public List<StackWithZValues> getAlign2DSfovStacksWithAllZ() {
+        return align2DSfovStacksWithAllZ;
+    }
+
+    public  List<StackWithZValues> getRenderedLayerStacksWithAllZ() {
+        return renderedLayerStacksWithAllZ;
+    }
+
+    public  List<StackWithZValues> getAlign3DSfovStacksWithAllZ() {
+        return align3DSfovStacksWithAllZ;
+    }
+
+    public List<String> getOwners() {
+        return align2DSfovStacksWithAllZ.stream().map(s -> s.getStackId().getOwner())
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getProjectsWithOwner(final String owner) {
+        return align2DSfovStacksWithAllZ.stream()
+                .filter(s -> s.getStackId().getOwner().equals(owner))
+                .map(s -> s.getStackId().getProject())
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    public  List<StackWithZValues> getRenderedLayerStacksWithAllZ(final String owner,
+                                                                  final String project) {
+        return renderedLayerStacksWithAllZ.stream()
+                .filter(stackWithZ -> {
+                    final StackId stackId = stackWithZ.getStackId();
+                    return stackId.getOwner().equals(owner) && stackId.getProject().equals(project);
+                }).collect(Collectors.toList());
+    }
+
+    public boolean isExistingStack(final StackId stackId) {
+        return existingStacks.contains(stackId);
+    }
+
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/MFOVAsTileParameters.java
@@ -200,6 +200,10 @@ public class MFOVAsTileParameters
             this.stackSuffix = stackSuffix;
             this.lambdasTranslation = lambdasTranslation;
         }
+
+        public List<Double> getLambdasTranslation() {
+            return lambdasTranslation;
+        }
     }
 
     public AffineBlockSolverSetup buildMfovAffineBlockSolverSetup(final SolveType solveType) {
@@ -246,18 +250,24 @@ public class MFOVAsTileParameters
     private static MatchRunParameters buildMontageMatchRunParameters() {
         final List<MatchStageParameters> matchStageParametersList =
                 List.of(new MatchStageParameters("montageMfovAsTilePass1",
-                                                 buildFeatureRenderParameters(0.4), // 11 secs for 15 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
+                                                 buildFeatureRenderParameters(0.4,
+                                                                              true), // 11 secs for 15 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
                                                  new FeatureRenderClipParameters(1500, 1500),
                                                  buildFeatureExtractionParameters(),
-                                                 buildFeatureMatchDerivation(100),
+                                                 buildFeatureMatchDerivation(MatchFilter.FilterType.SINGLE_SET,
+                                                                             100,
+                                                                             ModelType.TRANSLATION),
                                                  buildDisabledGeometricDescriptorAndMatch(),
                                                  null,
                                                  null),
                         new MatchStageParameters("montageMfovAsTilePass2",
-                                                 buildFeatureRenderParameters(1.0), // 220 secs for 261 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
+                                                 buildFeatureRenderParameters(1.0,
+                                                                              true), // 220 secs for 261 matches between w60_s360_r00_gc_z025_m0017 and w60_s360_r00_gc_z025_m0026
                                                  new FeatureRenderClipParameters(1500, 1500),
                                                  buildFeatureExtractionParameters(),
-                                                 buildFeatureMatchDerivation(25),
+                                                 buildFeatureMatchDerivation(MatchFilter.FilterType.SINGLE_SET,
+                                                                             25,
+                                                                             ModelType.TRANSLATION),
                                                  buildDisabledGeometricDescriptorAndMatch(),
                                                  null,
                                                  null));
@@ -280,18 +290,24 @@ public class MFOVAsTileParameters
         // 2 passes, render scales 0.2 and 0.3, minInliers 150
         final List<MatchStageParameters> matchStageParametersList =
                 List.of(new MatchStageParameters("crossMfovAsTilePass1",
-                                                 buildFeatureRenderParameters(0.2),
+                                                 buildFeatureRenderParameters(0.2,
+                                                                              true),
                                                  new FeatureRenderClipParameters(),
                                                  buildFeatureExtractionParameters(),
-                                                 buildFeatureMatchDerivation(150),
+                                                 buildFeatureMatchDerivation(MatchFilter.FilterType.SINGLE_SET,
+                                                                             150,
+                                                                             ModelType.TRANSLATION),
                                                  buildDisabledGeometricDescriptorAndMatch(),
                                                  null,
                                                  null),
                         new MatchStageParameters("crossMfovAsTilePass2",
-                                                 buildFeatureRenderParameters(0.3),
+                                                 buildFeatureRenderParameters(0.3,
+                                                                              true),
                                                  new FeatureRenderClipParameters(),
                                                  buildFeatureExtractionParameters(),
-                                                 buildFeatureMatchDerivation(150),
+                                                 buildFeatureMatchDerivation(MatchFilter.FilterType.SINGLE_SET,
+                                                                             150,
+                                                                             ModelType.TRANSLATION),
                                                  buildDisabledGeometricDescriptorAndMatch(),
                                                  null,
                                                  null));
@@ -302,7 +318,7 @@ public class MFOVAsTileParameters
                                       matchStageParametersList);
     }
 
-    private static MatchCommonParameters buildMatchCommonParameters(final int maxPairsPerStackBatch) {
+    public static MatchCommonParameters buildMatchCommonParameters(final int maxPairsPerStackBatch) {
         final MatchCommonParameters matchCommon = new MatchCommonParameters();
         matchCommon.maxPairsPerStackBatch = maxPairsPerStackBatch;
         matchCommon.featureStorage.maxFeatureSourceCacheGb = 6;
@@ -310,9 +326,9 @@ public class MFOVAsTileParameters
         return matchCommon;
     }
 
-    private static TilePairDerivationParameters buildTilePairDerivationParameters(final double xyNeighborFactor,
-                                                                                  final int zNeighborDistance,
-                                                                                  final boolean excludeSameLayerNeighbors) {
+    public static TilePairDerivationParameters buildTilePairDerivationParameters(final double xyNeighborFactor,
+                                                                                 final int zNeighborDistance,
+                                                                                 final boolean excludeSameLayerNeighbors) {
         final TilePairDerivationParameters tilePairDerivation = new TilePairDerivationParameters();
         tilePairDerivation.xyNeighborFactor = xyNeighborFactor;
         tilePairDerivation.useRowColPositions = false;
@@ -326,15 +342,16 @@ public class MFOVAsTileParameters
         return tilePairDerivation;
     }
 
-    private static FeatureRenderParameters buildFeatureRenderParameters(final double renderScale) {
+    public static FeatureRenderParameters buildFeatureRenderParameters(final double renderScale,
+                                                                       final boolean renderWithFilter) {
         final FeatureRenderParameters featureRender = new FeatureRenderParameters();
         featureRender.renderScale = renderScale;
-        featureRender.renderWithFilter = true;
+        featureRender.renderWithFilter = renderWithFilter;
         featureRender.renderWithoutMask = false;
         return featureRender;
     }
 
-    private static FeatureExtractionParameters buildFeatureExtractionParameters() {
+    public static FeatureExtractionParameters buildFeatureExtractionParameters() {
         final FeatureExtractionParameters featureExtraction = new FeatureExtractionParameters();
         featureExtraction.fdSize = 4;
         featureExtraction.maxScale = 1.0;
@@ -343,9 +360,11 @@ public class MFOVAsTileParameters
         return featureExtraction;
     }
 
-    private static MatchDerivationParameters buildFeatureMatchDerivation(final int matchMinNumInliers) {
+    public static MatchDerivationParameters buildFeatureMatchDerivation(final MatchFilter.FilterType matchFilterType,
+                                                                        final int matchMinNumInliers,
+                                                                        final ModelType matchModelType) {
         final MatchDerivationParameters featureMatchDerivation = new MatchDerivationParameters();
-        featureMatchDerivation.matchFilter = MatchFilter.FilterType.SINGLE_SET;
+        featureMatchDerivation.matchFilter = matchFilterType;
         featureMatchDerivation.matchFullScaleCoverageRadius = 10.0;
         featureMatchDerivation.matchIterations = 1000;
         featureMatchDerivation.matchMaxEpsilonFullScale = 10.0f;
@@ -353,12 +372,12 @@ public class MFOVAsTileParameters
         featureMatchDerivation.matchMinCoveragePercentage = 0.0;
         featureMatchDerivation.matchMinInlierRatio = 0.0f;
         featureMatchDerivation.matchMinNumInliers = matchMinNumInliers;
-        featureMatchDerivation.matchModelType = ModelType.TRANSLATION;
+        featureMatchDerivation.matchModelType = matchModelType;
         featureMatchDerivation.matchRod = 0.92f;
         return featureMatchDerivation;
     }
 
-    private static GeometricDescriptorAndMatchFilterParameters buildDisabledGeometricDescriptorAndMatch() {
+    public static GeometricDescriptorAndMatchFilterParameters buildDisabledGeometricDescriptorAndMatch() {
         final GeometricDescriptorAndMatchFilterParameters gdParams = new GeometricDescriptorAndMatchFilterParameters();
         gdParams.gdEnabled = false;
         return gdParams;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/TileRenderParameters.java
@@ -215,13 +215,13 @@ public class TileRenderParameters
         return parameters;
     }
 
-    public static TileRenderParameters buildMfovAsTileVersion(final String mfovRootDirectory,
-                                                              final String runTimestamp,
-                                                              final String hackStack) {
+    public static TileRenderParameters buildXAsTileVersion(final String rootDirectory,
+                                                           final String runTimestamp,
+                                                           final String hackStack) {
 
         final TileRenderParameters trp = new TileRenderParameters();
 
-        trp.rootDirectory = mfovRootDirectory;
+        trp.rootDirectory = rootDirectory;
         trp.runTimestamp = runTimestamp;
         trp.scale = 1.0; // MFOV-as-tile specs have source URLs with scale=0.2, so they should be rendered full scale
         trp.format = Utils.PNG_FORMAT;

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import mpicbg.trakem2.transform.AffineModel2D;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -21,6 +23,7 @@ import org.janelia.alignment.spec.LeafTransformSpec;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection.TransformApplicationMethod;
 import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.TransformSpec;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackMetaData;
 import org.janelia.alignment.spec.stack.StackWithZValues;
@@ -473,6 +476,8 @@ public class LayerAsTileClient
                                                                         final double layerAsTileRenderScale)
             throws IOException {
 
+        final String stackZContext = rawSfovStack + " z " + z;
+
         // example SFOV tile spec:
         // {
         //   "tileId": "w61_magc0145_scan004_m0009_r32_s49",
@@ -496,41 +501,46 @@ public class LayerAsTileClient
 
         // example layer-as-tile spec:
         // {
-        //   "tileId": "w61_s109_r00_gc_par_crc_align_stitch_only_z001",
+        //   "tileId": "w61_s109_r00_gc_par_crc_aso_z001",
         //   ...
         //   "transforms": {
         //     "type": "list",
         //     "specList": [
         //       {
-        //         "className": "mpicbg.trakem2.transform.TranslationModel2D",
-        //         "dataString": 0 8"
+        //         "className": "mpicbg.trakem2.transform.AffineModel2D",
+        //         "dataString": "0.9995111984001582 3.8059309390139125E-4 -2.3150605242131648E-4 1.0058163225403765 1.7289345344867812 13.165940488916831"
         //       }
         //     ]
         //   },
         //   ...
         // }
 
+        // TODO: remove renderedLayerTiles and renderedLayerTileSpec if they are not needed to build SFOV transform (these were needed for original offset approach)
         final ResolvedTileSpecCollection renderedLayerTiles = dataClient.getResolvedTiles(renderedLayerStack, z);
         final TileSpec renderedLayerTileSpec = getLayerTileSpec(renderedLayerStack, renderedLayerTiles);
 
         final ResolvedTileSpecCollection alignedLayerTiles = dataClient.getResolvedTiles(alignedLayerStack, z);
         final TileSpec alignedLayerTileSpec = getLayerTileSpec(alignedLayerStack, alignedLayerTiles);
+        final TransformSpec alignedLayerTransformSpec = alignedLayerTileSpec.getLastTransform();
+        final AffineModel2D alignedLayerModel =
+                ResolvedTileSpecCollection.getAffineModelForSpec(stackZContext,
+                                                                 alignedLayerTransformSpec);
 
-        final double[] offset = new double[] {
-                (alignedLayerTileSpec.getMinX() - renderedLayerTileSpec.getMinX()) / layerAsTileRenderScale,
-                (alignedLayerTileSpec.getMinY() - renderedLayerTileSpec.getMinY()) / layerAsTileRenderScale
-        };
+        // TODO: use affineModel2D and layerAsTileRenderScale to build LeafTransformSpec for SFOV tiles
 
-        LOG.info("buildAlign3DTileSpecsForZ: adding offset ({}, {}) to all tiles in z {} of {}",
-                 (int) offset[0], (int) offset[1], z, rawSfovStack);
+        final AffineModel2D sfovModel = new AffineModel2D();
+        final String sfovModelDataString = sfovModel.toDataString();
 
-        // to use addTransformSpecToTile method below, transform needs to be an affine
-        final String offsetAffineDataString = "1 0 0 1 " + offset[0] + " " + offset[1];
-        final LeafTransformSpec offsetTransformSpec = new LeafTransformSpec("mpicbg.trakem2.transform.AffineModel2D",
-                                                                            offsetAffineDataString);
+        final LeafTransformSpec zLayerTransformSpec =
+                new LeafTransformSpec("mpicbg.trakem2.transform.AffineModel2D",
+                                      sfovModelDataString);
+
+        LOG.info("buildAlign3DTileSpecsForZ: adding AffineModel2D transform {} to all tiles in {}",
+                 sfovModelDataString, stackZContext);
+
         for (final TileSpec tileSpec : sfovTiles.getTileSpecs()) {
             sfovTiles.addTransformSpecToTile(tileSpec.getTileId(),
-                                             offsetTransformSpec,
+                                             zLayerTransformSpec,
                                              TransformApplicationMethod.PRE_CONCATENATE_LAST);
         }
 

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
@@ -515,9 +515,17 @@ public class LayerAsTileClient
         //   ...
         // }
 
-        // TODO: remove renderedLayerTiles and renderedLayerTileSpec if they are not needed to build SFOV transform (these were needed for original offset approach)
         final ResolvedTileSpecCollection renderedLayerTiles = dataClient.getResolvedTiles(renderedLayerStack, z);
         final TileSpec renderedLayerTileSpec = getLayerTileSpec(renderedLayerStack, renderedLayerTiles);
+        final TransformSpec renderedLayerTransformSpec = renderedLayerTileSpec.getLastTransform();
+        final AffineModel2D renderedLayerModel =
+                ResolvedTileSpecCollection.getAffineModelForSpec(stackZContext,
+                                                                 renderedLayerTransformSpec);
+
+        // Invert renderedLayerModel to convert the scaled SFOV (layer world) coordinate
+        // into a local coordinate before the alignment is applied.
+        // This accounts for each rendered layer image having a different size and world origin.
+        final AffineModel2D layerToRenderedLocal = renderedLayerModel.createInverse();
 
         final ResolvedTileSpecCollection alignedLayerTiles = dataClient.getResolvedTiles(alignedLayerStack, z);
         final TileSpec alignedLayerTileSpec = getLayerTileSpec(alignedLayerStack, alignedLayerTiles);
@@ -526,9 +534,21 @@ public class LayerAsTileClient
                 ResolvedTileSpecCollection.getAffineModelForSpec(stackZContext,
                                                                  alignedLayerTransformSpec);
 
-        // TODO: use affineModel2D and layerAsTileRenderScale to build LeafTransformSpec for SFOV tiles
+        final AffineModel2D scaleSFOVToLayer = new AffineModel2D();
+        scaleSFOVToLayer.set(layerAsTileRenderScale, 0, 0,
+                             layerAsTileRenderScale, 0, 0);
+
+        final AffineModel2D scaleLayerToSFOV = new AffineModel2D();
+        final double inverseLayerAsTileRenderScale = 1.0 / layerAsTileRenderScale;
+        scaleLayerToSFOV.set(inverseLayerAsTileRenderScale, 0, 0,
+                             inverseLayerAsTileRenderScale, 0, 0);
 
         final AffineModel2D sfovModel = new AffineModel2D();
+        sfovModel.set(alignedLayerModel);
+        sfovModel.concatenate(layerToRenderedLocal); // alignedLayerModel * renderedLayerModel^-1
+        sfovModel.concatenate(scaleSFOVToLayer);     // alignedLayerModel * renderedLayerModel^-1 * scaleSFOVToLayer
+        sfovModel.preConcatenate(scaleLayerToSFOV);  // scaleLayerToSFOV * alignedLayerModel * renderedLayerModel^-1 * scaleSFOVToLayer
+
         final String sfovModelDataString = sfovModel.toDataString();
 
         final LeafTransformSpec zLayerTransformSpec =

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/LayerAsTileClient.java
@@ -1,0 +1,588 @@
+package org.janelia.render.client.spark.multisem;
+
+import com.beust.jcommander.ParametersDelegate;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.janelia.alignment.match.parameters.MatchRunParameters;
+import org.janelia.alignment.spec.LeafTransformSpec;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection;
+import org.janelia.alignment.spec.ResolvedTileSpecCollection.TransformApplicationMethod;
+import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackMetaData;
+import org.janelia.alignment.spec.stack.StackWithZValues;
+import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
+import org.janelia.render.client.multisem.MFOVAsTileStackClient;
+import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
+import org.janelia.render.client.parameter.CommandLineParameters;
+import org.janelia.render.client.parameter.LayerAsTileParameters;
+import org.janelia.render.client.parameter.LayerAsTileStackLists;
+import org.janelia.render.client.parameter.MultiProjectParameters;
+import org.janelia.render.client.parameter.TileRenderParameters;
+import org.janelia.render.client.spark.LogUtilities;
+import org.janelia.render.client.spark.match.MultiStagePointMatchClient;
+import org.janelia.render.client.spark.newsolver.DistributedAffineBlockSolverClient;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineParameters;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStep;
+import org.janelia.render.client.spark.pipeline.AlignmentPipelineStepId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Spark client for ...
+ */
+public class LayerAsTileClient
+        implements Serializable, AlignmentPipelineStep {
+
+    public static class Parameters extends CommandLineParameters {
+        @ParametersDelegate
+        public MultiProjectParameters multiProject = new MultiProjectParameters();
+
+        @ParametersDelegate
+        public LayerAsTileParameters layerAsTile = new LayerAsTileParameters();
+
+        public Parameters() {
+        }
+
+        public Parameters(final MultiProjectParameters multiProject,
+                          final LayerAsTileParameters layerAsTile) {
+            this.multiProject = multiProject;
+            this.layerAsTile = layerAsTile;
+        }
+    }
+
+    /** Run the client with command line parameters. */
+    public static void main(final String[] args) {
+        final ClientRunner clientRunner = new ClientRunner(args) {
+            @Override
+            public void runClient(final String[] args) throws Exception {
+                final Parameters parameters = new Parameters();
+                parameters.parse(args);
+                final LayerAsTileClient client = new LayerAsTileClient();
+                client.createContextAndRun(parameters);
+            }
+        };
+        clientRunner.run();
+    }
+
+    /** Empty constructor required for alignment pipeline steps. */
+    public LayerAsTileClient() {
+    }
+
+    /** Create a spark context and run the client with the specified parameters. */
+    public void createContextAndRun(final Parameters clientParameters) throws IOException {
+        final SparkConf conf = new SparkConf().setAppName(getClass().getSimpleName());
+        try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+            LOG.info("run: appId is {}", sparkContext.getConf().getAppId());
+            run(sparkContext, clientParameters);
+        }
+    }
+
+    /** Validates the specified pipeline parameters are sufficient. */
+    @Override
+    public void validatePipelineParameters(final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException {
+        AlignmentPipelineParameters.validateRequiredElementExists("layerAsTile",
+                                                                  pipelineParameters.getLayerAsTile());
+    }
+
+    /** Run the client as part of an alignment pipeline. */
+    public void runPipelineStep(final JavaSparkContext sparkContext,
+                                final AlignmentPipelineParameters pipelineParameters)
+            throws IllegalArgumentException, IOException {
+        final Parameters clientParameters = new Parameters();
+        clientParameters.multiProject = pipelineParameters.getMultiProject(pipelineParameters.getRawNamingGroup());
+        clientParameters.layerAsTile = pipelineParameters.getLayerAsTile();
+        run(sparkContext, clientParameters);
+    }
+
+    @Override
+    public AlignmentPipelineStepId getDefaultStepId() {
+        return AlignmentPipelineStepId.RENDER_TILES;
+    }
+
+    private void run(final JavaSparkContext sparkContext,
+                     final Parameters clientParameters)
+            throws IllegalArgumentException, IOException {
+
+        LOG.info("run: entry, clientParameters={}", clientParameters);
+
+        final String baseDataUrl = clientParameters.multiProject.getBaseDataUrl();
+
+        final LayerAsTileStackLists layerAsTileStackLists = new LayerAsTileStackLists(baseDataUrl,
+                                                                                      clientParameters.multiProject,
+                                                                                      clientParameters.layerAsTile);
+        buildDynamicLayerAsTileStacks(sparkContext, layerAsTileStackLists);
+
+        buildRenderedLayerAsTileStacks(sparkContext, layerAsTileStackLists);
+
+        generateLayerAsTileMatches(sparkContext, layerAsTileStackLists);
+
+        alignRenderedLayerAsTileStacks(sparkContext, layerAsTileStackLists);
+
+        buildAlign3DSfovStacks(sparkContext, layerAsTileStackLists);
+
+        LOG.info("run: exit");
+    }
+
+    private static void buildDynamicLayerAsTileStacks(final JavaSparkContext sparkContext,
+                                                      final LayerAsTileStackLists layerAsTileStackLists) {
+
+        final String baseDataUrl = layerAsTileStackLists.getBaseDataUrl();
+        final LayerAsTileParameters layerAsTile = layerAsTileStackLists.getLayerAsTile();
+        final double layerRenderScale = layerAsTile.getLayerRenderScale();
+        final String dynamicLayerStackSuffix = layerAsTile.getDynamicLayerStackSuffix();
+
+        final List<StackWithZValues> align2DSfovStacksWithAllZ = layerAsTileStackLists.getAlign2DSfovStacksWithAllZ();
+
+        final int parallelism = Math.min(MFOVASTileClient.MAX_PARTITIONS_FOR_ONE_WEB_SERVER, align2DSfovStacksWithAllZ.size());
+
+        LOG.info("buildDynamicLayerAsTileStacks: entry, distributing build of {} stack(s) with parallelism {} (defaultParallelism={})",
+                 align2DSfovStacksWithAllZ.size(), parallelism, sparkContext.defaultParallelism());
+
+        final JavaRDD<StackWithZValues> rddAlign2DSfovStacks = sparkContext.parallelize(align2DSfovStacksWithAllZ,
+                                                                                        parallelism);
+
+        final Function<StackWithZValues, StackId> buildLayerStackFunction = stackWithAllZ -> {
+
+            StackId builtStackId = null;
+
+            LogUtilities.setupExecutorLog4j(stackWithAllZ.getStackId().toDevString());
+
+            final StackId align2DStackId = stackWithAllZ.getStackId();
+            final StackId dynamicLayerAsTileStackId = align2DStackId.withStackSuffix(dynamicLayerStackSuffix);
+
+            LOG.info("buildLayerStackFunction: entry, prealignedStackId={}, dynamicLayerAsTileStackId={}",
+                     align2DStackId.toDevString(), dynamicLayerAsTileStackId.toDevString());
+
+            if (layerAsTileStackLists.isExistingStack(dynamicLayerAsTileStackId)) {
+                LOG.info("buildLayerStackFunction: skipping build of {} because it already exists",
+                         dynamicLayerAsTileStackId.toDevString());
+            } else {
+                final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                         align2DStackId.getOwner(),
+                                                                         align2DStackId.getProject());
+
+                builtStackId = MFOVAsTileStackClient.buildOneXAsTileStack(stackWithAllZ,
+                                                                          dataClient,
+                                                                          layerRenderScale,
+                                                                          dynamicLayerStackSuffix,
+                                                                          false);
+            }
+
+            LOG.info("buildLayerStackFunction: exit, prealignedStackId={}, dynamicLayerAsTileStackId={}",
+                     align2DStackId.toDevString(), dynamicLayerAsTileStackId.toDevString());
+
+            return builtStackId;
+        };
+
+        final JavaRDD<StackId> rddBuiltStacks = rddAlign2DSfovStacks.map(buildLayerStackFunction);
+        final List<StackId> builtStacks = rddBuiltStacks.collect();
+
+        final long skippedCount = rddBuiltStacks.filter(Objects::isNull).count();
+        final long builtCount = builtStacks.size() - skippedCount;
+
+        LOG.info("buildDynamicLayerAsTileStacks: exit, built {} stack(s), skipped build of {} pre-existing stack(s)",
+                 builtCount, skippedCount);
+    }
+
+    private static void buildRenderedLayerAsTileStacks(final JavaSparkContext sparkContext,
+                                                       final LayerAsTileStackLists layerAsTileStackLists)
+            throws IOException {
+
+        LOG.info("buildRenderedLayerAsTileStacks: entry");
+
+        final String baseDataUrl = layerAsTileStackLists.getBaseDataUrl();
+        final LayerAsTileParameters layerAsTile = layerAsTileStackLists.getLayerAsTile();
+        final String runTimestamp = layerAsTile.getRenderedLayerRunTimestamp();
+
+        final List<JavaRenderTilesClientInfoForLayer> layerClientInfoList = new ArrayList<>();
+        final List<StackId> renderedLayerStackList = new ArrayList<>();
+        for (final StackWithZValues rawSfovStackWithAllZ : layerAsTileStackLists.getAlign2DSfovStacksWithAllZ()) {
+
+            final StackId rawStackId = rawSfovStackWithAllZ.getStackId();
+            final StackId dynamicLayerAsTileStackId = layerAsTile.getDynamicLayerStackId(rawStackId);
+            final StackId renderedLayerAsTileStackId = layerAsTile.getRenderedLayerStackId(rawStackId);
+
+            if (layerAsTileStackLists.isExistingStack(renderedLayerAsTileStackId)) {
+
+                LOG.info("buildRenderedLayerAsTileStacks: skipping build of {} because it already exists",
+                         renderedLayerAsTileStackId.toDevString());
+
+            } else {
+
+                boolean isSetupNeeded = true;
+                for (final Double z : rawSfovStackWithAllZ.getzValues()) {
+                    final JavaRenderTilesClientInfoForLayer info =
+                            new JavaRenderTilesClientInfoForLayer(baseDataUrl,
+                                                                  dynamicLayerAsTileStackId,
+                                                                  z,
+                                                                  layerAsTile,
+                                                                  runTimestamp);
+                    layerClientInfoList.add(info);
+
+                    if (isSetupNeeded) {
+                        info.setupHackStackAndStorage();
+                        isSetupNeeded = false;
+                        renderedLayerStackList.add(renderedLayerAsTileStackId);
+                    }
+
+                }
+            }
+        }
+
+        if (! layerClientInfoList.isEmpty()) {
+
+            final int parallelism = Math.min(MFOVASTileClient.MAX_PARTITIONS_FOR_ONE_WEB_SERVER, layerClientInfoList.size());
+
+            LOG.info("buildRenderedLayerAsTileStacks: distributing rendering for {} layers with parallelism {} (defaultParallelism={})",
+                     layerClientInfoList.size(), parallelism, sparkContext.defaultParallelism());
+
+            final JavaRDD<JavaRenderTilesClientInfoForLayer> rddRenderTiles = sparkContext.parallelize(layerClientInfoList,
+                                                                                                           parallelism);
+            final Function<JavaRenderTilesClientInfoForLayer, Integer> renderTilesFunction = JavaRenderTilesClientInfoForLayer::renderTiles;
+            final JavaRDD<Integer> rddRenderedTileCounts = rddRenderTiles.map(renderTilesFunction);
+
+            final List<Integer> resultList = rddRenderedTileCounts.collect();
+
+            LOG.info("buildRenderedLayerAsTileStacks: completed rendering for {} layer tiles", resultList.size());
+
+            for (final StackId hackStackId : renderedLayerStackList) {
+                final RenderDataClient dataClient = new RenderDataClient(baseDataUrl,
+                                                                         hackStackId.getOwner(),
+                                                                         hackStackId.getProject());
+                dataClient.setStackState(hackStackId.getStack(), StackMetaData.StackState.COMPLETE);
+            }
+        }
+
+        LOG.info("buildRenderedLayerAsTileStacks: exit");
+    }
+
+    private static void generateLayerAsTileMatches(final JavaSparkContext sparkContext,
+                                                   final LayerAsTileStackLists layerAsTileStackLists)
+            throws IOException {
+
+        LOG.info("generateLayerAsTileMatches: entry");
+
+        final String baseDataUrl = layerAsTileStackLists.getBaseDataUrl();
+        final List<MatchRunParameters> layerMatchRunList = layerAsTileStackLists.getLayerAsTile().buildLayerMatchRunList();
+
+        for (final String owner : layerAsTileStackLists.getOwners()) {
+
+            final RenderDataClient renderDataClient = new RenderDataClient(baseDataUrl, owner, "not_used");
+            final Set<String> existingMatchCollectionNames = renderDataClient.getOwnerMatchCollections().stream()
+                    .map(mcmd -> mcmd.getCollectionId().getName())
+                    .collect(Collectors.toSet());
+
+            for (final String project : layerAsTileStackLists.getProjectsWithOwner(owner)) {
+
+                final MultiStagePointMatchClient matchClient = new MultiStagePointMatchClient();
+
+                final List<String> projectStackNameList = new ArrayList<>();
+                final List<StackWithZValues> listOfRenderedLayerStackLayersInProject = new ArrayList<>();
+
+                for (final StackWithZValues stackWithZ : layerAsTileStackLists.getRenderedLayerStacksWithAllZ(owner, project)) {
+
+                    final StackId stackId = stackWithZ.getStackId();
+                    final String matchCollectionName = stackId.getDefaultMatchCollectionId(false).getName();
+
+                    if (existingMatchCollectionNames.contains(matchCollectionName)) {
+                        LOG.info("generateLayerAsTileMatches: skipping {} match generation because it already exists",
+                                 matchCollectionName);
+                    } else {
+                        projectStackNameList.add(stackId.getStack());
+                        for (final Double z : stackWithZ.getzValues()) {
+                            listOfRenderedLayerStackLayersInProject.add(new StackWithZValues(stackId,
+                                                                                             Collections.singletonList(z)));
+                        }
+                    }
+                }
+
+                if (! projectStackNameList.isEmpty()) {
+
+                    LOG.info("generateLayerAsTileMatches: starting generation for project {} with stacks {}",
+                             project, projectStackNameList);
+
+                    final MultiProjectParameters multiProject = new MultiProjectParameters();
+                    multiProject.baseDataUrl = baseDataUrl;
+                    multiProject.owner = owner;
+                    multiProject.project = project;
+                    multiProject.stackIdWithZ.stackNames = projectStackNameList;
+
+                    matchClient.generatePairsAndMatchesForRunList(sparkContext,
+                                                                  multiProject,
+                                                                  listOfRenderedLayerStackLayersInProject,
+                                                                  layerMatchRunList);
+                }
+
+            }
+        }
+
+        LOG.info("generateLayerAsTileMatches: exit");
+    }
+
+    private static void alignRenderedLayerAsTileStacks(final JavaSparkContext sparkContext,
+                                                       final LayerAsTileStackLists layerAsTileStackLists)
+            throws IOException {
+
+        LOG.info("alignRenderedLayerAsTileStacks: entry");
+
+        final String baseDataUrl = layerAsTileStackLists.getBaseDataUrl();
+        final LayerAsTileParameters layerAsTile = layerAsTileStackLists.getLayerAsTile();
+        final AffineBlockSolverSetup affineSetup = layerAsTile.buildLayerAffineBlockSolverSetup();
+
+        final boolean deriveMatchCollectionNamesFromProject = false; // use standard stack-based match collection names
+        final String matchSuffix = "";                               // without any suffix
+
+        final List<AffineBlockSolverSetup> setupList = new ArrayList<>();
+        for (final StackWithZValues renderedLayerStackWithAllZ : layerAsTileStackLists.getRenderedLayerStacksWithAllZ()) {
+
+            final StackId renderedLayerStackId = renderedLayerStackWithAllZ.getStackId();
+            final StackId alignedLayerStackId =
+                    renderedLayerStackId.withStackSuffix(layerAsTile.getAlignedLayerStackSuffix());
+
+            if (layerAsTileStackLists.isExistingStack(alignedLayerStackId)) {
+                LOG.info("alignRenderedLayerAsTileStacks: skipping alignment of {} because {} already exists",
+                         renderedLayerStackId.toDevString(), alignedLayerStackId.toDevString());
+            } else {
+                setupList.add(affineSetup.buildPipelineClone(baseDataUrl,
+                                                             renderedLayerStackWithAllZ,
+                                                             deriveMatchCollectionNamesFromProject,
+                                                             matchSuffix));
+            }
+        }
+
+        if (! setupList.isEmpty()) {
+            LOG.info("alignRenderedLayerAsTileStacks: distributing alignment of {} stack(s)", setupList.size());
+            final DistributedAffineBlockSolverClient affineBlockSolverClient = new DistributedAffineBlockSolverClient();
+            affineBlockSolverClient.alignSetupList(sparkContext, setupList);
+        }
+
+        LOG.info("alignRenderedLayerAsTileStacks: exit");
+    }
+
+    private static void buildAlign3DSfovStacks(final JavaSparkContext sparkContext,
+                                               final LayerAsTileStackLists layerAsTileStackLists) {
+
+        LOG.info("buildAlign3DSfovStacks: entry");
+
+        final String baseDataUrl = layerAsTileStackLists.getBaseDataUrl();
+        final LayerAsTileParameters layerAsTile = layerAsTileStackLists.getLayerAsTile();
+        final String align3DSfovStackSuffix = layerAsTile.getAlign3DSfovStackSuffix();
+        final String renderedLayerStackSuffix = layerAsTile.getRenderedLayerStackSuffixForRawSfovStack();
+        final String alignedLayerStackSuffixForRaw = layerAsTile.getAlignedLayerStackSuffixForRawSfovStack();
+
+        final List<StackWithZValues> rawSfovStacksWithAllZ = layerAsTileStackLists.getAlign2DSfovStacksWithAllZ();
+        final List<StackWithZValues> align3DSfovStacksWithAllZ = layerAsTileStackLists.getAlign3DSfovStacksWithAllZ();
+
+        final List<StackWithZValues> rawSfovStacksNeedingAlign3DStack = new ArrayList<>();
+
+        for (int i = 0; i < align3DSfovStacksWithAllZ.size(); i++) {
+            final StackWithZValues align3DSfovStackWithAllZ = align3DSfovStacksWithAllZ.get(i);
+            final StackId align3DSfovStackId = align3DSfovStackWithAllZ.getStackId();
+            if (layerAsTileStackLists.isExistingStack(align3DSfovStackId)) {
+                LOG.info("buildAlign3DSfovStacks: skipping creation of {} because it already exists",
+                         align3DSfovStackId.toDevString());
+            } else {
+                rawSfovStacksNeedingAlign3DStack.add(rawSfovStacksWithAllZ.get(i));
+            }
+        }
+
+        if (! rawSfovStacksNeedingAlign3DStack.isEmpty()) {
+
+            final int parallelism = Math.min(MFOVASTileClient.MAX_PARTITIONS_FOR_ONE_WEB_SERVER, rawSfovStacksNeedingAlign3DStack.size());
+
+            LOG.info("buildAlign3DSfovStacks: distributing build of {} stack(s) with parallelism {} (defaultParallelism={})",
+                     rawSfovStacksNeedingAlign3DStack.size(), parallelism, sparkContext.defaultParallelism());
+
+            final JavaRDD<StackWithZValues> rddAlignedStacks = sparkContext.parallelize(rawSfovStacksNeedingAlign3DStack,
+                                                                                        parallelism);
+
+            final Function<StackWithZValues, StackId> buildAlign3DStackFunction = stackWithAllZ -> {
+
+                LogUtilities.setupExecutorLog4j(stackWithAllZ.getStackId().toDevString());
+
+                final StackId rawSfovStackId = stackWithAllZ.getStackId();
+                final StackId renderedLayerStackId = rawSfovStackId.withStackSuffix(renderedLayerStackSuffix);
+                final StackId alignedLayerStackId = rawSfovStackId.withStackSuffix(alignedLayerStackSuffixForRaw);
+                final StackId align3DSfovStackId = rawSfovStackId.withStackSuffix(align3DSfovStackSuffix);
+                final String align3DSfovStack = align3DSfovStackId.getStack();
+
+                final RenderDataClient workerDataClient = new RenderDataClient(baseDataUrl,
+                                                                               rawSfovStackId.getOwner(),
+                                                                               rawSfovStackId.getProject());
+
+                final StackMetaData rawSfovStackMetaData = workerDataClient.getStackMetaData(rawSfovStackId.getStack());
+                workerDataClient.setupDerivedStack(rawSfovStackMetaData, align3DSfovStack);
+
+                for (final Double z : stackWithAllZ.getzValues()) {
+                    final ResolvedTileSpecCollection align3DTiles = buildAlign3DTileSpecsForZ(workerDataClient,
+                                                                                              rawSfovStackId.getStack(),
+                                                                                              z,
+                                                                                              renderedLayerStackId.getStack(),
+                                                                                              alignedLayerStackId.getStack(),
+                                                                                              layerAsTile.getLayerRenderScale());
+                    workerDataClient.saveResolvedTiles(align3DTiles, align3DSfovStack, z);
+                }
+
+                workerDataClient.setStackState(align3DSfovStack, StackMetaData.StackState.COMPLETE);
+
+                return align3DSfovStackId;
+            };
+
+            final JavaRDD<StackId> rddBuiltStacks = rddAlignedStacks.map(buildAlign3DStackFunction);
+            final List<StackId> builtStacks = rddBuiltStacks.collect();
+
+            LOG.info("buildAlign3DSfovStacks: completed build of {} stack(s)", builtStacks.size());
+        }
+
+        LOG.info("buildAlign3DSfovStacks: exit");
+    }
+
+    private static TileSpec getLayerTileSpec(final String stack,
+                                             final ResolvedTileSpecCollection resolveTiles) throws IOException {
+        final Collection<TileSpec> tileSpecList = resolveTiles.getTileSpecs();
+        if (tileSpecList.size() != 1) {
+            throw new IOException("expected 1 tile in " + stack + " but found " + tileSpecList.size());
+        }
+        return tileSpecList.iterator().next();
+    }
+
+    @Nonnull
+    private static ResolvedTileSpecCollection buildAlign3DTileSpecsForZ(final RenderDataClient dataClient,
+                                                                        final String rawSfovStack,
+                                                                        final double z,
+                                                                        final String renderedLayerStack,
+                                                                        final String alignedLayerStack,
+                                                                        final double layerAsTileRenderScale)
+            throws IOException {
+
+        // example SFOV tile spec:
+        // {
+        //   "tileId": "w61_magc0145_scan004_m0009_r32_s49",
+        //   ...
+        //   "transforms": {
+        //     "type": "list",
+        //     "specList": [
+        //       {
+        //         "className": "org.janelia.alignment.transform.ExponentialFunctionOffsetTransform",
+        //         "dataString": "3.164065083689898,0.010223592506552219,0.0,0"
+        //       },
+        //       {
+        //         "className": "mpicbg.trakem2.transform.AffineModel2D",
+        //         "dataString": "0.9989275629591378 -0.0034777133301720285 0.001945630942943617 1.0041687686777434 33733.93229071569 52312.024345042184"
+        //       }
+        //     ]
+        //   },
+        //   ...
+        // }
+        final ResolvedTileSpecCollection sfovTiles = dataClient.getResolvedTiles(rawSfovStack, z);
+
+        // example layer-as-tile spec:
+        // {
+        //   "tileId": "w61_s109_r00_gc_par_crc_align_stitch_only_z001",
+        //   ...
+        //   "transforms": {
+        //     "type": "list",
+        //     "specList": [
+        //       {
+        //         "className": "mpicbg.trakem2.transform.TranslationModel2D",
+        //         "dataString": 0 8"
+        //       }
+        //     ]
+        //   },
+        //   ...
+        // }
+
+        final ResolvedTileSpecCollection renderedLayerTiles = dataClient.getResolvedTiles(renderedLayerStack, z);
+        final TileSpec renderedLayerTileSpec = getLayerTileSpec(renderedLayerStack, renderedLayerTiles);
+
+        final ResolvedTileSpecCollection alignedLayerTiles = dataClient.getResolvedTiles(alignedLayerStack, z);
+        final TileSpec alignedLayerTileSpec = getLayerTileSpec(alignedLayerStack, alignedLayerTiles);
+
+        final double[] offset = new double[] {
+                (alignedLayerTileSpec.getMinX() - renderedLayerTileSpec.getMinX()) / layerAsTileRenderScale,
+                (alignedLayerTileSpec.getMinY() - renderedLayerTileSpec.getMinY()) / layerAsTileRenderScale
+        };
+
+        LOG.info("buildAlign3DTileSpecsForZ: adding offset ({}, {}) to all tiles in z {} of {}",
+                 (int) offset[0], (int) offset[1], z, rawSfovStack);
+
+        // to use addTransformSpecToTile method below, transform needs to be an affine
+        final String offsetAffineDataString = "1 0 0 1 " + offset[0] + " " + offset[1];
+        final LeafTransformSpec offsetTransformSpec = new LeafTransformSpec("mpicbg.trakem2.transform.AffineModel2D",
+                                                                            offsetAffineDataString);
+        for (final TileSpec tileSpec : sfovTiles.getTileSpecs()) {
+            sfovTiles.addTransformSpecToTile(tileSpec.getTileId(),
+                                             offsetTransformSpec,
+                                             TransformApplicationMethod.PRE_CONCATENATE_LAST);
+        }
+
+        return sfovTiles;
+    }
+
+    // Serializable information that can be used to build RenderTilesClient instances in remote Spark workers
+    public static class JavaRenderTilesClientInfoForLayer
+            implements Serializable {
+
+        private final String baseDataUrl;
+        private final StackId stackId;
+        private final double z;
+        private final TileRenderParameters tileRender;
+
+        public JavaRenderTilesClientInfoForLayer(final String baseDataUrl,
+                                                 final StackId stackId,
+                                                 final double z,
+                                                 final LayerAsTileParameters layerAsTile,
+                                                 final String runTimestamp) {
+            this.baseDataUrl = baseDataUrl;
+            this.stackId = stackId;
+            this.z = z;
+            final String hackStack = stackId.getStack() + layerAsTile.getRenderedLayerStackSuffix();
+            this.tileRender = TileRenderParameters.buildXAsTileVersion(layerAsTile.getLayerRootDirectory(),
+                                                                       runTimestamp,
+                                                                       hackStack);
+        }
+
+        public org.janelia.render.client.tile.RenderTilesClient buildJavaRenderTilesClient() {
+            return new org.janelia.render.client.tile.RenderTilesClient(
+                    new RenderDataClient(baseDataUrl, stackId.getOwner(), stackId.getProject()),
+                    stackId.getStack(),
+                    tileRender);
+        }
+
+        public void setupHackStackAndStorage()
+                throws IOException {
+            final org.janelia.render.client.tile.RenderTilesClient jClient = buildJavaRenderTilesClient();
+            jClient.setupHackStackAsNeeded();
+            jClient.setupStorageDirectories();
+        }
+
+        public int renderTiles()
+                throws IOException {
+            LogUtilities.setupExecutorLog4j(stackId.toDevString());
+            LOG.info("renderTiles: entry, stackId={}, z={}", stackId.toDevString(), z);
+            final org.janelia.render.client.tile.RenderTilesClient jClient = buildJavaRenderTilesClient();
+            jClient.renderTiles(Collections.singletonList(z));
+            return 1;
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(LayerAsTileClient.class);
+}

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/multisem/MFOVASTileClient.java
@@ -271,10 +271,11 @@ public class MFOVASTileClient
                                                                          prealignedStackId.getOwner(),
                                                                          prealignedStackId.getProject());
 
-                builtStackId = MFOVAsTileStackClient.buildOneMFOVAsTileStack(stackWithAllZ,
-                                                                             dataClient,
-                                                                             mfovRenderScale,
-                                                                             dynamicMfovStackSuffix);
+                builtStackId = MFOVAsTileStackClient.buildOneXAsTileStack(stackWithAllZ,
+                                                                          dataClient,
+                                                                          mfovRenderScale,
+                                                                          dynamicMfovStackSuffix,
+                                                                          true);
             }
 
             LOG.info("buildMfovStackFunction: exit, prealignedStackId={}, dynamicMfovAsTileStackId={}",
@@ -804,9 +805,9 @@ public class MFOVASTileClient
             this.stackId = stackId;
             this.layerMFOV = layerMFOV;
             final String hackStack = stackId.getStack() + mfovAsTile.getRenderedMfovStackSuffix();
-            this.tileRender = TileRenderParameters.buildMfovAsTileVersion(mfovAsTile.getMfovRootDirectory(),
-                                                                          runTimestamp,
-                                                                          hackStack);
+            this.tileRender = TileRenderParameters.buildXAsTileVersion(mfovAsTile.getMfovRootDirectory(),
+                                                                       runTimestamp,
+                                                                       hackStack);
         }
 
         public org.janelia.render.client.tile.RenderTilesClient buildJavaRenderTilesClient(final String tileIdPattern) {
@@ -836,7 +837,7 @@ public class MFOVASTileClient
         }
     }
 
-    private static final int MAX_PARTITIONS_FOR_ONE_WEB_SERVER = 100000;
+    public static final int MAX_PARTITIONS_FOR_ONE_WEB_SERVER = 100000;
 
     private static final Logger LOG = LoggerFactory.getLogger(MFOVASTileClient.class);
 }

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineParameters.java
@@ -17,6 +17,7 @@ import org.janelia.alignment.util.UrlResourceUtil;
 import org.janelia.render.client.newsolver.setup.AffineBlockSolverSetup;
 import org.janelia.render.client.newsolver.setup.IntensityCorrectionSetup;
 import org.janelia.render.client.parameter.CreepCorrectionParameters;
+import org.janelia.render.client.parameter.LayerAsTileParameters;
 import org.janelia.render.client.parameter.MFOVAsTileParameters;
 import org.janelia.render.client.parameter.MFOVMontageMatchPatchParameters;
 import org.janelia.render.client.parameter.MaskHackParameters;
@@ -57,10 +58,12 @@ public class AlignmentPipelineParameters
     private final ScapeParameters scape;
     private final TileRenderParameters tileRender;
     private final MFOVAsTileParameters mfovAsTile;
+    private final LayerAsTileParameters layerAsTile;
 
     @SuppressWarnings("unused")
     public AlignmentPipelineParameters() {
         this(null,
+             null,
              null,
              null,
              null,
@@ -95,7 +98,8 @@ public class AlignmentPipelineParameters
                                        final MaskHackParameters maskHack,
                                        final ScapeParameters scape,
                                        final TileRenderParameters tileRender,
-                                       final MFOVAsTileParameters mfovAsTile) {
+                                       final MFOVAsTileParameters mfovAsTile,
+                                       final LayerAsTileParameters layerAsTile) {
         this.multiProject = multiProject;
         this.pipelineStackGroups = pipelineStackGroups;
         this.pipelineSteps = pipelineSteps;
@@ -113,6 +117,7 @@ public class AlignmentPipelineParameters
         this.scape = scape;
         this.tileRender = tileRender;
         this.mfovAsTile = mfovAsTile;
+        this.layerAsTile = layerAsTile;
     }
 
     public MultiProjectParameters getMultiProject(final StackIdNamingGroup withNamingGroup) {
@@ -195,6 +200,10 @@ public class AlignmentPipelineParameters
 
     public MFOVAsTileParameters getMfovAsTile() {
         return mfovAsTile;
+    }
+
+    public LayerAsTileParameters getLayerAsTile() {
+        return layerAsTile;
     }
 
     /**

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/pipeline/AlignmentPipelineStepId.java
@@ -9,6 +9,7 @@ import org.janelia.render.client.spark.match.ClusterCountClient;
 import org.janelia.render.client.spark.match.CopyMatchClient;
 import org.janelia.render.client.spark.match.MultiStagePointMatchClient;
 import org.janelia.render.client.spark.multisem.CreepCorrectionSparkClient;
+import org.janelia.render.client.spark.multisem.LayerAsTileClient;
 import org.janelia.render.client.spark.multisem.MFOVASTileClient;
 import org.janelia.render.client.spark.multisem.MFOVMontageMatchPatchClient;
 import org.janelia.render.client.spark.multisem.UnconnectedCrossMFOVClient;
@@ -37,7 +38,8 @@ public enum AlignmentPipelineStepId {
     HACK_MASK(MaskHackClient::new),
     RENDER_SCAPE_IMAGES(ScapeClient::new),
     RENDER_TILES(RenderTilesClient::new),
-    MFOV_AS_TILE(MFOVASTileClient::new);
+    MFOV_AS_TILE(MFOVASTileClient::new),
+    LAYER_AS_TILE(LayerAsTileClient::new);
 
     private final Supplier<AlignmentPipelineStep> stepClientSupplier;
 

--- a/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/multisem/MfovPrealignTaskTest.java
+++ b/render-ws-spark-client/src/test/java/org/janelia/render/client/spark/multisem/MfovPrealignTaskTest.java
@@ -70,10 +70,11 @@ public class MfovPrealignTaskTest {
                                                                          "_render",
                                                                          "_align",
                                                                          "_rough");
-        MFOVAsTileStackClient.buildOneMFOVAsTileStack(prealignedStackWithAllZ,
-                                                      dataClient,
-                                                      mfovAsTile.getMfovRenderScale(),
-                                                      mfovAsTile.getDynamicMfovStackSuffix());
+        MFOVAsTileStackClient.buildOneXAsTileStack(prealignedStackWithAllZ,
+                                                   dataClient,
+                                                   mfovAsTile.getMfovRenderScale(),
+                                                   mfovAsTile.getDynamicMfovStackSuffix(),
+                                                   true);
 
         final StackId dynamicMfovStackId = prealignedStackId.withStackSuffix(mfovAsTile.getDynamicMfovStackSuffix());
         final StackId renderedMfovStackId = dynamicMfovStackId.withStackSuffix(mfovAsTile.getRenderedMfovStackSuffix());


### PR DESCRIPTION
This code is intended to "roughly-3D-align" the 2D-stitch-only solve results to reduce the amount of work needed to run the results through SOFIMA.  It copies/reuses many of the components developed for our MFOV-as-tile process.

The process works with and creates a set of stacks like this:
```
w61_s109_r00_gc_par_crc_aso :             starting 2D-stitch-only SFOV tile stack
w61_s109_r00_gc_par_crc_aso_lat :         layer-as-tile stack with dynamically rendered layer images
w61_s109_r00_gc_par_crc_aso_latr :        layer-as-tile stack with persisted layer images
w61_s109_r00_gc_par_crc_aso_latr_align :  aligned layer-as-tile stack with persisted layer images
w61_s109_r00_gc_par_crc_aso_3d :          rough 3D aligned SFOV tile stack
```

The process also creates a layer-as-tile match collection that is used for the layer-as-tile solve.

Our hope is that the `..._aso_3d` result stacks are good enough that we can skip cross-layer SFOV match data generation and that the SOFIMA setup work will be reduced/simplified.

A few final notes ...
- We originally thought the layer-as-tile stacks might be useful for storing layer-based histogram intensity correction information, but that process has changed.  We currently do not need to store histogram data.  
- The layer-as-tile stacks might be useful if we want to orient the slabs similarly before we try to connect them into a single volume.