### PR TITLE
Well-behaved ic3d for multi-sem

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -33,6 +33,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final int maxIterations;
 	private final int maxPlateauWidth;
 	private final boolean useRansacMatching;
+	private final Double cutoffDifference;
 
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -56,7 +57,8 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.maxAllowedError,
 			 intensityAdjust.maxIterations,
 			 intensityAdjust.maxPlateauWidth,
-			 intensityAdjust.useRansacMatching);
+			 intensityAdjust.useRansacMatching,
+			 intensityAdjust.cutoffDifference);
 	}
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -76,7 +78,8 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final double maxAllowedError,
 			final int maxIterations,
 			final int maxPlateauWidth,
-			final boolean useRansacMatching) {
+			final boolean useRansacMatching,
+			final Double cutoffDifference) {
 		// TODO: properly copy blockSolveModel
 		super(baseDataUrl, owner, project, stack, blockSolveModel);
 
@@ -92,6 +95,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.maxIterations = maxIterations;
 		this.maxPlateauWidth = maxPlateauWidth;
 		this.useRansacMatching = useRansacMatching;
+		this.cutoffDifference = cutoffDifference;
 	}
 
 	public long maxPixelCacheGb() { return maxPixelCacheGb; }
@@ -106,6 +110,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public int maxIterations() { return maxIterations; }
 	public int maxPlateauWidth() { return maxPlateauWidth; }
 	public boolean useRansacMatching() { return useRansacMatching; }
+	public Double cutoffDifference() { return cutoffDifference; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -33,7 +33,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final int maxIterations;
 	private final int maxPlateauWidth;
 	private final boolean useRansacMatching;
-	private final Double skipMatchesAboveDifference;
+	private final boolean tetherCrossLayers;
 
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -58,7 +58,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.maxIterations,
 			 intensityAdjust.maxPlateauWidth,
 			 intensityAdjust.useRansacMatching,
-			 intensityAdjust.skipMatchesAboveDifference);
+			 intensityAdjust.tetherCrossLayers);
 	}
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -79,7 +79,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final int maxIterations,
 			final int maxPlateauWidth,
 			final boolean useRansacMatching,
-			final Double skipMatchesAboveDifference) {
+			final boolean tetherCrossLayers) {
 		// TODO: properly copy blockSolveModel
 		super(baseDataUrl, owner, project, stack, blockSolveModel);
 
@@ -95,7 +95,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.maxIterations = maxIterations;
 		this.maxPlateauWidth = maxPlateauWidth;
 		this.useRansacMatching = useRansacMatching;
-		this.skipMatchesAboveDifference = skipMatchesAboveDifference;
+		this.tetherCrossLayers = tetherCrossLayers;
 	}
 
 	public long maxPixelCacheGb() { return maxPixelCacheGb; }
@@ -110,7 +110,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public int maxIterations() { return maxIterations; }
 	public int maxPlateauWidth() { return maxPlateauWidth; }
 	public boolean useRansacMatching() { return useRansacMatching; }
-	public Double skipMatchesAboveDifference() { return skipMatchesAboveDifference; }
+	public boolean tetherCrossLayers() { return tetherCrossLayers; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/blocksolveparameters/FIBSEMIntensityCorrectionParameters.java
@@ -33,7 +33,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	private final int maxIterations;
 	private final int maxPlateauWidth;
 	private final boolean useRansacMatching;
-	private final Double cutoffDifference;
+	private final Double skipMatchesAboveDifference;
 
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -58,7 +58,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			 intensityAdjust.maxIterations,
 			 intensityAdjust.maxPlateauWidth,
 			 intensityAdjust.useRansacMatching,
-			 intensityAdjust.cutoffDifference);
+			 intensityAdjust.skipMatchesAboveDifference);
 	}
 
 	public FIBSEMIntensityCorrectionParameters(
@@ -79,7 +79,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 			final int maxIterations,
 			final int maxPlateauWidth,
 			final boolean useRansacMatching,
-			final Double cutoffDifference) {
+			final Double skipMatchesAboveDifference) {
 		// TODO: properly copy blockSolveModel
 		super(baseDataUrl, owner, project, stack, blockSolveModel);
 
@@ -95,7 +95,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 		this.maxIterations = maxIterations;
 		this.maxPlateauWidth = maxPlateauWidth;
 		this.useRansacMatching = useRansacMatching;
-		this.cutoffDifference = cutoffDifference;
+		this.skipMatchesAboveDifference = skipMatchesAboveDifference;
 	}
 
 	public long maxPixelCacheGb() { return maxPixelCacheGb; }
@@ -110,7 +110,7 @@ public class FIBSEMIntensityCorrectionParameters<M>
 	public int maxIterations() { return maxIterations; }
 	public int maxPlateauWidth() { return maxPlateauWidth; }
 	public boolean useRansacMatching() { return useRansacMatching; }
-	public Double cutoffDifference() { return cutoffDifference; }
+	public Double skipMatchesAboveDifference() { return skipMatchesAboveDifference; }
 
 	@Override
 	public Worker<ArrayList<AffineModel1D>, FIBSEMIntensityCorrectionParameters<M>> createWorker(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -196,14 +196,14 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		final MatchFilter sameLayerFilter;
 		final MatchFilter crossLayerFilter;
 
-		final Double cutoffDifference = this.parameters.cutoffDifference();
-		if (cutoffDifference != null) {
+		final Double skipMatchesAboveDifference = this.parameters.skipMatchesAboveDifference();
+		if (skipMatchesAboveDifference != null) {
 			// a per-pixel cutoff requires pixel-by-pixel matching, so histogram matching cannot be used here;
 			// the cutoff only applies to cross-layer pairs (a large same-layer shift is what 2D correction fixes)
-			LOG.info("getIntensityMatcher: applying cross-layer cutoff of {} gray levels (forces pixel-by-pixel matching), renderStack={}, blockData={}",
-					 cutoffDifference, renderStack, blockData);
+			LOG.info("getIntensityMatcher: skipping cross-layer matches above {} gray levels (forces pixel-by-pixel matching), renderStack={}, blockData={}",
+					 skipMatchesAboveDifference, renderStack, blockData);
 			sameLayerFilter = new RansacMatchFilter();
-			crossLayerFilter = new CutoffRansacMatchFilter(cutoffDifference / 255.0);
+			crossLayerFilter = new CutoffRansacMatchFilter(skipMatchesAboveDifference / 255.0);
 		} else if (this.parameters.useRansacMatching()) {
 			sameLayerFilter = new RansacMatchFilter();
 			crossLayerFilter = sameLayerFilter;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -193,14 +193,27 @@ public class AffineIntensityCorrectionBlockWorker<M>
 			final List<TileSpec> tiles,
 			final ImageProcessorCache imageProcessorCache
 	) {
-		final MatchFilter filter;
-		if (this.parameters.useRansacMatching()) {
-			filter = new RansacMatchFilter();
+		final MatchFilter sameLayerFilter;
+		final MatchFilter crossLayerFilter;
+
+		final Double cutoffDifference = this.parameters.cutoffDifference();
+		if (cutoffDifference != null) {
+			// a per-pixel cutoff requires pixel-by-pixel matching, so histogram matching cannot be used here;
+			// the cutoff only applies to cross-layer pairs (a large same-layer shift is what 2D correction fixes)
+			LOG.info("getIntensityMatcher: applying cross-layer cutoff of {} gray levels (forces pixel-by-pixel matching), renderStack={}, blockData={}",
+					 cutoffDifference, renderStack, blockData);
+			sameLayerFilter = new RansacMatchFilter();
+			crossLayerFilter = new CutoffRansacMatchFilter(cutoffDifference / 255.0);
+		} else if (this.parameters.useRansacMatching()) {
+			sameLayerFilter = new RansacMatchFilter();
+			crossLayerFilter = sameLayerFilter;
 		} else {
-			filter = new HistogramMatchFilter();
+			sameLayerFilter = new HistogramMatchFilter();
+			crossLayerFilter = sameLayerFilter;
 		}
+
 		final int meshResolution = (int) tiles.get(0).getMeshCellSize();
-		return new IntensityMatcher(filter, parameters, meshResolution, imageProcessorCache);
+		return new IntensityMatcher(sameLayerFilter, crossLayerFilter, parameters, meshResolution, imageProcessorCache);
 	}
 
 	private  HashMap<String, IntensityTile> generateCoefficientsTiles(final Collection<TileSpec> patches) {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/AffineIntensityCorrectionBlockWorker.java
@@ -196,14 +196,14 @@ public class AffineIntensityCorrectionBlockWorker<M>
 		final MatchFilter sameLayerFilter;
 		final MatchFilter crossLayerFilter;
 
-		final Double skipMatchesAboveDifference = this.parameters.skipMatchesAboveDifference();
-		if (skipMatchesAboveDifference != null) {
-			// a per-pixel cutoff requires pixel-by-pixel matching, so histogram matching cannot be used here;
-			// the cutoff only applies to cross-layer pairs (a large same-layer shift is what 2D correction fixes)
-			LOG.info("getIntensityMatcher: skipping cross-layer matches above {} gray levels (forces pixel-by-pixel matching), renderStack={}, blockData={}",
-					 skipMatchesAboveDifference, renderStack, blockData);
+		if (this.parameters.tetherCrossLayers()) {
+			// tethering keeps only cross-layer matches whose intensities already coincide (cutoff 0); this requires
+			// pixel-by-pixel matching, so histogram matching cannot be used, and applies to cross-layer pairs only
+			// (a large same-layer shift is what 2D correction fixes)
+			LOG.info("getIntensityMatcher: tethering cross-layers at coinciding intensities (forces pixel-by-pixel matching), renderStack={}, blockData={}",
+					 renderStack, blockData);
 			sameLayerFilter = new RansacMatchFilter();
-			crossLayerFilter = new CutoffRansacMatchFilter(skipMatchesAboveDifference / 255.0);
+			crossLayerFilter = new CutoffRansacMatchFilter(0.0);
 		} else if (this.parameters.useRansacMatching()) {
 			sameLayerFilter = new RansacMatchFilter();
 			crossLayerFilter = sameLayerFilter;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/CutoffRansacMatchFilter.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/CutoffRansacMatchFilter.java
@@ -1,0 +1,95 @@
+package org.janelia.render.client.newsolver.solvers.intensity;
+
+import mpicbg.models.AffineModel1D;
+import mpicbg.models.PointMatch;
+import net.imglib2.util.Pair;
+import net.imglib2.util.ValuePair;
+import org.janelia.render.client.intensityadjust.intensity.RansacRegressionReduceFilter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * A match filter for cross-layer intensity matching with a per-pixel-match cutoff. It works like
+ * {@link RansacMatchFilter} (bin pixel matches, then RANSAC-reduce to two surrogate matches that yield the same
+ * affine model), but first discards individual pixel matches whose intensity shift {@code |q - p|} exceeds a cutoff.
+ * This suppresses spurious matches at abrupt intensity transitions in z, e.g. where tissue transitions into resin.
+ * <p>
+ * Because it operates per pixel match, it requires pixel-by-pixel matching and cannot be combined with the
+ * percentile-based {@link HistogramMatchFilter} (which discards the pixel correspondence).
+ * <p>
+ * If fewer than two matches survive the cutoff (so an affine model cannot be reliably fit), two weightless
+ * placeholder matches are returned. These keep the coefficient-tile pair structurally consistent (they satisfy the
+ * affine model's minimum match count) but, having zero weight, drop out of every weighted fit and therefore add no
+ * constraint to the solve.
+ */
+public class CutoffRansacMatchFilter implements MatchFilter {
+
+	// use the fact that the float intensity values in [0,1] originate from integers in [0,255]
+	private static final int N_BINS = 256;
+
+	// maximum allowed per-pixel intensity shift |q - p|, in normalized [0,1] units
+	private final double cutoff;
+
+	/**
+	 * @param cutoff maximum allowed per-pixel intensity shift {@code |q - p|}, in normalized [0,1] units
+	 */
+	public CutoffRansacMatchFilter(final double cutoff) {
+		this.cutoff = cutoff;
+	}
+
+	@Override
+	public List<PointMatch> filter(final FlatIntensityMatches matches) {
+		final List<PointMatch> compressedCandidates = compressByBinningWithinCutoff(matches);
+
+		// use a fresh model/filter per call so that this filter can be safely shared across matching threads
+		final RansacRegressionReduceFilter reduceFilter = new RansacRegressionReduceFilter(new AffineModel1D());
+		final List<PointMatch> inliers = new ArrayList<>();
+		reduceFilter.filter(compressedCandidates, inliers);
+
+		// an affine model needs at least two matches; if too few survived the cutoff, add no real constraint
+		if (inliers.size() < 2)
+			return weightlessPlaceholderMatches();
+
+		return inliers;
+	}
+
+	private List<PointMatch> compressByBinningWithinCutoff(final FlatIntensityMatches candidates) {
+		// bin the matches into N_BINS x N_BINS bins and sum their weights, dropping matches beyond the cutoff
+		final Map<Pair<Integer, Integer>, Double> pairToWeights = new HashMap<>(N_BINS * N_BINS);
+		for (int k = 0; k < candidates.size(); k++) {
+			// discard matches whose per-pixel intensity shift exceeds the cutoff
+			if (Math.abs(candidates.q[k] - candidates.p[k]) > cutoff)
+				continue;
+
+			final int p = (int) Math.round(candidates.p[k] * N_BINS);
+			final int q = (int) Math.round(candidates.q[k] * N_BINS);
+			final Pair<Integer, Integer> pair = new ValuePair<>(p, q);
+			pairToWeights.merge(pair, candidates.w[k], Double::sum);
+		}
+
+		// create new compressed candidates from the binned matches
+		final List<PointMatch> compressedCandidates = new ArrayList<>(pairToWeights.size());
+		for (final Map.Entry<Pair<Integer, Integer>, Double> entry : pairToWeights.entrySet()) {
+			final Pair<Integer, Integer> pair = entry.getKey();
+			final double weight = entry.getValue();
+			final Point1D p1 = new Point1D((double) pair.getA() / N_BINS);
+			final Point1D p2 = new Point1D((double) pair.getB() / N_BINS);
+			compressedCandidates.add(new PointMatch1D(p1, p2, weight));
+		}
+
+		return compressedCandidates;
+	}
+
+	private static List<PointMatch> weightlessPlaceholderMatches() {
+		// two distinct, deterministic points with weight 0: they satisfy the affine model's minimum match count
+		// (keeping the pair structurally consistent), but drop out of every weighted fit and so add no constraint
+		final List<PointMatch> placeholders = new ArrayList<>(2);
+		placeholders.add(new PointMatch1D(new Point1D(0.0), new Point1D(0.0), 0.0));
+		placeholders.add(new PointMatch1D(new Point1D(1.0), new Point1D(1.0), 0.0));
+		return placeholders;
+	}
+}

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -36,6 +36,9 @@ class IntensityMatcher {
 	final private int numCoefficients;
 	final int meshResolution;
 	final ImageProcessorCache imageProcessorCache;
+	// cutoff for cross-layer matches, expressed in normalized [0,1] intensity units (null cutoff => disabled)
+	final private boolean applyCutoff;
+	final private double cutoffShiftNormalized;
 
 	public IntensityMatcher(
 			final MatchFilter filter,
@@ -48,6 +51,11 @@ class IntensityMatcher {
 		this.numCoefficients = parameters.numCoefficients();
 		this.meshResolution = meshResolution;
 		this.imageProcessorCache = imageProcessorCache;
+
+		// the cutoff is given in 8-bit gray levels but compared against intensities normalized to [0,1]
+		final Double cutoffDifference = parameters.cutoffDifference();
+		this.applyCutoff = (cutoffDifference != null);
+		this.cutoffShiftNormalized = this.applyCutoff ? (cutoffDifference / 255.0) : 0.0;
 	}
 
 	public void match(final String renderStack,
@@ -57,7 +65,8 @@ class IntensityMatcher {
 
 		final StopWatch stopWatch = StopWatch.createAndStart();
 
-		final double scale = (p1.zDistanceFrom(p2) == 0) ? sameLayerScale : crossLayerScale;
+		final boolean crossLayer = (p1.zDistanceFrom(p2) != 0);
+		final double scale = crossLayer ? crossLayerScale : sameLayerScale;
 		final Rectangle box = computeIntersection(p1, p2);
 		final int w = numberOfPixels(box.width, scale);
 		final int h = numberOfPixels(box.height, scale);
@@ -114,6 +123,11 @@ class IntensityMatcher {
                 throw new RuntimeException("failed to filter coefficients for pair " + p1 + " (z " + p1.getZ() + "), " +
                                            p2 + " (z " + p2.getZ() + ") in " + renderStack, e);
             }
+
+            // suppress bad cross-layer matches (e.g. at tissue-to-resin transitions in z) by zeroing their weight
+            if (applyCutoff && crossLayer)
+                zeroWeightIfShiftExceedsCutoff(filteredMatchesForPair);
+
             filteredMatches.add(filteredMatchesForPair);
 		}
 
@@ -142,6 +156,30 @@ class IntensityMatcher {
 
 		stopWatch.stop();
 		LOG.debug("match: pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
+	}
+
+	/**
+	 * Computes the mean intensity shift of the (already reduced) matches for a single coefficient-tile pair and,
+	 * if it exceeds the configured cutoff, sets the weight of all these matches to 0 so that they do not contribute
+	 * to the solve. Both point locations are stored in normalized [0,1] intensity units, so the shift is compared
+	 * against the (likewise normalized) cutoff. The matches are left in place (rather than removed) to honor the
+	 * "set weight to 0" semantics.
+	 */
+	private void zeroWeightIfShiftExceedsCutoff(final List<PointMatch> matches) {
+		if (matches.isEmpty())
+			return;
+
+		double shiftSum = 0.0;
+		for (final PointMatch match : matches)
+			shiftSum += match.getP2().getL()[0] - match.getP1().getL()[0];
+		final double meanShift = Math.abs(shiftSum / matches.size());
+
+		if (meanShift > cutoffShiftNormalized) {
+			for (final PointMatch match : matches)
+				match.setWeights(new double[] { 0.0 });
+			LOG.debug("zeroWeightIfShiftExceedsCutoff: zeroed {} match(es), meanShift {} > cutoff {} (normalized)",
+					  matches.size(), meanShift, cutoffShiftNormalized);
+		}
 	}
 
 	private static List<FlatIntensityMatches> getPairwiseCoefficients(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcher.java
@@ -30,32 +30,28 @@ import net.imglib2.util.StopWatch;
  * Also, computation of averages for a tile is done here.
  */
 class IntensityMatcher {
-	final private MatchFilter filter;
+	// separate filters per layer relationship: a per-pixel cutoff (when configured) only applies to cross-layer pairs
+	final private MatchFilter sameLayerFilter;
+	final private MatchFilter crossLayerFilter;
 	final private double sameLayerScale;
 	final private double crossLayerScale;
 	final private int numCoefficients;
 	final int meshResolution;
 	final ImageProcessorCache imageProcessorCache;
-	// cutoff for cross-layer matches, expressed in normalized [0,1] intensity units (null cutoff => disabled)
-	final private boolean applyCutoff;
-	final private double cutoffShiftNormalized;
 
 	public IntensityMatcher(
-			final MatchFilter filter,
+			final MatchFilter sameLayerFilter,
+			final MatchFilter crossLayerFilter,
 			final FIBSEMIntensityCorrectionParameters<?> parameters,
 			final int meshResolution,
 			final ImageProcessorCache imageProcessorCache) {
-		this.filter = filter;
+		this.sameLayerFilter = sameLayerFilter;
+		this.crossLayerFilter = crossLayerFilter;
 		this.sameLayerScale = parameters.renderScale();
 		this.crossLayerScale = parameters.crossLayerRenderScale();
 		this.numCoefficients = parameters.numCoefficients();
 		this.meshResolution = meshResolution;
 		this.imageProcessorCache = imageProcessorCache;
-
-		// the cutoff is given in 8-bit gray levels but compared against intensities normalized to [0,1]
-		final Double cutoffDifference = parameters.cutoffDifference();
-		this.applyCutoff = (cutoffDifference != null);
-		this.cutoffShiftNormalized = this.applyCutoff ? (cutoffDifference / 255.0) : 0.0;
 	}
 
 	public void match(final String renderStack,
@@ -67,6 +63,7 @@ class IntensityMatcher {
 
 		final boolean crossLayer = (p1.zDistanceFrom(p2) != 0);
 		final double scale = crossLayer ? crossLayerScale : sameLayerScale;
+		final MatchFilter filter = crossLayer ? crossLayerFilter : sameLayerFilter;
 		final Rectangle box = computeIntersection(p1, p2);
 		final int w = numberOfPixels(box.width, scale);
 		final int h = numberOfPixels(box.height, scale);
@@ -123,11 +120,6 @@ class IntensityMatcher {
                 throw new RuntimeException("failed to filter coefficients for pair " + p1 + " (z " + p1.getZ() + "), " +
                                            p2 + " (z " + p2.getZ() + ") in " + renderStack, e);
             }
-
-            // suppress bad cross-layer matches (e.g. at tissue-to-resin transitions in z) by zeroing their weight
-            if (applyCutoff && crossLayer)
-                zeroWeightIfShiftExceedsCutoff(filteredMatchesForPair);
-
             filteredMatches.add(filteredMatchesForPair);
 		}
 
@@ -156,30 +148,6 @@ class IntensityMatcher {
 
 		stopWatch.stop();
 		LOG.debug("match: pair {} <-> {} has {} connections, matching took {}", p1.getTileId(), p2.getTileId(), connectionCount, stopWatch);
-	}
-
-	/**
-	 * Computes the mean intensity shift of the (already reduced) matches for a single coefficient-tile pair and,
-	 * if it exceeds the configured cutoff, sets the weight of all these matches to 0 so that they do not contribute
-	 * to the solve. Both point locations are stored in normalized [0,1] intensity units, so the shift is compared
-	 * against the (likewise normalized) cutoff. The matches are left in place (rather than removed) to honor the
-	 * "set weight to 0" semantics.
-	 */
-	private void zeroWeightIfShiftExceedsCutoff(final List<PointMatch> matches) {
-		if (matches.isEmpty())
-			return;
-
-		double shiftSum = 0.0;
-		for (final PointMatch match : matches)
-			shiftSum += match.getP2().getL()[0] - match.getP1().getL()[0];
-		final double meanShift = Math.abs(shiftSum / matches.size());
-
-		if (meanShift > cutoffShiftNormalized) {
-			for (final PointMatch match : matches)
-				match.setWeights(new double[] { 0.0 });
-			LOG.debug("zeroWeightIfShiftExceedsCutoff: zeroed {} match(es), meanShift {} > cutoff {} (normalized)",
-					  matches.size(), meanShift, cutoffShiftNormalized);
-		}
 	}
 
 	private static List<FlatIntensityMatches> getPairwiseCoefficients(

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -88,6 +88,15 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	)
 	public boolean useRansacMatching = false;
 
+	@Parameter(
+			names = "--cutoffDifference",
+			description = "If set, cross-layer intensity matches between two coefficient tiles whose mean intensity " +
+					"shift exceeds this many 8-bit gray levels (0-255) get their weight set to 0 (i.e. are ignored " +
+					"by the solve). This suppresses bad matches at tissue-to-resin transitions in z. " +
+					"Default: null (no cutoff)."
+	)
+	public Double cutoffDifference = null;
+
 
 	public void initDefaultValues() throws IllegalArgumentException {
 		this.zDistance.initDefaultValues();

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -89,13 +89,13 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	public boolean useRansacMatching = false;
 
 	@Parameter(
-			names = "--skipMatchesAboveDifference",
-			description = "If set, cross-layer intensity matches between two coefficient tiles whose mean intensity " +
-					"shift exceeds this many 8-bit gray levels (0-255) get their weight set to 0 (i.e. are ignored " +
-					"by the solve). This suppresses bad matches at tissue-to-resin transitions in z. " +
-					"Default: null (no cutoff)."
+			names = "--tetherCrossLayers",
+			description = "If set, cross-layer coefficient tiles are only tethered at pixels whose intensities already " +
+					"coincide (matches with a non-zero shift are dropped). This smooths intensities across z without " +
+					"introducing correction on top of the tether, avoiding systematically wrong matches at " +
+					"tissue-to-resin transitions in z. Forces pixel-by-pixel matching. Default: false."
 	)
-	public Double skipMatchesAboveDifference = null;
+	public boolean tetherCrossLayers = false;
 
 
 	public void initDefaultValues() throws IllegalArgumentException {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/parameter/AlgorithmicIntensityAdjustParameters.java
@@ -89,13 +89,13 @@ public class AlgorithmicIntensityAdjustParameters implements Serializable {
 	public boolean useRansacMatching = false;
 
 	@Parameter(
-			names = "--cutoffDifference",
+			names = "--skipMatchesAboveDifference",
 			description = "If set, cross-layer intensity matches between two coefficient tiles whose mean intensity " +
 					"shift exceeds this many 8-bit gray levels (0-255) get their weight set to 0 (i.e. are ignored " +
 					"by the solve). This suppresses bad matches at tissue-to-resin transitions in z. " +
 					"Default: null (no cutoff)."
 	)
-	public Double cutoffDifference = null;
+	public Double skipMatchesAboveDifference = null;
 
 
 	public void initDefaultValues() throws IllegalArgumentException {

--- a/render-ws-java-client/src/test/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcherTest.java
+++ b/render-ws-java-client/src/test/java/org/janelia/render/client/newsolver/solvers/intensity/IntensityMatcherTest.java
@@ -52,6 +52,7 @@ public class IntensityMatcherTest {
         final HashMap<String, IntensityTile> coefficientTiles = new HashMap<>();
 
         final IntensityMatcher matcher = new IntensityMatcher(matchFilter,
+                                                              matchFilter,
                                                               intensityParameters,
                                                               meshResolution,
                                                               ImageProcessorCache.DISABLED_CACHE);


### PR DESCRIPTION
This PR adds a variant of 3D intensity correction that, instead of simply matching different layers, only tethers them at pixels where they already coincide. This is a common situation in multi-sem: parts of a layer might coincide very well with adjacent layers, other parts don't (like at a tissue -> substrate transition). By tethering the parts that coincide, 2D intensity correction is just constrained enough to yield a result that is fairly homogeneous in z without over/under correcting due to spurious matches.

@trautmane This is the second part of #237 that I intentionally separated from there.