### PR TITLE
improve-IC2D-distribution-20260824

### DIFF
--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedAffineBlockSolver.java
@@ -21,6 +21,7 @@ import mpicbg.models.RigidModel2D;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.render.client.newsolver.assembly.Assembler;
 import org.janelia.render.client.newsolver.assembly.BlockCombiner;
 import org.janelia.render.client.newsolver.assembly.GlobalSolver;
@@ -163,7 +164,8 @@ public class DistributedAffineBlockSolver implements Serializable
 
 		final ResultContainer<AffineModel2D> finalTiles = solveAndCombineBlocks(cmdLineSetup,
 																				allItems,
-																				alignmentSolver.blockFactory);
+																				alignmentSolver.blockFactory,
+																				alignmentSolver.renderSetup.getSourceStackId());
 
 		// save the re-aligned part
 		LOG.info("solveCombineAndSaveBlocks: saving target stack {}", cmdLineSetup.targetStack);
@@ -203,14 +205,16 @@ public class DistributedAffineBlockSolver implements Serializable
 	private static ResultContainer<AffineModel2D> solveAndCombineBlocks(
 			final AffineBlockSolverSetup cmdLineSetup,
 			final List<BlockData<AffineModel2D, ?>> allItems,
-			final BlockFactory blockFactory) {
+			final BlockFactory blockFactory,
+			final StackId sourceStackId) {
 
 		final BlockCombiner<AffineModel2D, AffineModel2D, RigidModel2D, AffineModel2D> fusion = chooseCombiner(blockFactory);
 
 		final GlobalSolver<RigidModel2D, AffineModel2D> globalSolver =
 				new GlobalSolver<>(new RigidModel2D(),
 								   new SameTileMatchCreatorAffine2D<AffineModel2D>(),
-								   cmdLineSetup.distributedSolve);
+								   cmdLineSetup.distributedSolve,
+								   sourceStackId);
 
 		final Assembler<AffineModel2D, RigidModel2D, AffineModel2D> assembler =
 				new Assembler<>(globalSolver, fusion, (r) -> {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/DistributedIntensityCorrectionSolver.java
@@ -153,7 +153,8 @@ public class DistributedIntensityCorrectionSolver implements Serializable {
 		final GlobalSolver<TranslationModel1D, ArrayList<AffineModel1D>> globalSolver =
 				new GlobalSolver<>(new TranslationModel1D(),
 								   new SameTileMatchCreatorAffineIntensity(),
-								   solverSetup.distributedSolve);
+								   solverSetup.distributedSolve,
+								   renderSetup.getSourceStackId());
 
 		final Assembler<ArrayList<AffineModel1D>, TranslationModel1D, ArrayList<AffineModel1D>> assembler =
 				new Assembler<>(globalSolver, fusion, r -> {

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/assembly/GlobalSolver.java
@@ -17,6 +17,7 @@ import mpicbg.models.TileUtil;
 
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.TileSpec;
+import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.assembly.matches.SameTileMatchCreator;
 import org.janelia.render.client.newsolver.setup.DistributedSolveParameters;
@@ -33,10 +34,13 @@ public class GlobalSolver<G extends Model<G>, R> {
 	final private int maxIterations;
 	final private int numThreads;
 
+	final private String sourceStackDevString;
+
 	public GlobalSolver(
 			final G globalModel,
 			final SameTileMatchCreator<R> sameTileMatchCreator,
-			final DistributedSolveParameters parameters
+			final DistributedSolveParameters parameters,
+			final StackId sourceStackId
 	) {
 		this.globalModel = globalModel;
 		this.sameTileMatchCreator = sameTileMatchCreator;
@@ -44,6 +48,7 @@ public class GlobalSolver<G extends Model<G>, R> {
 		this.maxAllowedError = parameters.maxAllowedErrorGlobal;
 		this.maxIterations = parameters.maxIterationsGlobal;
 		this.numThreads = parameters.threadsGlobal;
+		this.sourceStackDevString = sourceStackId.toDevString();
 	}
 
 	public HashMap<BlockData<R, ?>, Tile<G>> globalSolve(
@@ -55,14 +60,15 @@ public class GlobalSolver<G extends Model<G>, R> {
 			blockToTile.put(block, new Tile<>(globalModel.copy()));
 		}
 
-		LOG.info("globalSolve: solving {} items", blocks.size());
+		LOG.info("globalSolve: {}, solving {} items",
+		         sourceStackDevString, blocks.size());
 		final Set<? extends BlockData<R, ?>> otherBlocks = new HashSet<>(blocks);
 		final TileConfiguration tileConfigBlocks = new TileConfiguration();
 
 		final Set<BlockData<R, ?>> matchedSolveItems = new HashSet<>();
 
 		for (final BlockData<R, ?> solveItemA : blocks) {
-			LOG.info("globalSolve: solveItemA is {}", solveItemA);
+			LOG.info("globalSolve: {}, solveItemA is {}", sourceStackDevString, solveItemA);
 
 			final ResultContainer<R> resultsA = solveItemA.getResults();
 			otherBlocks.remove(solveItemA);
@@ -71,7 +77,7 @@ public class GlobalSolver<G extends Model<G>, R> {
 			final ResolvedTileSpecCollection tileSpecs = solveItemA.rtsc();
 
 			for (final BlockData<R, ?> solveItemB : otherBlocks) {
-				LOG.info("globalSolve: solveItemB is {}", solveItemB);
+				LOG.info("globalSolve: {}, solveItemB is {}", sourceStackDevString, solveItemB);
 
 				final ResultContainer<R> resultsB = solveItemB.getResults();
 				final Set<String> commonTileIds = getCommonTileIds(solveItemA, solveItemB);
@@ -84,23 +90,25 @@ public class GlobalSolver<G extends Model<G>, R> {
 					final R modelB = resultsB.getModelFor(tileId);
 					if (modelA == null) {
 						throw new IllegalArgumentException("model A is missing for tile " + tileId + " in block " +
-														   solveItemA.toDetailsString());
+														   solveItemA.toDetailsString() + " of " + sourceStackDevString);
 					} else if (modelB == null) {
 						throw new IllegalArgumentException("model B is missing for tile " + tileId + " in block " +
-														   solveItemB.toDetailsString());
+														   solveItemB.toDetailsString() + " of " + sourceStackDevString);
 					}
 					sameTileMatchCreator.addMatches(tileSpecAB, modelA, modelB, solveItemA, solveItemB, matchesAtoB);
 				}
 
 				if (matchesAtoB.isEmpty()) {
 
-					LOG.info("globalSolve: no matches found between {} with {} and {} with {}",
+					LOG.info("globalSolve: {}, no matches found between {} with {} and {} with {}",
+					         sourceStackDevString,
 							 solveItemA, resultsA.toTileSummaryString(),
 							 solveItemB, resultsB.toTileSummaryString());
 
 				} else {
 
-					LOG.info("globalSolve: found {} commonTileIds and {} matches between {} and {}",
+					LOG.info("globalSolve: {}, found {} commonTileIds and {} matches between {} and {}",
+					         sourceStackDevString,
 							 commonTileIds.size(), matchesAtoB.size(), solveItemA, solveItemB);
 
 					matchedSolveItems.add(solveItemA);
@@ -123,16 +131,19 @@ public class GlobalSolver<G extends Model<G>, R> {
 
 		for (final BlockData<R, ?> block : blocks) {
 			if (! matchedSolveItems.contains(block)) {
-				throw new IllegalStateException("no other blocks are matched with " + block.toDetailsString());
+				throw new IllegalStateException("no other blocks are matched with " + block.toDetailsString() +
+											   " when solving " + blocks.size() + " blocks in " + sourceStackDevString);
 			}
 		}
 
-		LOG.info("globalSolve: launching Pre-Align, tileConfigBlocks has {} tiles and {} fixed tiles",
-				  tileConfigBlocks.getTiles().size(), tileConfigBlocks.getFixedTiles().size());
+		LOG.info("globalSolve: {}, launching Pre-Align, tileConfigBlocks has {} tiles and {} fixed tiles",
+		         sourceStackDevString,
+				 tileConfigBlocks.getTiles().size(),
+				 tileConfigBlocks.getFixedTiles().size());
 
 		tileConfigBlocks.preAlign();
 
-		LOG.info("globalSolve: Optimizing ... ");
+		LOG.info("globalSolve: {}, Optimizing ... ", sourceStackDevString);
 		final float damp = 1.0f;
 		TileUtil.optimizeConcurrently(
 				new ErrorStatistic(maxPlateauWidth + 1),

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/IntensityCorrectionSetup.java
@@ -3,6 +3,10 @@ package org.janelia.render.client.newsolver.setup;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.janelia.alignment.json.JsonUtils;
 import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackWithZValues;
@@ -88,6 +92,52 @@ public class IntensityCorrectionSetup extends CommandLineParameters {
 		clone.targetStack.setValuesFromPipeline(sourceStackId, "_ic");
 
 		return clone;
+	}
+
+	/**
+	 * Builds a separate clone of this setup for each z layer in the specified stack so that
+	 * the layers can be corrected independently (and therefore concurrently).
+	 * <p>
+	 * This is only valid for 2D corrections without XY partitioning
+	 * (see {@link #is2DCorrectionWithoutXYPartitioning}) because layers in those runs
+	 * are not constrained by data in other layers or blocks.
+	 * <p>
+	 * Target stack completion is disabled in each clone so that each target stack can be completed
+	 * once after all of its layers have been saved.
+	 *
+	 * @param  baseDataUrl       base web service URL for data.
+	 * @param  stackWithZValues  identifies stack and z layers to correct.
+	 *
+	 * @return list with one clone of this setup for each z layer to correct.
+	 */
+	public List<IntensityCorrectionSetup> buildPipelineClonesForEachZ(final String baseDataUrl,
+																	  final StackWithZValues stackWithZValues) {
+
+		final List<IntensityCorrectionSetup> cloneList = new ArrayList<>();
+
+		for (final StackWithZValues stackWithOneZ : stackWithZValues.splitByZ()) {
+
+			final Double z = stackWithOneZ.getFirstZ();
+
+			if (isLayerInRange(z)) {
+				final IntensityCorrectionSetup clone = buildPipelineClone(baseDataUrl, stackWithOneZ);
+				clone.layerRange.minZ = z;
+				clone.layerRange.maxZ = z;
+				clone.targetStack.completeStack = false;
+				cloneList.add(clone);
+			}
+		}
+
+		return cloneList;
+	}
+
+	/**
+	 * @return true if the specified z is within this setup's configured layer range, otherwise false.
+	 */
+	private boolean isLayerInRange(final Double z) {
+		return (layerRange == null) ||
+			   (((layerRange.minZ == null) || (z >= layerRange.minZ)) &&
+				((layerRange.maxZ == null) || (z <= layerRange.maxZ)));
 	}
 
 	/** (Slowly) creates a clone of this setup by serializing it to and from JSON. */

--- a/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/RenderSetup.java
+++ b/render-ws-java-client/src/main/java/org/janelia/render/client/newsolver/setup/RenderSetup.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.janelia.alignment.spec.Bounds;
 import org.janelia.alignment.spec.ResolvedTileSpecCollection;
 import org.janelia.alignment.spec.SectionData;
+import org.janelia.alignment.spec.stack.StackId;
 import org.janelia.alignment.spec.stack.StackMetaData;
 import org.janelia.alignment.util.ZFilter;
 import org.janelia.render.client.RenderDataClient;
@@ -35,9 +36,14 @@ public class RenderSetup
 	public int totalTileCount;
 
 	private Bounds bounds;
+	private StackId sourceStackId;
 
 	public Bounds getBounds() {
 		return bounds;
+	}
+
+	public StackId getSourceStackId() {
+		return sourceStackId;
 	}
 
 	public static RenderSetup setupSolve(final AffineBlockSolverSetup parameters) throws IOException {
@@ -78,6 +84,7 @@ public class RenderSetup
 		runParams.totalTileCount = 0;
 
 		final StackMetaData sourceStackMetaData = renderDataClient.getStackMetaData(stack);
+		runParams.sourceStackId = sourceStackMetaData.getStackId();
 
 		// create the target stack if it doesn't exist ...
 		if (targetStack != null) {

--- a/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
+++ b/render-ws-spark-client/src/main/java/org/janelia/render/client/spark/newsolver/DistributedIntensityCorrectionBlockSolverClient.java
@@ -8,8 +8,10 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.storage.StorageLevel;
 import org.janelia.alignment.spec.stack.StackId;
+import org.janelia.alignment.spec.stack.StackMetaData;
 import org.janelia.alignment.spec.stack.StackWithZValues;
 import org.janelia.render.client.ClientRunner;
+import org.janelia.render.client.RenderDataClient;
 import org.janelia.render.client.newsolver.BlockCollection;
 import org.janelia.render.client.newsolver.BlockData;
 import org.janelia.render.client.newsolver.DistributedIntensityCorrectionSolver;
@@ -31,7 +33,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -277,16 +281,36 @@ public class DistributedIntensityCorrectionBlockSolverClient
 		final int nRuns = setup.alternatingRuns.nRuns;
 		final boolean cleanUpIntermediateStacks = ! setup.alternatingRuns.keepIntermediateStacks;
 
+		// 2D corrections are independent for each layer, so build a setup for each layer instead of
+		// for each stack.  This distributes the layers of a stack across the cluster instead of
+		// solving them one after another within the same task.
+		setup.initDefaultValues();
+		final boolean correctEachLayerSeparately = setup.is2DCorrectionWithoutXYPartitioning();
+
 		for (final StackWithZValues stackWithZValues : stackList) {
-			setupList.add(setup.buildPipelineClone(multiProject.getBaseDataUrl(),
-												   stackWithZValues));
+			if (correctEachLayerSeparately) {
+				setupList.addAll(setup.buildPipelineClonesForEachZ(multiProject.getBaseDataUrl(),
+																   stackWithZValues));
+			} else {
+				setupList.add(setup.buildPipelineClone(multiProject.getBaseDataUrl(),
+													   stackWithZValues));
+			}
 		}
+
+		LOG.info("runPipelineStep: built {} setup(s) for {} stack(s), correctEachLayerSeparately={}",
+				 setupList.size(), stackList.size(), correctEachLayerSeparately);
 
 		final DistributedIntensityCorrectionBlockSolverClient intensityCorrectionSolverClient = new DistributedIntensityCorrectionBlockSolverClient();
 
 		if (nRuns == 1) {
 
 			intensityCorrectionSolverClient.intensityCorrectSetupList(sparkContext, setupList);
+
+			// per-layer setups leave their target stacks in the LOADING state, so complete each
+			// target stack once here after all of its layers have been saved
+			if (correctEachLayerSeparately && setup.targetStack.completeStack) {
+				completeTargetStacks(setupList);
+			}
 
 		} else {
 
@@ -317,6 +341,45 @@ public class DistributedIntensityCorrectionBlockSolverClient
 	@Override
 	public AlignmentPipelineStepId getDefaultStepId() {
 		return AlignmentPipelineStepId.CORRECT_INTENSITY;
+	}
+
+	/**
+	 * Completes each distinct target stack in the specified setup list.
+	 * This is needed for runs with one setup per layer because those setups
+	 * save layers to a shared target stack and cannot safely complete it themselves.
+	 *
+	 * @throws IOException
+	 *   if any request fails.
+	 */
+	private static void completeTargetStacks(final List<IntensityCorrectionSetup> setupList)
+			throws IOException {
+
+		final Map<StackId, IntensityCorrectionSetup> targetStackIdToSetup = new LinkedHashMap<>();
+
+		for (final IntensityCorrectionSetup setup : setupList) {
+			if (setup.targetStack.stack != null) {
+				final StackId targetStackId = new StackId(setup.targetStack.owner,
+														  setup.targetStack.project,
+														  setup.targetStack.stack);
+				targetStackIdToSetup.putIfAbsent(targetStackId, setup);
+			}
+		}
+
+		LOG.info("completeTargetStacks: entry, completing {} stack(s)", targetStackIdToSetup.size());
+
+		for (final Map.Entry<StackId, IntensityCorrectionSetup> entry : targetStackIdToSetup.entrySet()) {
+
+			final StackId targetStackId = entry.getKey();
+			final RenderDataClient dataClient =
+					entry.getValue().renderWeb.getDataClient().buildClient(targetStackId.getOwner(),
+																		   targetStackId.getProject());
+
+			LOG.info("completeTargetStacks: completing {}", targetStackId.toDevString());
+
+			dataClient.setStackState(targetStackId.getStack(), StackMetaData.StackState.COMPLETE);
+		}
+
+		LOG.info("completeTargetStacks: exit");
 	}
 
 	private List<List<IntensityCorrectionSetup>> buildSetupListsForRuns(final int nRuns,

--- a/render-ws-with-mongo-db/db-dump-google-collections.sh
+++ b/render-ws-with-mongo-db/db-dump-google-collections.sh
@@ -93,7 +93,7 @@ LOCATION="google"
 
 if [[ -n "${ARG_STAGE}" ]]; then
   case "${ARG_STAGE}" in
-    00_par|01_match|02_align|03_ic2d_nc4_hist_rs0p5)
+    00_par|01_match|02_align|03_ic2d_nc4_hist_rs0p5|04a_layer_as_tile|04b_3d_align)
       STAGE="${ARG_STAGE}"
       ;;
     timestamp)


### PR DESCRIPTION
This change allows 2D intensity correction work to be parallelized by z-layer.  Previously, intensity correction was parallelized by stack because it was originally built for 3D correction.