### PR TITLE
Swap Descriptor_based_registration for mvrecon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,6 @@
         -->
         <n5-version>4.0.1</n5-version>
 
-        <!-- pom-scijava 45 bumps Descriptor_based_registration to 3.0.1, whose SPIM_Registration replacement
-             (net.preibisch:multiview-reconstruction) drops the point-descriptor / DoG API render's geometric
-             descriptor matcher is built on (mpicbg.pointdescriptor.matcher.*, mpicbg.spim.segmentation.*). Porting
-             that matcher is a separate effort, so keep the 2.x line reactor-wide (render-app also pins 2.1.3). -->
-        <Descriptor_based_registration.version>2.1.3</Descriptor_based_registration.version>
-
         <!--
           Keep this in sync with the jackson version bundled with the spark version in
           render-ws-spark-client/pom.xml: spark refuses to start when its jackson-module-scala does not

--- a/render-app/pom.xml
+++ b/render-app/pom.xml
@@ -182,7 +182,6 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>Descriptor_based_registration</artifactId>
-            <version>2.1.3</version>
             <exclusions>
                 <!-- filter out slf4j jar so that it does not conflict with jetty version -->
                 <exclusion>

--- a/render-app/src/main/java/org/janelia/alignment/match/CanvasPeakMatcher.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/CanvasPeakMatcher.java
@@ -7,8 +7,8 @@ import mpicbg.imglib.algorithm.scalespace.DifferenceOfGaussianPeak;
 import mpicbg.imglib.type.numeric.real.FloatType;
 import mpicbg.models.Model;
 import mpicbg.models.PointMatch;
-import mpicbg.pointdescriptor.matcher.Matcher;
-import mpicbg.pointdescriptor.matcher.SubsetMatcher;
+import net.preibisch.mvrecon.process.pointcloud.pointdescriptor.matcher.Matcher;
+import net.preibisch.mvrecon.process.pointcloud.pointdescriptor.matcher.SubsetMatcher;
 import mpicbg.util.Timer;
 
 import org.janelia.alignment.match.parameters.GeometricDescriptorParameters;

--- a/render-app/src/main/java/org/janelia/alignment/match/parameters/GeometricDescriptorParameters.java
+++ b/render-app/src/main/java/org/janelia/alignment/match/parameters/GeometricDescriptorParameters.java
@@ -5,7 +5,7 @@ import com.beust.jcommander.Parameter;
 import java.io.Serializable;
 import java.util.Objects;
 
-import mpicbg.spim.segmentation.InteractiveDoG;
+import net.preibisch.mvrecon.fiji.plugin.interestpointdetection.interactive.HelperFunctions;
 
 import plugin.DescriptorParameters;
 
@@ -149,7 +149,7 @@ public class GeometricDescriptorParameters
         dp.redundancy = redundancy;
         dp.significance = significance;
         dp.sigma1 = sigma;
-        dp.sigma2 = InteractiveDoG.computeSigma2(sigma.floatValue(), InteractiveDoG.standardSensitivity );
+        dp.sigma2 = HelperFunctions.computeSigma2(sigma, 4); // 4 = former InteractiveDoG.standardSensitivity
         dp.threshold = threshold;
         dp.localization = localization.code;
         dp.lookForMinima = lookForMinima;

--- a/render-app/src/main/java/process/GeometricDescriptorMatcher.java
+++ b/render-app/src/main/java/process/GeometricDescriptorMatcher.java
@@ -7,7 +7,7 @@ import mpicbg.imglib.algorithm.scalespace.DifferenceOfGaussianPeak;
 import mpicbg.imglib.type.numeric.real.FloatType;
 import mpicbg.models.Model;
 import mpicbg.models.PointMatch;
-import mpicbg.pointdescriptor.matcher.Matcher;
+import net.preibisch.mvrecon.process.pointcloud.pointdescriptor.matcher.Matcher;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/render-app/src/test/java/org/janelia/alignment/match/GeometricDescriptorSIFTMatcherTest.java
+++ b/render-app/src/test/java/org/janelia/alignment/match/GeometricDescriptorSIFTMatcherTest.java
@@ -15,7 +15,7 @@ import mpicbg.imglib.type.numeric.real.FloatType;
 import mpicbg.models.AffineModel2D;
 import mpicbg.models.Point;
 import mpicbg.models.PointMatch;
-import mpicbg.spim.io.IOFunctions;
+import net.preibisch.legacy.io.IOFunctions;
 import mpicbg.trakem2.transform.TransformMeshMappingWithMasks.ImageProcessorWithMasks;
 
 import org.janelia.alignment.RenderParameters;

--- a/render-ws-java-client/pom.xml
+++ b/render-ws-java-client/pom.xml
@@ -78,7 +78,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>sc.fiji:SPIM_Registration</artifact>
+                                    <artifact>net.preibisch:multiview-reconstruction</artifact>
                                     <excludes>
                                         <exclude>META-INF/json/**</exclude>
                                     </excludes>

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/destreak/StreakCorrection_Plugin.java
@@ -22,7 +22,7 @@ import org.janelia.alignment.util.ImageProcessorCache;
 import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.parameter.CommandLineParameters;
 import org.janelia.render.client.parameter.RenderWebServiceParameters;
-import spim.Threads;
+import net.preibisch.mvrecon.Threads;
 
 import javax.swing.SwingUtilities;
 import java.awt.KeyboardFocusManager;

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/IntensityCorrectionClient.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/intensityadjust/IntensityCorrectionClient.java
@@ -25,6 +25,7 @@ public class IntensityCorrectionClient
 
                 final IntensityAdjustParameters parameters = new IntensityAdjustParameters();
                 parameters.parse(args);
+                parameters.algorithmic.initDefaultValues();
 
                 LOG.info("runClient: entry, parameters={}", parameters);
 

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/solver/DistributedSolveMultiThread.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/solver/DistributedSolveMultiThread.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import bdv.util.BdvStackSource;
 import mpicbg.models.Affine2D;
-import mpicbg.spim.io.IOFunctions;
+import net.preibisch.legacy.io.IOFunctions;
 import net.imglib2.multithreading.SimpleMultiThreading;
 
 public class DistributedSolveMultiThread extends DistributedSolve

--- a/render-ws-spark-client/pom.xml
+++ b/render-ws-spark-client/pom.xml
@@ -75,7 +75,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>sc.fiji:SPIM_Registration</artifact>
+                                    <artifact>net.preibisch:multiview-reconstruction</artifact>
                                     <excludes>
                                         <exclude>META-INF/json/**</exclude>
                                     </excludes>

--- a/render-ws/src/main/java/org/janelia/render/service/util/ConfiguredJsonProvider.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/ConfiguredJsonProvider.java
@@ -30,19 +30,15 @@ public class ConfiguredJsonProvider extends JacksonJaxbJsonProvider {
     }
 
     @Override
-    protected ObjectMapper _locateMapperViaProvider(final Class<?> type,
-                                                    final MediaType mediaType) {
-
-        final ObjectMapper mapper;
-
-        // for collections and lists, use fast mapper which skips pretty printing
-        if ((type == ResolvedTileSpecCollection.class) || (type == ArrayList.class)) {
-            mapper = JsonUtils.FAST_MAPPER;
-        } else {
-            mapper = JsonUtils.MAPPER;
-        }
-
-        return mapper;
+    protected ObjectMapper _locateMapperViaProvider(final Class<?> type, final MediaType mediaType) {
+        return getMapperForType(type);
     }
 
+    static ObjectMapper getMapperForType(final Class<?> type) {
+        // for collections and lists, use fast mapper which skips pretty printing
+        if ((type == ResolvedTileSpecCollection.class) || (type == ArrayList.class)) {
+            return JsonUtils.FAST_MAPPER;
+        }
+        return JsonUtils.MAPPER;
+    }
 }

--- a/render-ws/src/main/java/org/janelia/render/service/util/ObjectMapperContextResolver.java
+++ b/render-ws/src/main/java/org/janelia/render/service/util/ObjectMapperContextResolver.java
@@ -1,0 +1,28 @@
+package org.janelia.render.service.util;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * RESTEasy can pick either {@link ConfiguredJsonProvider} or the library's own default JSON provider
+ * to handle a response.  Both providers now match "application/json" equally well, so the pick
+ * is not deterministic.
+ * <p>
+ * This class removes the need to control that pick.  Both providers ask a {@code ContextResolver} for
+ * the {@code ObjectMapper} before they serialize a response.  This class is that {@code ContextResolver}.  It
+ * always returns the correct field-visibility mapper, no matter which provider RESTEasy chose.
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+
+    @Override
+    public ObjectMapper getContext(final Class<?> type) {
+        return ConfiguredJsonProvider.getMapperForType(type);
+    }
+
+}


### PR DESCRIPTION
In the version of `Descriptor_based_registration` that the new pom-scijava uses, key features were migrated to mvrecon. This PR accounts for that change and uses the equivalent mvrecon functionality where applicable. 